### PR TITLE
hotfix(config): fix problem with tests through jest.config

### DIFF
--- a/app/[lang]/about-us/__snapshots__/page.test.tsx.snap
+++ b/app/[lang]/about-us/__snapshots__/page.test.tsx.snap
@@ -2,6 +2,6 @@
 
 exports[`About Component renders the About component correctly 1`] = `
 <div>
-  About
+  AboutUs
 </div>
 `;

--- a/app/[lang]/about-us/page.test.tsx
+++ b/app/[lang]/about-us/page.test.tsx
@@ -5,7 +5,7 @@ import About from './page';
 describe('About Component', () => {
   it('renders the About component correctly', () => {
     render(<About />);
-    const aboutElement = screen.getByText('About');
+    const aboutElement = screen.getByText('AboutUs');
     expect(aboutElement).toMatchSnapshot();
   });
 });

--- a/app/[lang]/page.test.tsx
+++ b/app/[lang]/page.test.tsx
@@ -1,15 +1,24 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import Home from './page';
+
 describe('Home component', () => {
-  it('renders the Home component correctly', () => {
-    render(<Home />);
-    const homeElement = screen.getByText('Liatoshynsky project');
+  const params = Promise.resolve({ lang: 'en' });
+
+  it('renders the Home component correctly', async () => {
+    await act(async () => {
+      render(<Home params={params} />);
+    });
+
+    const homeElement = await screen.findByText(/Liatoshynsky project/i);
     expect(homeElement).toBeInTheDocument();
   });
 
-  it('renders the Home component with correct text', () => {
-    render(<Home />);
-    const homeElement = screen.getByText('Liatoshynsky project');
+  it('renders the Home component with correct text', async () => {
+    await act(async () => {
+      render(<Home params={params} />);
+    });
+
+    const homeElement = await screen.findByText(/Liatoshynsky project/i);
     expect(homeElement).toBeInTheDocument();
   });
 });

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,9 @@
 import type { Config } from 'jest';
+import nextJest from 'next/jest';
+
+const createJestConfig = nextJest({
+  dir: './',
+});
 
 const config: Config = {
   bail: 1,
@@ -30,4 +35,4 @@ const config: Config = {
   setupFilesAfterEnv: ['@testing-library/jest-dom'],
 };
 
-export default config;
+export default createJestConfig(config);


### PR DESCRIPTION
## Jest Config Fix

- Updated Jest config for Next.js support using `next/jest`.
- Added:

```js
import nextJest from 'next/jest';

const createJestConfig = nextJest({
  dir: './',
});
```
![image](https://github.com/user-attachments/assets/915ee4a6-573c-4d0e-96ae-6493215c74de)
