### PR TITLE
Create Slider component aligned with design system #56

### DIFF
--- a/app/components/Slider/Slider.styles.ts
+++ b/app/components/Slider/Slider.styles.ts
@@ -1,0 +1,100 @@
+const commonColors = {
+  primary: "#FCBD28",
+  primaryHover: "rgba(0, 0, 0, 0.08)",
+  secondary: "#FFA500",
+  disabled: "#B2BEBE",
+  valueLabelBackground: "#63666E",
+};
+
+const commonThumbSizes = {
+  small: "12px",
+  big: "20px",
+};
+
+const commonTrackRailHeights = {
+  small: "4px",
+  big: "6px",
+};
+
+export const sliderStyles = {
+  base: {
+    position: "relative",
+    width: "100%",
+  },
+  valueContainer: {
+    position: "relative",
+    height: "25px",
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  valueLabel: {
+    position: "absolute",
+    top: "0",
+    transform: "translateX(-50%)",
+    fontSize: (size: "small" | "big") => (size === "small" ? "10px" : "12px"),
+    fontWeight: "bold",
+    background: commonColors.valueLabelBackground,
+    color: "#fff",
+    padding: "2px 6px",
+    borderRadius: "4px",
+    "&::after": {
+      content: '""',
+      position: "absolute",
+      bottom: "-6px",
+      left: "50%",
+      transform: "translateX(-50%)",
+      width: 0,
+      height: 0,
+      borderLeft: "6px solid transparent",
+      borderRight: "6px solid transparent",
+      borderTop: `6px solid ${commonColors.valueLabelBackground}`,
+    },
+  },
+  slider: {
+    color: commonColors.primary,
+    "& .MuiSlider-thumb": {
+      width: (size: "small" | "big") => commonThumbSizes[size],
+      height: (size: "small" | "big") => commonThumbSizes[size],
+      backgroundColor: commonColors.primary,
+      "&:hover": {
+        boxShadow: `0px 0px 0px 8px ${commonColors.primaryHover}`,
+      },
+    },
+    "& .MuiSlider-track": {
+      height: (size: "small" | "big") => commonTrackRailHeights[size],
+      backgroundColor: commonColors.primary,
+    },
+    "& .MuiSlider-rail": {
+      height: (size: "small" | "big") => commonTrackRailHeights[size],
+    },
+    "& .MuiSlider-mark": {
+      width: "5px",
+      height: "5px",
+      borderRadius: "50%",
+      backgroundColor: commonColors.primary,
+      transform: "translateX(-50%) translateY(-2px)",
+    },
+    "& .MuiSlider-markActive": {
+      backgroundColor: commonColors.secondary,
+    },
+    "&.Mui-disabled .MuiSlider-thumb": {
+      backgroundColor: commonColors.disabled,
+    },
+    "&.Mui-disabled .MuiSlider-track": {
+      backgroundColor: commonColors.disabled,
+    },
+    "&.Mui-disabled .MuiSlider-rail": {
+      backgroundColor: commonColors.disabled,
+    },
+    "&.Mui-disabled .MuiSlider-mark": {
+      backgroundColor: commonColors.disabled,
+    },
+  },
+  minMaxContainer: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  minMaxLabel: {
+    fontSize: (size: "small" | "big") => (size === "small" ? "12px" : "14px"),
+  },
+};

--- a/app/components/Slider/Slider.test.tsx
+++ b/app/components/Slider/Slider.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { DesignSystemSlider, CustomSliderProps } from "./Slider";
+
+describe("DesignSystemSlider", () => {
+  const renderComponent = (props: Partial<CustomSliderProps> = {}) =>
+    render(<DesignSystemSlider min={0} max={100} value={[20, 80]} {...props} />);
+
+  it("renders the slider correctly", () => {
+    renderComponent();
+    const thumbs = screen.getAllByRole("slider");
+    expect(thumbs.length).toBeGreaterThan(0);
+  });
+
+  it("displays value labels for the range slider", () => {
+    renderComponent();
+    expect(screen.getByText("20")).toBeInTheDocument();
+    expect(screen.getByText("80")).toBeInTheDocument();
+  });
+
+  it("applies the correct styles for small size", () => {
+    renderComponent({ size: "small" });
+
+    const thumb = document.querySelector(".MuiSlider-thumb");
+    expect(thumb).toHaveStyle({
+      width: "12px",
+      height: "12px",
+    });
+  });
+
+  it("displays correct min and max labels", () => {
+    renderComponent({ min: 10, max: 50 });
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("50")).toBeInTheDocument();
+  });
+
+  it("renders marks correctly when marks are enabled", () => {
+    renderComponent({ marks: true });
+    const marks = document.querySelectorAll(".MuiSlider-mark");
+    expect(marks.length).toBeGreaterThan(0);
+  });
+
+  it("displays the correct value labels", () => {
+    renderComponent();
+    expect(screen.getByText("20")).toBeInTheDocument();
+    expect(screen.getByText("80")).toBeInTheDocument();
+  });
+});

