### PR TITLE
(SP:3) Create MenuItem element aligned with design system

### DIFF
--- a/app/shared/components/design-system/all-components/menu-item/MenuItem.styles.ts
+++ b/app/shared/components/design-system/all-components/menu-item/MenuItem.styles.ts
@@ -1,0 +1,25 @@
+export const menuItemStyles = {
+  fontSize: '16px',
+  fontFamily: 'Mulish, sans-serif',
+  fontWeight: 500,
+  gap: '4px',
+
+  '&.Mui-disabled': {
+    color: '#63666e',
+    backgroundColor: 'transparent',
+    pointerEvents: 'none'
+  },
+
+  '&:hover': {
+    backgroundColor: '#190d030f'
+  },
+  '&:active': {
+    backgroundColor: '#190d031f'
+  },
+  '&.Mui-selected:hover': {
+    backgroundColor: '#190d030f'
+  },
+  '&.Mui-selected': {
+    backgroundColor: 'transparent'
+  }
+};

--- a/app/shared/components/design-system/all-components/menu-item/MenuItem.test.jsx
+++ b/app/shared/components/design-system/all-components/menu-item/MenuItem.test.jsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CustomMenuItem from './MenuItem';
+
+describe('CustomMenuItem', () => {
+  it('should render children correctly', () => {
+    render(<CustomMenuItem>Test Item</CustomMenuItem>);
+    expect(screen.getByText('Test Item')).toBeInTheDocument();
+  });
+
+  it('should show check icon when selected', () => {
+    render(<CustomMenuItem selected>Selected Item</CustomMenuItem>);
+    const checkIcon = screen.getByAltText('Item selected');
+    expect(checkIcon).toBeInTheDocument();
+    expect(checkIcon).toHaveAttribute('src', '/icons/check-icon.svg');
+  });
+
+  it('should not show check icon when not selected', () => {
+    render(<CustomMenuItem>Not Selected</CustomMenuItem>);
+    const checkIcon = screen.queryByAltText('check');
+    expect(checkIcon).not.toBeInTheDocument();
+  });
+
+  it('should call onClick handler when clicked', () => {
+    const handleClick = jest.fn();
+    render(<CustomMenuItem onClick={handleClick}>Clickable Item</CustomMenuItem>);
+    fireEvent.click(screen.getByText('Clickable Item'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/shared/components/design-system/all-components/menu-item/MenuItem.tsx
+++ b/app/shared/components/design-system/all-components/menu-item/MenuItem.tsx
@@ -7,13 +7,15 @@ interface CustomMenuItemProps extends MenuItemProps {
   selected?: boolean;
 }
 
+type ReadonlyCustomMenuItemProps = Readonly<CustomMenuItemProps>;
+
 export default function CustomMenuItem({
   children,
   selected = false,
   disabled,
   onClick,
   ...props
-}: CustomMenuItemProps) {
+}: ReadonlyCustomMenuItemProps) {
   return (
     <MenuItem sx={menuItemStyles} selected={selected} disabled={disabled} onClick={onClick} {...props}>
       {children}

--- a/app/shared/components/design-system/all-components/menu-item/MenuItem.tsx
+++ b/app/shared/components/design-system/all-components/menu-item/MenuItem.tsx
@@ -1,0 +1,23 @@
+import { MenuItem, MenuItemProps } from '@mui/material';
+import { menuItemStyles } from './MenuItem.styles';
+import { SvgImage } from '~/shared/components/svg-image/SvgImage';
+
+interface CustomMenuItemProps extends MenuItemProps {
+  children: React.ReactNode;
+  selected?: boolean;
+}
+
+export default function CustomMenuItem({
+  children,
+  selected = false,
+  disabled,
+  onClick,
+  ...props
+}: CustomMenuItemProps) {
+  return (
+    <MenuItem sx={menuItemStyles} selected={selected} disabled={disabled} onClick={onClick} {...props}>
+      {children}
+      {selected && <SvgImage src="/icons/check-icon.svg" alt="Item selected" width={20} height={20} />}
+    </MenuItem>
+  );
+}

--- a/public/icons/check-icon.svg
+++ b/public/icons/check-icon.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.6663 5L7.49967 14.1667L3.33301 10" stroke="#190D03" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION

## Summary of change

- added custom MenuItem component
- displaying an icon for the selected element, just like in the design system

## Testing approach
![image](https://github.com/user-attachments/assets/c8f01c22-ca9e-4747-964b-43968c05b0a7)

## Results


https://github.com/user-attachments/assets/fb2360f0-7389-411d-9e99-f5f3866bc98b


