### PR TITLE
(SP:1) Hot fix for SvgImage  Component

### DIFF
--- a/app/shared/components/svg-image/SvgImage.tsx
+++ b/app/shared/components/svg-image/SvgImage.tsx
@@ -1,10 +1,12 @@
-import Image, { StaticImageData } from 'next/image';
+import Image from 'next/image';
 
 type SvgImageProps = {
-  src: StaticImageData;
+  src: string;
   alt: string;
+  width: number;  
+  height: number;
 };
 
-export const SvgImage = ({ src, alt }: SvgImageProps) => (
-  <Image src={src} alt={alt} />
+export const SvgImage = ({ src, alt , width , height }: SvgImageProps) => (
+  <Image src={src} alt={alt} width={24} height={24} />
 );

--- a/app/shared/components/svg-image/SvgImage.tsx
+++ b/app/shared/components/svg-image/SvgImage.tsx
@@ -3,10 +3,10 @@ import Image from 'next/image';
 type SvgImageProps = {
   src: string;
   alt: string;
-  width: number;  
+  width: number;
   height: number;
 };
 
-export const SvgImage = ({ src, alt , width , height }: SvgImageProps) => (
+export const SvgImage = ({ src, alt, width, height }: SvgImageProps) => (
   <Image src={src} alt={alt} width={width} height={height} />
 );

--- a/app/shared/components/svg-image/SvgImage.tsx
+++ b/app/shared/components/svg-image/SvgImage.tsx
@@ -8,5 +8,5 @@ type SvgImageProps = {
 };
 
 export const SvgImage = ({ src, alt , width , height }: SvgImageProps) => (
-  <Image src={src} alt={alt} width={24} height={24} />
+  <Image src={src} alt={alt} width={width} height={height} />
 );

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,9 @@
-import {NextConfig} from 'next';
+import { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
-  webpack: config => {
+  webpack: (config) => {
     config.module.rules.push({
       test: /\.svg$/,
       use: [
@@ -22,18 +22,16 @@ const nextConfig: NextConfig = {
         and: [/\.(ts|tsx|js|jsx|md|mdx)$/]
       }
     });
-
     return config;
   },
   turbopack: {
     rules: {
       '*.svg': {
         loaders: ['@svgr/webpack'],
-        as: '*.js',
-      },
-    },
-  },
-
+        as: '*.js'
+      }
+    }
+  }
 };
 
 const withNextIntl = createNextIntlPlugin();

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,7 +24,16 @@ const nextConfig: NextConfig = {
     });
 
     return config;
-  }
+  },
+  turbopack: {
+    rules: {
+      '*.svg': {
+        loaders: ['@svgr/webpack'],
+        as: '*.js',
+      },
+    },
+  },
+
 };
 
 const withNextIntl = createNextIntlPlugin();


### PR DESCRIPTION
Instead of importing icons , a string path in src may be applied 
I found that in Next.js, the public/ directory is special and we do not need to import files from it using relative imports 
![image](https://github.com/user-attachments/assets/ce7d0f31-b264-4c99-a71e-176dbc15cd1a)
Also width and height should be taken into account 