### PR TITLE
(SP: 3) Create Dropdown element aligned with design system 

### DIFF
--- a/app/components/dropdown-menu/DropdownMenu.style.ts
+++ b/app/components/dropdown-menu/DropdownMenu.style.ts
@@ -1,0 +1,11 @@
+export const styles = {
+  menu: {
+    mt: 1,
+    borderRadius: 2,
+     boxShadow: `
+      0px 4px 8px rgba(0, 0, 0, 0.06),
+      0px 0px 4px rgba(0, 0, 0, 0.04)
+    `,
+    minWidth: 250,
+  },
+};

--- a/app/components/dropdown-menu/DropdownMenu.style.ts
+++ b/app/components/dropdown-menu/DropdownMenu.style.ts
@@ -2,10 +2,8 @@ export const styles = {
   menu: {
     mt: 1,
     borderRadius: 2,
-     boxShadow: `
+    boxShadow: `
       0px 4px 8px rgba(0, 0, 0, 0.06),
-      0px 0px 4px rgba(0, 0, 0, 0.04)
-    `,
-    minWidth: 250,
+      0px 0px 4px rgba(0, 0, 0, 0.04) `,
   },
 };

--- a/app/components/dropdown-menu/DropdownMenu.test.tsx
+++ b/app/components/dropdown-menu/DropdownMenu.test.tsx
@@ -4,7 +4,7 @@ import DropdownMenu from '../dropdown-menu/DropdownMenu';
 import { MenuItem } from '@mui/material';
 
 describe('DropdownMenu', () => {
-  it('renders menu items when open is true', () => {
+  it('should render menu items when open is true', () => {
     render(
       <DropdownMenu
         open={true}
@@ -21,7 +21,7 @@ describe('DropdownMenu', () => {
     expect(screen.getByText('Item 2')).toBeInTheDocument();
   });
 
-  it('does not render when open is false', () => {
+  it('should not render when open is false', () => {
     render(
       <DropdownMenu
         open={false}

--- a/app/components/dropdown-menu/DropdownMenu.test.tsx
+++ b/app/components/dropdown-menu/DropdownMenu.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DropdownMenu from '../dropdown-menu/DropdownMenu';
+import { MenuItem } from '@mui/material';
+
+describe('DropdownMenu', () => {
+  it('renders menu items when open is true', () => {
+    render(
+      <DropdownMenu
+        open={true}
+        onClose={() => {}}
+        anchorEl={document.body}
+        menuList={[
+          <MenuItem key="1">Item 1</MenuItem>,
+          <MenuItem key="2">Item 2</MenuItem>,
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Item 2')).toBeInTheDocument();
+  });
+
+  it('does not render when open is false', () => {
+    render(
+      <DropdownMenu
+        open={false}
+        onClose={() => {}}
+        anchorEl={document.body}
+        menuList={<MenuItem>Hidden Item</MenuItem>}
+      />,
+    );
+
+    expect(screen.queryByText('Hidden Item')).not.toBeInTheDocument();
+  });
+});

--- a/app/components/dropdown-menu/DropdownMenu.tsx
+++ b/app/components/dropdown-menu/DropdownMenu.tsx
@@ -1,0 +1,40 @@
+'use client';
+import Menu, { type MenuProps } from '@mui/material/Menu';
+import { styles } from './DropdownMenu.style';
+import { ReactNode } from 'react';
+
+interface DropdownMenuProps extends MenuProps {
+  maxHeight?: number;
+  menuList: ReactNode
+}
+
+const DropdownMenu: React.FC<DropdownMenuProps> = ({
+  maxHeight,
+  menuList,
+  sx,
+  ...props
+}) => {
+  return (
+    <Menu
+      PaperProps={{
+        style: {
+          maxHeight,
+        },
+      }}
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'center',
+      }}
+      transformOrigin={{
+        vertical: 'top',
+        horizontal: 'center',
+      }}
+      sx={{ ...styles.menu, ...sx }}
+      {...props}
+    >
+      {menuList}
+    </Menu>
+  );
+};
+
+export default DropdownMenu;

--- a/app/components/dropdown-menu/DropdownMenu.tsx
+++ b/app/components/dropdown-menu/DropdownMenu.tsx
@@ -2,16 +2,25 @@
 import Menu, { type MenuProps } from '@mui/material/Menu';
 import { styles } from './DropdownMenu.style';
 import { ReactNode } from 'react';
+import { PositionEnum } from '~/types/enums/common.enums';
 
 interface DropdownMenuProps extends MenuProps {
   maxHeight?: number;
-  menuList: ReactNode
+  menuList: ReactNode;
 }
 
 const DropdownMenu: React.FC<DropdownMenuProps> = ({
   maxHeight,
   menuList,
   sx,
+  anchorOrigin = {
+    vertical: PositionEnum.Bottom,
+    horizontal: PositionEnum.Center,
+  },
+  transformOrigin = {
+    vertical: PositionEnum.Top,
+    horizontal: PositionEnum.Center,
+  },
   ...props
 }) => {
   return (
@@ -21,14 +30,8 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
           maxHeight,
         },
       }}
-      anchorOrigin={{
-        vertical: 'bottom',
-        horizontal: 'center',
-      }}
-      transformOrigin={{
-        vertical: 'top',
-        horizontal: 'center',
-      }}
+      anchorOrigin={anchorOrigin}
+      transformOrigin={transformOrigin}
       sx={{ ...styles.menu, ...sx }}
       {...props}
     >

--- a/app/types/enums/common.enums.ts
+++ b/app/types/enums/common.enums.ts
@@ -1,0 +1,10 @@
+export enum PositionEnum {
+  Left = 'left',
+  Right = 'right',
+  Bottom = 'bottom',
+  Top = 'top',
+  Start = 'start',
+  End = 'end',
+  Vertical = 'vertical',
+  Center = 'center',
+}


### PR DESCRIPTION

## Summary of change
Implemented a reusable DropdownMenu component based on the design system and Figma mockups.
Added a reusable PositionEnum to centralize and standardize position values across the app.

Unit test for component:
![image](https://github.com/user-attachments/assets/2d7baec3-a4bc-455b-bc40-62b22a031932)

## Result
![image](https://github.com/user-attachments/assets/ce4c2b08-28c2-4909-bad4-a2070ece52d9)
![image](https://github.com/user-attachments/assets/a564cd03-54f5-459a-8af3-a0923630ed20)

