### PR TITLE
Implemented 'TextField' element

### DIFF
--- a/app/shared/components/design-system/all-components/text-field/CustomTextField.styles.ts
+++ b/app/shared/components/design-system/all-components/text-field/CustomTextField.styles.ts
@@ -1,0 +1,115 @@
+const black = '#190D03';
+const blue700 = '#63666E';
+const error = '#E63C14';
+const yellow900 = '#673E0F';
+
+export const standardStyles = {
+  '& .MuiInput-root': {
+    width: '385px',
+    height: '46px',
+    '&:before': {
+      borderBottom: `1px solid ${black}`,
+    },
+    '&:hover:not(.Mui-disabled):before': {
+      borderBottom: `2px solid ${black}`,
+    },
+    '&.Mui-focused:after': {
+      borderBottom: `2px solid ${black}`,
+    },
+    '&.Mui-error:before': {
+      borderBottom: `2px solid ${error}`,
+    },
+    '&.Mui-error:after': {
+      borderBottom: `2px solid ${error}`,
+    },
+    '&.Mui-error:hover:before': {
+      borderBottom: `2px solid ${error}`,
+    },
+    '&.Mui-error:hover:after': {
+      borderBottom: `2px solid ${error}`,
+    },
+    '&.Mui-disabled:before': {
+      borderBottom: `2px dotted ${blue700}`,
+    },
+    '&:after': {
+      borderBottom: `1px solid ${black}`,
+    },
+  },
+  '&.MuiFormControl-root.Mui-error': {
+    borderBottom: `2px solid ${error}`,
+  },
+
+  '& .MuiInputLabel-root': {
+    color: yellow900,
+    '&.Mui-focused': {
+      color: black,
+    },
+    '&.Mui-hover': {
+      color: blue700,
+    },
+    '&.Mui-disabled': {
+      color: blue700,
+    },
+    '&.Mui-error': {
+      color: error,
+    },
+  },
+  '& .MuiInputBase-input': {
+    color: yellow900,
+  },
+
+  '& .Mui-disabled .MuiInputBase-input': {
+    color: blue700,
+  },
+
+  '& .Mui-focused .MuiInputBase-input': {
+    color: black,
+  },
+
+  '& .Mui-error .MuiInputBase-input': {
+    color: black,
+  },
+};
+
+export const outlinedStyles = {
+  '& .MuiOutlinedInput-root': {
+    width: '280px',
+    height: '48px',
+    borderRadius: '8px',
+    padding: '0 16px',
+    '& fieldset': {
+      border: '1px solid rgba(13, 3, 61, 0.24)',
+    },
+    '&:hover fieldset': {
+      border: '1px solid rgba(13, 3, 61, 0.5)',
+    },
+    '&.Mui-focused fieldset': {
+      border: `1px solid ${black}`,
+    },
+    '&.Mui-disabled fieldset': {
+      border: `1px solid ${blue700}`,
+    },
+    '&.Mui-error fieldset': {
+      border: `1px solid ${error}`,
+    },
+  },
+  '& .MuiInputLabel-root': {
+    color: '#52545a',
+    '&.Mui-focused': {
+      color: black,
+    },
+    '&.Mui-hover': {
+      color: blue700,
+    },
+    '&.Mui-disabled': {
+      color: blue700,
+    },
+    '&.Mui-error': {
+      color: error,
+    },
+  },
+  '& .MuiOutlinedInput-input.Mui-disabled': {
+    color: blue700,
+    WebkitTextFillColor: blue700,
+  },
+};

--- a/app/shared/components/design-system/all-components/text-field/CustomTextField.styles.ts
+++ b/app/shared/components/design-system/all-components/text-field/CustomTextField.styles.ts
@@ -1,17 +1,18 @@
 const black = '#190D03';
+const blue600 = '#898C95';
 const blue700 = '#63666E';
+const blue800 = '#52545A';
 const error = '#E63C14';
