### PR TITLE
(SP: 2) Implement Backend Logic for Contact Form Submission

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { validateContactData } from '~/lib/utils/validateContactData';
+
+export async function POST(request: Request) {
+  const data = await request.json();
+  const errors = validateContactData(data);
+
+  if (errors.length > 0) {
+    return NextResponse.json({ success: false, errors }, { status: 400 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { successResponse, errorResponse } from '~/lib/utils/apiResponse';
 import { validateContactData } from '~/lib/utils/validateContactData';
 
 export async function POST(request: Request) {
@@ -6,8 +6,8 @@ export async function POST(request: Request) {
   const errors = validateContactData(data);
 
   if (errors.length > 0) {
-    return NextResponse.json({ success: false, errors }, { status: 400 });
+    return errorResponse(errors, 400);
   }
 
-  return NextResponse.json({ success: true });
+  return successResponse({ data, success: true });
 }

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,7 +1,9 @@
 import { successResponse, errorResponse } from '~/lib/utils/apiResponse';
-import { validateContactData } from '~/lib/utils/validateContactData';
+import {
+  validateContactData,
+  type ContactFormData,
+} from '~/lib/utils/validateContactData';
 import { validateRequestData } from '~/lib/utils/validateRequestData';
-import { ContactFormData } from '~/lib/utils/validateContactData';
 
 export async function POST(request: Request) {
   const data = await request.json();

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,13 +1,21 @@
 import { successResponse, errorResponse } from '~/lib/utils/apiResponse';
 import { validateContactData } from '~/lib/utils/validateContactData';
+import { validateRequestData } from '~/lib/utils/validateRequestData';
+import { ContactFormData } from '~/lib/utils/validateContactData';
 
 export async function POST(request: Request) {
   const data = await request.json();
-  const errors = validateContactData(data);
 
-  if (errors.length > 0) {
-    return errorResponse(errors, 400);
+  const validationResult = validateRequestData<ContactFormData>(
+    data,
+    validateContactData,
+  );
+
+  if (!validationResult.valid) {
+    return errorResponse(validationResult.errors);
   }
 
-  return successResponse({ data, success: true });
+  const { value } = validationResult;
+
+  return successResponse({ data: value, success: true });
 }

--- a/app/constants/errors.ts
+++ b/app/constants/errors.ts
@@ -1,0 +1,7 @@
+import { lengths } from './validation';
+
+export const errors = {
+  NAME_ERROR: `Name must be a string between ${lengths.NAME_MIN_LENGTH} and ${lengths.NAME_MAX_LENGTH} characters long.`,
+  EMAIL_ERROR: 'Invalid email address.',
+  MESSAGE_ERROR: `Message must be a string between ${lengths.MESSAGE_MIN_LENGTH} and ${lengths.MESSAGE_MAX_LENGTH} characters.`,
+};

--- a/app/constants/validation.ts
+++ b/app/constants/validation.ts
@@ -1,0 +1,17 @@
+export const lengths = {
+  NAME_MIN_LENGTH: 2,
+  NAME_MAX_LENGTH: 50,
+  MESSAGE_MIN_LENGTH: 10,
+  MESSAGE_MAX_LENGTH: 1000,
+};
+
+export const regex = {
+  EMAIL_PATTERN:
+    /^([a-z\d]+([._-][a-z\d]+)*)@([a-z\d]+([.-][a-z\d]+)*\.[a-z]{2,})$/i,
+};
+
+export const error = {
+  NAME_ERROR: `Name must be a string between ${lengths.NAME_MIN_LENGTH} and ${lengths.NAME_MAX_LENGTH} characters long.`,
+  EMAIL_ERROR: 'Invalid email address.',
+  MESSAGE_ERROR: `Message must be a string between ${lengths.MESSAGE_MIN_LENGTH} and ${lengths.MESSAGE_MAX_LENGTH} characters.`,
+};

--- a/app/constants/validation.ts
+++ b/app/constants/validation.ts
@@ -9,9 +9,3 @@ export const regex = {
   EMAIL_PATTERN:
     /^([a-z\d]+([._-][a-z\d]+)*)@([a-z\d]+([.-][a-z\d]+)*\.[a-z]{2,})$/i,
 };
-
-export const error = {
-  NAME_ERROR: `Name must be a string between ${lengths.NAME_MIN_LENGTH} and ${lengths.NAME_MAX_LENGTH} characters long.`,
-  EMAIL_ERROR: 'Invalid email address.',
-  MESSAGE_ERROR: `Message must be a string between ${lengths.MESSAGE_MIN_LENGTH} and ${lengths.MESSAGE_MAX_LENGTH} characters.`,
-};

--- a/app/lib/utils/apiResponse.test.ts
+++ b/app/lib/utils/apiResponse.test.ts
@@ -1,0 +1,48 @@
+import { successResponse, errorResponse } from '~/lib/utils/apiResponse';
+import { NextResponse } from 'next/server';
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: jest.fn(),
+  },
+}));
+
+describe('apiResponse utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a success response with status 200 by default', () => {
+    const data = { message: 'OK' };
+    successResponse(data);
+
+    expect(NextResponse.json).toHaveBeenCalledWith(data, { status: 200 });
+  });
+
+  it('should return a success response with custom status', () => {
+    const data = { message: 'Created' };
+    successResponse(data, 201);
+
+    expect(NextResponse.json).toHaveBeenCalledWith(data, { status: 201 });
+  });
+
+  it('should return an error response with default status 400', () => {
+    const errors = ['Invalid input'];
+    errorResponse(errors);
+
+    expect(NextResponse.json).toHaveBeenCalledWith(
+      { success: false, errors },
+      { status: 400 },
+    );
+  });
+
+  it('should return an error response with custom status', () => {
+    const errors = { field: 'Required' };
+    errorResponse(errors, 422);
+
+    expect(NextResponse.json).toHaveBeenCalledWith(
+      { success: false, errors },
+      { status: 422 },
+    );
+  });
+});

--- a/app/lib/utils/apiResponse.ts
+++ b/app/lib/utils/apiResponse.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+interface ErrorResponse {
+  success: false;
+  errors: string[] | Record<string, unknown>;
+}
+
+export const successResponse = <T>(data: T, status: number = 200) => {
+  return NextResponse.json(data, { status });
+};
+
+export const errorResponse = (
+  errors: string[] | Record<string, unknown>,
+  status: number = 400,
+): NextResponse<ErrorResponse> => {
+  return NextResponse.json({ success: false, errors }, { status });
+};

--- a/app/lib/utils/apiResponse.ts
+++ b/app/lib/utils/apiResponse.ts
@@ -5,7 +5,7 @@ interface ErrorResponse {
   errors: string[] | Record<string, unknown>;
 }
 
-export const successResponse = <T>(data: T, status: number = 200) => {
+export const successResponse = (data: unknown, status: number = 200) => {
   return NextResponse.json(data, { status });
 };
 

--- a/app/lib/utils/validateContactData.test.ts
+++ b/app/lib/utils/validateContactData.test.ts
@@ -1,0 +1,106 @@
+import { validateContactData } from '~/lib/utils/validateContactData';
+import { error, lengths } from '~/constants/validation';
+
+describe('validateContactData', () => {
+  it('should return no errors for valid input', () => {
+    const result = validateContactData({
+      name: 'John',
+      email: 'john@example.com',
+      message: 'This is a valid message.',
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return error if name is missing', () => {
+    const result = validateContactData({
+      name: undefined,
+      email: 'john@example.com',
+      message: 'Valid message',
+    });
+
+    expect(result).toContain(error.NAME_ERROR);
+  });
+
+  it('should return error if name is too short', () => {
+    const result = validateContactData({
+      name: 'A',
+      email: 'john@example.com',
+      message: 'Valid message',
+    });
+
+    expect(result).toContain(error.NAME_ERROR);
+  });
+
+  it('should return error if name is too long', () => {
+    const result = validateContactData({
+      name: 'A'.repeat(lengths.NAME_MAX_LENGTH + 1),
+      email: 'john@example.com',
+      message: 'Valid message',
+    });
+
+    expect(result).toContain(error.NAME_ERROR);
+  });
+
+  it('should return error if email is missing', () => {
+    const result = validateContactData({
+      name: 'John',
+      email: undefined,
+      message: 'Valid message',
+    });
+
+    expect(result).toContain(error.EMAIL_ERROR);
+  });
+
+  it('should return error if email is invalid', () => {
+    const result = validateContactData({
+      name: 'John',
+      email: 'invalid-email',
+      message: 'Valid message',
+    });
+
+    expect(result).toContain(error.EMAIL_ERROR);
+  });
+
+  it('should return error if message is missing', () => {
+    const result = validateContactData({
+      name: 'John',
+      email: 'john@example.com',
+      message: undefined,
+    });
+
+    expect(result).toContain(error.MESSAGE_ERROR);
+  });
+
+  it('should return error if message is too short', () => {
+    const result = validateContactData({
+      name: 'John',
+      email: 'john@example.com',
+      message: 'Too short',
+    });
+
+    expect(result).toContain(error.MESSAGE_ERROR);
+  });
+
+  it('should return error if message is too long', () => {
+    const result = validateContactData({
+      name: 'John',
+      email: 'john@example.com',
+      message: 'A'.repeat(lengths.MESSAGE_MAX_LENGTH + 1),
+    });
+
+    expect(result).toContain(error.MESSAGE_ERROR);
+  });
+
+  it('should return multiple errors if all fields are invalid', () => {
+    const result = validateContactData({
+      name: '',
+      email: 'invalid',
+      message: '',
+    });
+
+    expect(result).toContain(error.NAME_ERROR);
+    expect(result).toContain(error.EMAIL_ERROR);
+    expect(result).toContain(error.MESSAGE_ERROR);
+  });
+});

--- a/app/lib/utils/validateContactData.test.ts
+++ b/app/lib/utils/validateContactData.test.ts
@@ -1,5 +1,6 @@
 import { validateContactData } from '~/lib/utils/validateContactData';
-import { error, lengths } from '~/constants/validation';
+import { errors } from '~/constants/errors';
+import { lengths } from '~/constants/validation';
 
 describe('validateContactData', () => {
   it('should return no errors for valid input', () => {
@@ -19,7 +20,7 @@ describe('validateContactData', () => {
       message: 'Valid message',
     });
 
-    expect(result).toContain(error.NAME_ERROR);
+    expect(result).toContain(errors.NAME_ERROR);
   });
 
   it('should return error if name is too short', () => {
@@ -29,7 +30,7 @@ describe('validateContactData', () => {
       message: 'Valid message',
     });
 
-    expect(result).toContain(error.NAME_ERROR);
+    expect(result).toContain(errors.NAME_ERROR);
   });
 
   it('should return error if name is too long', () => {
@@ -39,7 +40,7 @@ describe('validateContactData', () => {
       message: 'Valid message',
     });
 
-    expect(result).toContain(error.NAME_ERROR);
+    expect(result).toContain(errors.NAME_ERROR);
   });
 
   it('should return error if email is missing', () => {
@@ -49,7 +50,7 @@ describe('validateContactData', () => {
       message: 'Valid message',
     });
 
-    expect(result).toContain(error.EMAIL_ERROR);
+    expect(result).toContain(errors.EMAIL_ERROR);
   });
 
   it('should return error if email is invalid', () => {
@@ -59,7 +60,7 @@ describe('validateContactData', () => {
       message: 'Valid message',
     });
 
-    expect(result).toContain(error.EMAIL_ERROR);
+    expect(result).toContain(errors.EMAIL_ERROR);
   });
 
   it('should return error if message is missing', () => {
@@ -69,7 +70,7 @@ describe('validateContactData', () => {
       message: undefined,
     });
 
-    expect(result).toContain(error.MESSAGE_ERROR);
+    expect(result).toContain(errors.MESSAGE_ERROR);
   });
 
   it('should return error if message is too short', () => {
@@ -79,7 +80,7 @@ describe('validateContactData', () => {
       message: 'Too short',
     });
 
-    expect(result).toContain(error.MESSAGE_ERROR);
+    expect(result).toContain(errors.MESSAGE_ERROR);
   });
 
   it('should return error if message is too long', () => {
@@ -89,7 +90,7 @@ describe('validateContactData', () => {
       message: 'A'.repeat(lengths.MESSAGE_MAX_LENGTH + 1),
     });
 
-    expect(result).toContain(error.MESSAGE_ERROR);
+    expect(result).toContain(errors.MESSAGE_ERROR);
   });
 
   it('should return multiple errors if all fields are invalid', () => {
@@ -99,8 +100,8 @@ describe('validateContactData', () => {
       message: '',
     });
 
-    expect(result).toContain(error.NAME_ERROR);
-    expect(result).toContain(error.EMAIL_ERROR);
-    expect(result).toContain(error.MESSAGE_ERROR);
+    expect(result).toContain(errors.NAME_ERROR);
+    expect(result).toContain(errors.EMAIL_ERROR);
+    expect(result).toContain(errors.MESSAGE_ERROR);
   });
 });

--- a/app/lib/utils/validateContactData.ts
+++ b/app/lib/utils/validateContactData.ts
@@ -1,4 +1,5 @@
-import { lengths, regex, error } from '~/constants/validation';
+import { lengths, regex } from '~/constants/validation';
+import { errors } from '~/constants/errors';
 
 export type ContactFormData = {
   name: unknown;
@@ -8,18 +9,18 @@ export type ContactFormData = {
 
 export function validateContactData(data: ContactFormData): string[] {
   const { name, email, message } = data;
-  const errors: string[] = [];
+  const errorsMessages: string[] = [];
 
   if (
     typeof name !== 'string' ||
     name.length < lengths.NAME_MIN_LENGTH ||
     name.length > lengths.NAME_MAX_LENGTH
   ) {
-    errors.push(error.NAME_ERROR);
+    errorsMessages.push(errors.NAME_ERROR);
   }
 
   if (typeof email !== 'string' || !regex.EMAIL_PATTERN.test(email)) {
-    errors.push(error.EMAIL_ERROR);
+    errorsMessages.push(errors.EMAIL_ERROR);
   }
 
   if (
@@ -27,8 +28,8 @@ export function validateContactData(data: ContactFormData): string[] {
     message.length < lengths.MESSAGE_MIN_LENGTH ||
     message.length > lengths.MESSAGE_MAX_LENGTH
   ) {
-    errors.push(error.MESSAGE_ERROR);
+    errorsMessages.push(errors.MESSAGE_ERROR);
   }
 
-  return errors;
+  return errorsMessages;
 }

--- a/app/lib/utils/validateContactData.ts
+++ b/app/lib/utils/validateContactData.ts
@@ -1,0 +1,34 @@
+import { lengths, regex, error } from '~/constants/validation';
+
+export type ContactFormData = {
+  name: unknown;
+  email: unknown;
+  message: unknown;
+};
+
+export function validateContactData(data: ContactFormData): string[] {
+  const { name, email, message } = data;
+  const errors: string[] = [];
+
+  if (
+    typeof name !== 'string' ||
+    name.length < lengths.NAME_MIN_LENGTH ||
+    name.length > lengths.NAME_MAX_LENGTH
+  ) {
+    errors.push(error.NAME_ERROR);
+  }
+
+  if (typeof email !== 'string' || !regex.EMAIL_PATTERN.test(email)) {
+    errors.push(error.EMAIL_ERROR);
+  }
+
+  if (
+    typeof message !== 'string' ||
+    message.length < lengths.MESSAGE_MIN_LENGTH ||
+    message.length > lengths.MESSAGE_MAX_LENGTH
+  ) {
+    errors.push(error.MESSAGE_ERROR);
+  }
+
+  return errors;
+}

--- a/app/lib/utils/validateRequestData.test.ts
+++ b/app/lib/utils/validateRequestData.test.ts
@@ -1,0 +1,48 @@
+import { validateRequestData } from './validateRequestData';
+
+describe('validateRequestData', () => {
+  const mockValidationFn = jest.fn();
+
+  beforeEach(() => {
+    mockValidationFn.mockReset();
+  });
+
+  it('should return valid: true and the value when there are no validation errors', () => {
+    const data = { name: 'John' };
+    mockValidationFn.mockReturnValue([]);
+
+    const result = validateRequestData(data, mockValidationFn);
+
+    expect(result).toEqual({ valid: true, value: data });
+    expect(mockValidationFn).toHaveBeenCalledWith(data);
+  });
+
+  it('should return valid: false and the errors when validation fails', () => {
+    const data = { name: '' };
+    mockValidationFn.mockReturnValue(['Name is required']);
+
+    const result = validateRequestData(data, mockValidationFn);
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Name is required'],
+    });
+    expect(mockValidationFn).toHaveBeenCalledWith(data);
+  });
+
+  it('should handle multiple validation errors', () => {
+    const data = { name: '', email: 'invalid-email' };
+    mockValidationFn.mockReturnValue([
+      'Name is required',
+      'Email format is invalid',
+    ]);
+
+    const result = validateRequestData(data, mockValidationFn);
+
+    expect(result).toEqual({
+      valid: false,
+      errors: ['Name is required', 'Email format is invalid'],
+    });
+    expect(mockValidationFn).toHaveBeenCalledWith(data);
+  });
+});

--- a/app/lib/utils/validateRequestData.ts
+++ b/app/lib/utils/validateRequestData.ts
@@ -1,0 +1,10 @@
+export function validateRequestData<T>(
+  data: T,
+  validationFunction: (data: T) => string[],
+): { errors: string[]; valid: false } | { valid: true; value: T } {
+  const errors = validationFunction(data);
+
+  return errors.length === 0
+    ? { valid: true, value: data }
+    : { errors, valid: false };
+}


### PR DESCRIPTION

## Summary of change
Added a backend route /api/contact to handle contact form submissions
It accepts POST requests with a JSON payload (name, email, message), performs server-side validation, and returns either validation errors (400) or { success: true } (200)


## Result



https://github.com/user-attachments/assets/10839bc4-0036-4f1b-a434-46eb2292fa53




