### PR TITLE
Increase test coverage

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,10 +11,10 @@ const config: Config = {
   coverageProvider: 'v8',
   coverageThreshold: {
     global: {
-      branches: 70,
-      functions: 70,
-      lines: 70,
-      statements: 70,
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
     },
   },
   coverageReporters: ['text', 'lcov', 'json', 'html'],


### PR DESCRIPTION
hotfix

## Issue

https://github.com/Liatoshynsky-Foundation/lf-client/issues/60

## Summary of issue

The test coverage threshold was set too low (70%), potentially allowing insufficiently tested code to pass CI.

## Summary of change

- Updated coverage threshold in jest.config.ts from 70% to 80%  