-const yellow900 = '#673E0F';
 
 export const standardStyles = {
   '& .MuiInput-root': {
     width: '385px',
     height: '46px',
     '&:before': {
-      borderBottom: `1px solid ${black}`,
+      borderBottom: '1px solid rgba(13, 3, 61, 0.25)',
     },
     '&:hover:not(.Mui-disabled):before': {
-      borderBottom: `2px solid ${black}`,
+      borderBottom: '1px solid rgba(13, 3, 61, 0.5)',
     },
     '&.Mui-focused:after': {
       borderBottom: `2px solid ${black}`,
@@ -25,49 +26,36 @@ export const standardStyles = {
     '&.Mui-error:hover:before': {
       borderBottom: `2px solid ${error}`,
     },
-    '&.Mui-error:hover:after': {
-      borderBottom: `2px solid ${error}`,
-    },
     '&.Mui-disabled:before': {
-      borderBottom: `2px dotted ${blue700}`,
+      borderBottom: `1px solid ${blue600}`,
     },
-    '&:after': {
+    '&:not(.Mui-focused):not(.Mui-error):after': {
       borderBottom: `1px solid ${black}`,
     },
   },
-  '&.MuiFormControl-root.Mui-error': {
-    borderBottom: `2px solid ${error}`,
-  },
 
   '& .MuiInputLabel-root': {
-    color: yellow900,
-    '&.Mui-focused': {
-      color: black,
-    },
-    '&.Mui-hover': {
-      color: blue700,
-    },
-    '&.Mui-disabled': {
-      color: blue700,
-    },
-    '&.Mui-error': {
-      color: error,
-    },
+    color: black,
   },
+
   '& .MuiInputBase-input': {
-    color: yellow900,
+    color: blue800,
+    WebkitTextFillColor: blue800,
   },
 
   '& .Mui-disabled .MuiInputBase-input': {
-    color: blue700,
+    color: blue600,
+    WebkitTextFillColor: blue600,
   },
 
   '& .Mui-focused .MuiInputBase-input': {
     color: black,
+    WebkitTextFillColor: black,
   },
 
   '& .Mui-error .MuiInputBase-input': {
     color: black,
+    WebkitTextFillColor: black,
   },
 };
 
@@ -78,7 +66,7 @@ export const outlinedStyles = {
     borderRadius: '8px',
     padding: '0 16px',
     '& fieldset': {
-      border: '1px solid rgba(13, 3, 61, 0.24)',
+      border: '1px solid rgba(13, 3, 61, 0.25)',
     },
     '&:hover fieldset': {
       border: '1px solid rgba(13, 3, 61, 0.5)',
@@ -94,18 +82,23 @@ export const outlinedStyles = {
     },
   },
   '& .MuiInputLabel-root': {
-    color: '#52545a',
+    color: blue800,
+    WebkitTextFillColor: blue800,
+    '&:not(.Mui-disabled):hover': {
+      color: blue700,
+      WebkitTextFillColor: blue700,
+    },
     '&.Mui-focused': {
       color: black,
-    },
-    '&.Mui-hover': {
-      color: blue700,
+      WebkitTextFillColor: black,
     },
     '&.Mui-disabled': {
       color: blue700,
+      WebkitTextFillColor: blue700,
     },
     '&.Mui-error': {
       color: error,
+      WebkitTextFillColor: error,
     },
   },
   '& .MuiOutlinedInput-input.Mui-disabled': {

--- a/app/shared/components/design-system/all-components/text-field/CustomTextField.test.tsx
+++ b/app/shared/components/design-system/all-components/text-field/CustomTextField.test.tsx
@@ -2,19 +2,19 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import CustomTextField from './CustomTextField';
 
 describe('Footer', () => {
-  test('renders with label and placeholder', () => {
+  it('should render with label and placeholder', () => {
     render(<CustomTextField label="Label" placeholder="Enter text..." />);
     expect(screen.getByLabelText('Label')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Enter text...')).toBeInTheDocument();
   });
 
-  test('renders with a value', () => {
+  it('should render with a value', () => {
     render(<CustomTextField value="Value" label="Label" />);
     const input = screen.getByLabelText('Label') as HTMLInputElement;
     expect(input.value).toBe('Value');
   });
 
-  test('calls onChange when typing', () => {
+  it('should call onChange when typing', () => {
     const handleChange = jest.fn();
     render(
       <CustomTextField
@@ -29,31 +29,31 @@ describe('Footer', () => {
     expect(handleChange).toHaveBeenCalledTimes(1);
   });
 
-  test('is disabled when disabled prop is true', () => {
+  it('should be disabled when disabled prop is true', () => {
     render(<CustomTextField label="Disabled" disabled value="Value" />);
     const input = screen.getByLabelText('Disabled');
     expect(input).toBeDisabled();
   });
 
-  test('shows error style when error is true', () => {
+  it('should show error style when error is true', () => {
     render(<CustomTextField label="Error" error />);
     const input = screen.getByLabelText('Error');
-    expect(input).toHaveClass('Mui-error');
+    expect(input.closest('.MuiInput-root')).toHaveClass('Mui-error');
   });
 
-  test('uses outlined variant when passed', () => {
+  it('should use outlined variant when passed', () => {
     render(<CustomTextField label="Outlined" variant="outlined" />);
     const input = screen.getByLabelText('Outlined');
     expect(input.closest('.MuiOutlinedInput-root')).toBeInTheDocument();
   });
 
-  test('uses standard variant by default', () => {
+  it('should use standard variant by default', () => {
     render(<CustomTextField label="Standard" />);
     const input = screen.getByLabelText('Standard');
     expect(input.closest('.MuiInput-root')).toBeInTheDocument();
   });
 
-  test('uses default id when label is not provided', () => {
+  it('should use default id when label is not provided', () => {
     render(<CustomTextField value="Value" />);
     const input = screen.getByDisplayValue('Value');
     expect(input).toHaveAttribute('id', 'custom-text-field');

--- a/app/shared/components/design-system/all-components/text-field/CustomTextField.test.tsx
+++ b/app/shared/components/design-system/all-components/text-field/CustomTextField.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CustomTextField from './CustomTextField';
+
+describe('Footer', () => {
+  test('renders with label and placeholder', () => {
+    render(<CustomTextField label="Label" placeholder="Enter text..." />);
+    expect(screen.getByLabelText('Label')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Enter text...')).toBeInTheDocument();
+  });
+
+  test('renders with a value', () => {
+    render(<CustomTextField value="Value" label="Label" />);
+    const input = screen.getByLabelText('Label') as HTMLInputElement;
+    expect(input.value).toBe('Value');
+  });
+
+  test('calls onChange when typing', () => {
+    const handleChange = jest.fn();
+    render(
+      <CustomTextField
+        label="Input"
+        value=""
+        onChange={handleChange}
+        placeholder="Enter text..."
+      />,
+    );
+    const input = screen.getByPlaceholderText('Enter text...');
+    fireEvent.change(input, { target: { value: 'abc' } });
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('is disabled when disabled prop is true', () => {
+    render(<CustomTextField label="Disabled" disabled value="Value" />);
+    const input = screen.getByLabelText('Disabled');
+    expect(input).toBeDisabled();
+  });
+
+  test('shows error style when error is true', () => {
+    render(<CustomTextField label="Error" error />);
+    const input = screen.getByLabelText('Error');
+    expect(input).toHaveClass('Mui-error');
+  });
+
+  test('uses outlined variant when passed', () => {
+    render(<CustomTextField label="Outlined" variant="outlined" />);
+    const input = screen.getByLabelText('Outlined');
+    expect(input.closest('.MuiOutlinedInput-root')).toBeInTheDocument();
+  });
+
+  test('uses standard variant by default', () => {
+    render(<CustomTextField label="Standard" />);
+    const input = screen.getByLabelText('Standard');
+    expect(input.closest('.MuiInput-root')).toBeInTheDocument();
+  });
+
+  test('uses default id when label is not provided', () => {
+    render(<CustomTextField value="Value" />);
+    const input = screen.getByDisplayValue('Value');
+    expect(input).toHaveAttribute('id', 'custom-text-field');
+  });
+});

--- a/app/shared/components/design-system/all-components/text-field/CustomTextField.test.tsx
+++ b/app/shared/components/design-system/all-components/text-field/CustomTextField.test.tsx
@@ -1,60 +1,59 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import CustomTextField from './CustomTextField';
 
-describe('Footer', () => {
+describe('CustomTextField', () => {
+  const handleChange = jest.fn();
+
+  beforeEach(() => {
+    handleChange.mockClear();
+  });
+  afterEach(() => jest.clearAllMocks());
+
   it('should render with label and placeholder', () => {
-    render(<CustomTextField label="Label" placeholder="Enter text..." />);
+    render(<CustomTextField onChange={handleChange} label="Label" placeholder="Enter text..." />);
     expect(screen.getByLabelText('Label')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Enter text...')).toBeInTheDocument();
   });
 
   it('should render with a value', () => {
-    render(<CustomTextField value="Value" label="Label" />);
+    render(<CustomTextField onChange={handleChange} value="Value" label="Label" />);
     const input = screen.getByLabelText('Label') as HTMLInputElement;
     expect(input.value).toBe('Value');
   });
 
   it('should call onChange when typing', () => {
-    const handleChange = jest.fn();
-    render(
-      <CustomTextField
-        label="Input"
-        value=""
-        onChange={handleChange}
-        placeholder="Enter text..."
-      />,
-    );
+    render(<CustomTextField label="Input" value="" onChange={handleChange} placeholder="Enter text..." />);
     const input = screen.getByPlaceholderText('Enter text...');
     fireEvent.change(input, { target: { value: 'abc' } });
     expect(handleChange).toHaveBeenCalledTimes(1);
   });
 
   it('should be disabled when disabled prop is true', () => {
-    render(<CustomTextField label="Disabled" disabled value="Value" />);
+    render(<CustomTextField onChange={handleChange} label="Disabled" disabled value="Value" />);
     const input = screen.getByLabelText('Disabled');
     expect(input).toBeDisabled();
   });
 
   it('should show error style when error is true', () => {
-    render(<CustomTextField label="Error" error />);
+    render(<CustomTextField onChange={handleChange} label="Error" error />);
     const input = screen.getByLabelText('Error');
     expect(input.closest('.MuiInput-root')).toHaveClass('Mui-error');
   });
 
   it('should use outlined variant when passed', () => {
-    render(<CustomTextField label="Outlined" variant="outlined" />);
+    render(<CustomTextField onChange={handleChange} label="Outlined" variant="outlined" />);
     const input = screen.getByLabelText('Outlined');
     expect(input.closest('.MuiOutlinedInput-root')).toBeInTheDocument();
   });
 
   it('should use standard variant by default', () => {
-    render(<CustomTextField label="Standard" />);
+    render(<CustomTextField onChange={handleChange} label="Standard" />);
     const input = screen.getByLabelText('Standard');
     expect(input.closest('.MuiInput-root')).toBeInTheDocument();
   });
 
   it('should use default id when label is not provided', () => {
-    render(<CustomTextField value="Value" />);
+    render(<CustomTextField onChange={handleChange} value="Value" />);
     const input = screen.getByDisplayValue('Value');
     expect(input).toHaveAttribute('id', 'custom-text-field');
   });

--- a/app/shared/components/design-system/all-components/text-field/CustomTextField.tsx
+++ b/app/shared/components/design-system/all-components/text-field/CustomTextField.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { TextField, InputAdornment, SxProps } from '@mui/material';
+import { TextField, InputAdornment, SxProps, TextFieldProps as MuiTextFieldProps } from '@mui/material';
 import { outlinedStyles, standardStyles } from './CustomTextField.styles';
 import { SvgImage } from '~/shared/components/svg-image/SvgImage';
 
-type TextFieldProps = Readonly<{
+type CustomBaseProps = {
   variant?: 'standard' | 'outlined';
   disabled?: boolean;
   value?: string;
@@ -11,60 +11,53 @@ type TextFieldProps = Readonly<{
   startIcon?: string;
   endIcon?: string;
   placeholder?: string;
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   error?: boolean;
   sx?: SxProps;
-}>;
+};
 
-export default function CustomTextField({
-  variant = 'standard',
-  disabled,
-  value,
-  label,
-  startIcon,
-  endIcon,
-  placeholder,
-  onChange,
-  error,
-  sx,
-  ...props
-}: TextFieldProps) {
-  const variantStyles =
-    variant === 'outlined' ? outlinedStyles : standardStyles;
-  const effectiveStartIcon =
-    variant === 'standard' ? (startIcon ?? 'icons/search-icon.svg') : startIcon;
+type CustomTextFieldProps = CustomBaseProps & Omit<MuiTextFieldProps, keyof CustomBaseProps>;
 
-  return (
-    <TextField
-      id={label ?? 'custom-text-field'}
-      variant={variant}
-      disabled={disabled}
-      value={value}
-      label={label}
-      placeholder={placeholder}
-      onChange={onChange}
-      error={error}
-      sx={{ ...variantStyles, ...sx }}
-      slotProps={{
-        input: {
-          startAdornment: effectiveStartIcon && (
-            <InputAdornment position="start">
-              <SvgImage
-                src={effectiveStartIcon}
-                alt="start icon"
-                width={24}
-                height={24}
-              />
-            </InputAdornment>
-          ),
-          endAdornment: endIcon && (
-            <InputAdornment position="end">
-              <SvgImage src={endIcon} alt="end icon" width={24} height={24} />
-            </InputAdornment>
-          ),
-        },
-      }}
-      {...props}
-    />
-  );
-}
+const CustomTextField = React.forwardRef<HTMLInputElement, CustomTextFieldProps>(
+  (
+    { variant = 'standard', disabled, value, label, startIcon, endIcon, placeholder, onChange, error, sx, ...props },
+    ref
+  ) => {
+    const variantStyles = variant === 'outlined' ? outlinedStyles : standardStyles;
+    const effectiveStartIcon = variant === 'standard' ? (startIcon ?? 'icons/search-icon.svg') : startIcon;
+
+    return (
+      <TextField
+        id={label ?? 'custom-text-field'}
+        variant={variant}
+        disabled={disabled}
+        value={value}
+        label={label}
+        placeholder={placeholder}
+        onChange={onChange}
+        error={error}
+        sx={{ ...variantStyles, ...sx }}
+        inputRef={ref}
+        slotProps={{
+          input: {
+            startAdornment: effectiveStartIcon && (
+              <InputAdornment position="start">
+                <SvgImage src={effectiveStartIcon} alt="start icon" width={24} height={24} />
+              </InputAdornment>
+            ),
+            endAdornment: endIcon && (
+              <InputAdornment position="end">
+                <SvgImage src={endIcon} alt="end icon" width={24} height={24} />
+              </InputAdornment>
+            )
+          }
+        }}
+        {...props}
+      />
+    );
+  }
+);
+
+CustomTextField.displayName = 'CustomTextField';
+
+export default CustomTextField;

--- a/app/shared/components/design-system/all-components/text-field/CustomTextField.tsx
+++ b/app/shared/components/design-system/all-components/text-field/CustomTextField.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { TextField, InputAdornment, SxProps } from '@mui/material';
+import Image, { StaticImageData } from 'next/image';
+import { outlinedStyles, standardStyles } from './CustomTextField.styles';
+
+type TextFieldProps = Readonly<{
+  variant?: 'standard' | 'outlined';
+  disabled?: boolean;
+  value?: string;
+  label?: string;
+  startIcon?: StaticImageData | string;
+  endIcon?: StaticImageData | string;
+  placeholder?: string;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  error?: boolean;
+  sx?: SxProps;
+}>;
+
+export default function CustomTextField({
+  variant = 'standard',
+  disabled,
+  value,
+  label,
+  startIcon,
+  endIcon,
+  placeholder,
+  onChange,
+  error,
+  sx,
+  ...props
+}: TextFieldProps) {
+  const variantStyles =
+    variant === 'outlined' ? outlinedStyles : standardStyles;
+
+  return (
+    <TextField
+      id={label ?? 'custom-text-field'}
+      variant={variant}
+      disabled={disabled}
+      value={value}
+      label={label}
+      placeholder={placeholder}
+      onChange={onChange}
+      error={error}
+      sx={{ ...variantStyles, ...sx }}
+      slotProps={{
+        input: {
+          startAdornment: startIcon && (
+            <InputAdornment position="start">
+              <Image src={startIcon} alt="start icon" width={24} height={24} />
+            </InputAdornment>
+          ),
+          endAdornment: endIcon && (
+            <InputAdornment position="end">
+              <Image src={endIcon} alt="end icon" width={24} height={24} />
+            </InputAdornment>
+          ),
+        },
+      }}
+      {...props}
+    />
+  );
+}

--- a/app/shared/components/design-system/all-components/text-field/CustomTextField.tsx
+++ b/app/shared/components/design-system/all-components/text-field/CustomTextField.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { TextField, InputAdornment, SxProps } from '@mui/material';
-import Image, { StaticImageData } from 'next/image';
 import { outlinedStyles, standardStyles } from './CustomTextField.styles';
+import { SvgImage } from '~/shared/components/svg-image/SvgImage';
 
 type TextFieldProps = Readonly<{
   variant?: 'standard' | 'outlined';
   disabled?: boolean;
   value?: string;
   label?: string;
-  startIcon?: StaticImageData | string;
-  endIcon?: StaticImageData | string;
+  startIcon?: string;
+  endIcon?: string;
   placeholder?: string;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   error?: boolean;
@@ -31,6 +31,8 @@ export default function CustomTextField({
 }: TextFieldProps) {
   const variantStyles =
     variant === 'outlined' ? outlinedStyles : standardStyles;
+  const effectiveStartIcon =
+    variant === 'standard' ? (startIcon ?? 'icons/search-icon.svg') : startIcon;
 
   return (
     <TextField
@@ -45,14 +47,19 @@ export default function CustomTextField({
       sx={{ ...variantStyles, ...sx }}
       slotProps={{
         input: {
-          startAdornment: startIcon && (
+          startAdornment: effectiveStartIcon && (
             <InputAdornment position="start">
-              <Image src={startIcon} alt="start icon" width={24} height={24} />
+              <SvgImage
+                src={effectiveStartIcon}
+                alt="start icon"
+                width={24}
+                height={24}
+              />
             </InputAdornment>
           ),
           endAdornment: endIcon && (
             <InputAdornment position="end">
-              <Image src={endIcon} alt="end icon" width={24} height={24} />
+              <SvgImage src={endIcon} alt="end icon" width={24} height={24} />
             </InputAdornment>
           ),
         },

--- a/public/icons/search-icon.svg
+++ b/public/icons/search-icon.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 21L16.7 16.7M19 11C19 15.4183 15.4183 19 11 19C6.58172 19 3 15.4183 3 11C3 6.58172 6.58172 3 11 3C15.4183 3 19 6.58172 19 11Z" stroke="#565656" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
This Pull Request introduces a custom `CustomTextField` component based on `MUI’s TextField` with support for two style variants: **standard** and **outlined**.

**Key changes:**
- created a component with `startIcon` and `endIcon` props to easily add icons inside the input;
- implemented styles for both variants (**standardStyles** and **outlinedStyles**), including color handling for different states like focus, error, and disabled;
- added styles for states (**default, hover, focused, disable, error**)

Tests:
![Screenshot 2025-05-29 223457](https://github.com/user-attachments/assets/5333a087-ff6b-418a-9284-00261a2a6f75)