--- a/app/components/Slider/Slider.tsx
+++ b/app/components/Slider/Slider.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { Box, Typography, Slider, SliderProps } from "@mui/material";
+import { sliderStyles } from "./Slider.styles";
+
+export interface CustomSliderProps extends Omit<SliderProps, "size" | "valueLabelDisplay"> {
+  size?: "small" | "big";
+}
+
+export const DesignSystemSlider: React.FC<CustomSliderProps> = ({
+  size = "big",
+  min = 0,
+  max = 100,
+  value,
+  ...props
+}) => {
+  const marks = Array.isArray(value)
+    ? Array.from({ length: Math.floor((max - min) / 5) + 1 }, (_, i) => ({
+        value: min + i * 5,
+      }))
+    : undefined;
+
+  return (
+    <Box sx={sliderStyles.base}>
+      {Array.isArray(value) && (
+        <Box sx={sliderStyles.valueContainer}>
+          <Typography
+            variant="body2"
+            sx={{
+              ...sliderStyles.valueLabel,
+              left: `${((value[0] - min) / (max - min)) * 100}%`,
+              fontSize: sliderStyles.valueLabel.fontSize(size),
+            }}
+          >
+            {value[0]}
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{
+              ...sliderStyles.valueLabel,
+              left: `${((value[1] - min) / (max - min)) * 100}%`,
+              fontSize: sliderStyles.valueLabel.fontSize(size),
+            }}
+          >
+            {value[1]}
+          </Typography>
+        </Box>
+      )}
+      <Slider
+        {...props}
+        value={value}
+        min={min}
+        max={max}
+        marks={marks}
+        sx={{
+          ...sliderStyles.slider,
+          "& .MuiSlider-thumb": {
+            ...sliderStyles.slider["& .MuiSlider-thumb"],
+            width: sliderStyles.slider["& .MuiSlider-thumb"].width(size),
+            height: sliderStyles.slider["& .MuiSlider-thumb"].height(size),
+          },
+          "& .MuiSlider-track": {
+            ...sliderStyles.slider["& .MuiSlider-track"],
+            height: sliderStyles.slider["& .MuiSlider-track"].height(size),
+          },
+          "& .MuiSlider-rail": {
+            ...sliderStyles.slider["& .MuiSlider-rail"],
+            height: sliderStyles.slider["& .MuiSlider-rail"].height(size),
+          },
+        }}
+      />
+      <Box sx={sliderStyles.minMaxContainer}>
+        <Typography
+          variant="body2"
+          sx={{
+            fontSize: sliderStyles.minMaxLabel.fontSize(size),
+          }}
+        >
+          {min}
+        </Typography>
+        <Typography
+          variant="body2"
+          sx={{
+            fontSize: sliderStyles.minMaxLabel.fontSize(size),
+          }}
+        >
+          {max}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};


### PR DESCRIPTION
### Created Slider Component:
- Single Slider: Supports a single slider thumb with a displayed value.
- Range Slider: Enables two thumbs to select a range of values.
### Styled Slider component according to the design system:
- Unified styles for all slider states (active, disabled, hover).
- Supports two size options: small and big.
- Common variables for colors and dimensions ensure consistency.
### Covered Slider with unit tests:
- Tests for rendering single and range sliders.
- Validates correct display of labels, minimum, and maximum values.
- Ensures custom styles and behavior apply correctly for various props.

![Screenshot 2025-05-26 at 10 28 28](https://github.com/user-attachments/assets/be008839-a644-4877-9b4b-62ae7f51e187)
