### PR TITLE
Feature/54/language switcher

### DIFF
--- a/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.styles.ts
+++ b/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.styles.ts
@@ -1,0 +1,25 @@
+export const styles = {
+  menuItem: {
+    minWidth: '153px',
+    gap: '4px',
+    minHeight: '36px',
+    fontFamily: 'Mulish, sans-serif',
+    fontSize: '16px',
+    fontWeight: 500,
+    color: '#190D03',
+    lineHeight: '150%',
+    '&.Mui-selected': {
+      backgroundColor: 'transparent'
+    },
+    '&.Mui-selected:hover': {
+      backgroundColor: 'rgba(25, 13, 3, 0.1)'
+    },
+    '&:hover': {
+      backgroundColor: 'rgba(25, 13, 3, 0.1)'
+    }
+  },
+  dropdownMenu: {
+    minHeight: '88px',
+    padding: '8px 0'
+  }
+};

--- a/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.test.tsx
+++ b/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.test.tsx
@@ -3,7 +3,7 @@ import LanguageSwitcher from './LanguageSwitcher';
 import { usePathname, useRouter } from '../../../../../../i18n/navigation';
 import { useLocale } from 'next-intl';
 
-jest.mock('../../../../../../i18n/navigation', () => ({
+jest.mock('~/../i18n/navigation', () => ({
   useRouter: jest.fn(),
   usePathname: jest.fn()
 }));

--- a/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.test.tsx
+++ b/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import LanguageSwitcher from './LanguageSwitcher';
+import { usePathname, useRouter } from '../../../../../../i18n/navigation';
+import { useLocale } from 'next-intl';
+
+jest.mock('../../../../../../i18n/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn()
+}));
+
+jest.mock('next-intl', () => ({
+  useLocale: jest.fn()
+}));
+
+jest.mock('~/shared/components/svg-image/SvgImage', () => ({
+  SvgImage: () => <span data-testid="svg-image" />
+}));
+
+describe('LanguageSwitcher', () => {
+  const mockPush = jest.fn();
+  const mockPathname = '/test-path';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+    (usePathname as jest.Mock).mockReturnValue(mockPathname);
+  });
+
+  describe('icon variant', () => {
+    it('should render icon and handles language switch', () => {
+      (useLocale as jest.Mock).mockReturnValue('uk');
+
+      render(<LanguageSwitcher variant="icon" />);
+
+      const iconBtn = screen.getByRole('button');
+      expect(iconBtn).toBeInTheDocument();
+
+      fireEvent.click(iconBtn);
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+
+      const englishOption = screen.getByText('English');
+      fireEvent.click(englishOption);
+      expect(mockPush).toHaveBeenCalledWith(mockPathname, { locale: 'en' });
+    });
+
+    it('should show check icon for current locale', () => {
+      (useLocale as jest.Mock).mockReturnValue('en');
+
+      render(<LanguageSwitcher variant="icon" />);
+      fireEvent.click(screen.getByRole('button'));
+
+      const selectedOption = screen.getByText('English');
+      expect(selectedOption).toBeInTheDocument();
+      expect(screen.getAllByTestId('svg-image').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('toggle variant', () => {
+    it('should render toggle and switches language', () => {
+      (useLocale as jest.Mock).mockReturnValue('en');
+
+      render(<LanguageSwitcher variant="toggle" />);
+
+      const toggleButton = screen.getByRole('button', { name: 'Українською' });
+      expect(toggleButton).toBeInTheDocument();
+      expect(toggleButton.textContent).toContain('Українською');
+
+      fireEvent.click(toggleButton);
+      expect(mockPush).toHaveBeenCalledWith(mockPathname, { locale: 'uk' });
+    });
+  });
+});

--- a/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
+++ b/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
@@ -15,10 +15,10 @@ const locales = ['uk', 'en'] as const;
 type Locale = (typeof locales)[number];
 
 export interface LanguageSwitcherProps {
-  variant?: 'icon' | 'toggle';
+  variant: 'icon' | 'toggle';
 }
 
-const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ variant = 'icon' }) => {
+const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ variant }) => {
   const router = useRouter();
   const pathname = usePathname();
   const currentLocale = useLocale();

--- a/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
+++ b/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
@@ -5,7 +5,7 @@ import { MenuItem } from '@mui/material';
 import { IconButton } from '../icon-button/IconButton';
 import Button from '../button/Button';
 import { useLocale } from 'next-intl';
-import { usePathname, useRouter } from '../../../../../../i18n/navigation';
+import { usePathname, useRouter } from '~/../i18n/navigation';
 import DropdownMenu from '../dropdown-menu/DropdownMenu';
 import { SvgImage } from '~/shared/components/svg-image/SvgImage';
 import { styles } from './LanguageSwitcher.styles';

--- a/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
+++ b/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import React, { useState } from 'react';
+import { MenuItem } from '@mui/material';
+import { IconButton } from '../icon-button/IconButton';
+import Button from '../button/Button';
+import { useLocale } from 'next-intl';
+import { usePathname, useRouter } from '../../../../../../i18n/navigation';
+import DropdownMenu from '../dropdown-menu/DropdownMenu';
+import { SvgImage } from '~/shared/components/svg-image/SvgImage';
+import { styles } from './LanguageSwitcher.styles';
+import { IconButtonColorVariant, IconButtonVariant, PositionEnum } from '~/types/enums/common.enums';
+
+const locales = ['uk', 'en'] as const;
+type Locale = (typeof locales)[number];
+
+export interface LanguageSwitcherProps {
+  variant?: 'icon' | 'toggle';
+}
+
+const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ variant = 'icon' }) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const currentLocale = useLocale();
+
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => setAnchorEl(null);
+
+  const handleLanguageChange = (newLocale: Locale) => {
+    router.push(pathname, { locale: newLocale });
+    handleClose();
+  };
+
+  const toggleLocale = () => {
+    const newLocale = currentLocale === 'uk' ? 'en' : 'uk';
+    router.push(pathname, { locale: newLocale });
+  };
+
+  const menuItems = locales.map((locale) => (
+    <MenuItem
+      key={locale}
+      selected={locale === currentLocale}
+      onClick={() => handleLanguageChange(locale)}
+      sx={styles.menuItem}
+    >
+      {locale === 'en' ? 'English' : 'Українська'}
+      {locale === currentLocale && <SvgImage src="/icons/check.svg" alt="selected locale" width={20} height={20} />}
+    </MenuItem>
+  ));
+
+  if (variant === 'toggle') {
+    return (
+      <Button
+        onClick={toggleLocale}
+        size="medium"
+        variant="outlined"
+        color="primary"
+        startIcon={<SvgImage src="/icons/planet.svg" alt="switch language" width={20} height={20} />}
+      >
+        {currentLocale === 'uk' ? 'In English' : 'Українською'}
+      </Button>
+    );
+  }
+
+  return (
+    <>
+      <IconButton
+        variant={IconButtonColorVariant.Primary}
+        type={IconButtonVariant.icon}
+        size="medium"
+        onClick={handleClick}
+      >
+        <SvgImage src="/icons/planet.svg" alt="select language" width={40} height={40} />
+      </IconButton>
+
+      <DropdownMenu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        menuList={menuItems}
+        anchorOrigin={{ vertical: PositionEnum.Bottom, horizontal: PositionEnum.Left }}
+        transformOrigin={{ vertical: PositionEnum.Top, horizontal: PositionEnum.Left }}
+        sx={styles.dropdownMenu}
+      />
+    </>
+  );
+};
+
+export default LanguageSwitcher;

--- a/public/icons/check.svg
+++ b/public/icons/check.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.6668 5L7.50016 14.1667L3.3335 10" stroke="#190D03" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/planet.svg
+++ b/public/icons/planet.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#190D03" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 2C9.43223 4.69615 8 8.27674 8 12C8 15.7233 9.43223 19.3038 12 22C14.5678 19.3038 16 15.7233 16 12C16 8.27674 14.5678 4.69615 12 2Z" stroke="#190D03" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 12H22" stroke="#190D03" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION

## Summary of change

- Added LanguageSwitcher component with two variants: icon (for header) and toggle (for footer).

- Switching the language updates the URL using Next.js internationalized routing.

- Current language is visually highlighted.

## Testing approach
![image](https://github.com/user-attachments/assets/85776063-fad0-4f8b-8993-38f005603ce0)

## Results

https://github.com/user-attachments/assets/b9f8799d-f2e4-43a6-b3d9-1e031ba47fb9

