### PR TITLE
Implemented eslint for imports

### DIFF
--- a/app/[lang]/[...unknown-route]/page.test.tsx
+++ b/app/[lang]/[...unknown-route]/page.test.tsx
@@ -1,14 +1,14 @@
 import { render } from '@testing-library/react';
+
 import UnknownRoutePage from './page';
 
 jest.mock('next/navigation', () => ({
   notFound: jest.fn(() => {
     throw new Error('notFound called');
-  }),
+  })
 }));
 
 describe('UnknownRoutePage', () => {
-
   it('calls notFound()', () => {
     expect(() => render(<UnknownRoutePage />)).toThrow('notFound called');
   });

--- a/app/[lang]/about-us/page.test.tsx
+++ b/app/[lang]/about-us/page.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+
 import About from './page';
 
 describe('About Component', () => {

--- a/app/[lang]/biography/page.test.tsx
+++ b/app/[lang]/biography/page.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+
 import Biography from './page';
 
 it('renders the Biography component correctly', async () => {

--- a/app/[lang]/collaboration/page.test.tsx
+++ b/app/[lang]/collaboration/page.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen } from '@testing-library/react';
+
 import Collaboration from './page';
 
 jest.mock('next-intl/server', () => ({
   getTranslations: jest.fn().mockResolvedValue((key: string) => {
     const translations: Record<string, string> = {
-      'text': 'Collaborations',
+      text: 'Collaborations'
     };
     return translations[key];
   }),
@@ -13,7 +14,7 @@ jest.mock('next-intl/server', () => ({
 
 describe('Collaboration component', () => {
   it('should render Collaboration component correctly', async () => {
-    render(await Collaboration ({ params: Promise.resolve({ lang: 'en' }) }));
+    render(await Collaboration({ params: Promise.resolve({ lang: 'en' }) }));
     expect(await screen.findByText(/Collaborations/i)).toBeInTheDocument();
   });
 });

--- a/app/[lang]/collaboration/page.tsx
+++ b/app/[lang]/collaboration/page.tsx
@@ -1,12 +1,8 @@
-import {
-  getTranslations,
-  setRequestLocale
-} from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
 import { ParamsWithLanguage } from '~/types/types/paramsWithLanguage';
 
-export default async function CollaborationPage({
-  params
-}: Readonly<ParamsWithLanguage>) {
+export default async function CollaborationPage({ params }: Readonly<ParamsWithLanguage>) {
   const { lang } = await params;
   setRequestLocale(lang);
   const t = await getTranslations('collaborations');

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -1,15 +1,18 @@
+import '../globals.css';
+import { Container } from '@mui/material';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono, Mulish, Oswald } from 'next/font/google';
-import Footer from '~/shared/components/Footer/Footer';
-import Header from '~/shared/components/Header/Header';
-import { Container } from '@mui/material';
-import '../globals.css';
-import { ReactNode } from 'react';
-import { NextIntlClientProvider, Locale, hasLocale } from 'next-intl';
-import { routing } from '~/i18n/routing';
 import { notFound } from 'next/navigation';
-import { theme } from '~/shared/components/design-system/all-components/theme/Theme';
-import ThemeProvider from '~/shared/components/design-system/all-components/theme/ThemeProvider';
+import { hasLocale, Locale, NextIntlClientProvider } from 'next-intl';
+import { ReactNode } from 'react';
+
+import Footer from '~/components/Footer/Footer';
+import Header from '~/components/Header/Header';
+import { theme } from '~/ds-components/theme/Theme';
+import ThemeProvider from '~/ds-components/theme/ThemeProvider';
+
+import { routing } from '~/i18n/routing';
+
 const geistSans = Geist({
   variable: '--font-geist-sans',
   subsets: ['latin']

--- a/app/[lang]/media-about-us/page.test.tsx
+++ b/app/[lang]/media-about-us/page.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+
 import MediaAboutUs from './page';
 
 it('renders the MediaAboutUs component correctly', async () => {

--- a/app/[lang]/not-found.test.tsx
+++ b/app/[lang]/not-found.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
+import React from 'react';
 
 import NotFoundPage from './not-found';
-import React from 'react';
 
 jest.mock('~/i18n/navigation', () => ({
   Link: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>

--- a/app/[lang]/not-found.test.tsx
+++ b/app/[lang]/not-found.test.tsx
@@ -1,4 +1,5 @@
-import { screen, render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+
 import NotFoundPage from './not-found';
 import React from 'react';
 

--- a/app/[lang]/not-found.tsx
+++ b/app/[lang]/not-found.tsx
@@ -1,5 +1,6 @@
-import { Link } from '~/i18n/navigation';
 import { getTranslations } from 'next-intl/server';
+
+import { Link } from '~/i18n/navigation';
 
 export default async function CustomNotFoundPage() {
   const t = await getTranslations('common');

--- a/app/[lang]/page.test.tsx
+++ b/app/[lang]/page.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen } from '@testing-library/react';
+
 import Home from './page';
 
 jest.mock('next-intl/server', () => ({
   getTranslations: jest.fn().mockResolvedValue((key: string) => {
     const translations: Record<string, string> = {
-      'text': 'Liatoshynsky project',
+      text: 'Liatoshynsky project'
     };
     return translations[key];
   }),
@@ -13,7 +14,7 @@ jest.mock('next-intl/server', () => ({
 
 describe('Home component', () => {
   it('should render Home component correctly', async () => {
-    render(await Home ({ params: Promise.resolve({ lang: 'en' }) }));
+    render(await Home({ params: Promise.resolve({ lang: 'en' }) }));
     expect(await screen.findByText(/Liatoshynsky project/i)).toBeInTheDocument();
   });
 });

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -1,10 +1,9 @@
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 import React from 'react';
-import {getTranslations, setRequestLocale} from 'next-intl/server';
+
 import { ParamsWithLanguage } from '~/types/types/paramsWithLanguage';
 
-export default async function Home({
-  params
-}: Readonly<ParamsWithLanguage>) {
+export default async function Home({ params }: Readonly<ParamsWithLanguage>) {
   const { lang } = await params;
   setRequestLocale(lang);
   const t = await getTranslations('home');

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,5 +1,5 @@
-import { successResponse, errorResponse } from '~/utils/apiResponse';
-import { validateContactData, type ContactFormData } from '~/utils/validateContactData';
+import { errorResponse, successResponse } from '~/utils/apiResponse';
+import { type ContactFormData, validateContactData } from '~/utils/validateContactData';
 import { validateRequestData } from '~/utils/validateRequestData';
 
 export async function POST(request: Request) {

--- a/app/constants/errors.ts
+++ b/app/constants/errors.ts
@@ -1,12 +1,13 @@
-import { createEnvErrors } from '~/lib/utils/errorHelper';
 import { lengths } from './validation';
+
+import { createEnvErrors } from '~/lib/utils/errorHelper';
 
 export const errors = {
   NAME_ERROR: `Name must be a string between ${lengths.NAME_MIN_LENGTH} and ${lengths.NAME_MAX_LENGTH} characters long.`,
   EMAIL_ERROR: 'Invalid email address.',
   MESSAGE_ERROR: `Message must be a string between ${lengths.MESSAGE_MIN_LENGTH} and ${lengths.MESSAGE_MAX_LENGTH} characters.`,
   MISSING_MONGO_URL: '❌ mongoUrl is not defined or is empty',
-  FAILED_TO_CONNECT_DB: '❌ Failed to connect to the database',
+  FAILED_TO_CONNECT_DB: '❌ Failed to connect to the database'
 };
 
 export const envErrors = {
@@ -17,6 +18,5 @@ export const envErrors = {
 
   MONGO_PORT_INVALID: 'MONGO_PORT must be a valid number',
 
-  CREDENTIALS_REQUIRED:
-    'MONGO_USERNAME and MONGO_PASSWORD are required for non-localhost connections'
+  CREDENTIALS_REQUIRED: 'MONGO_USERNAME and MONGO_PASSWORD are required for non-localhost connections'
 };

--- a/app/db/connect.ts
+++ b/app/db/connect.ts
@@ -1,17 +1,18 @@
 import mongoose from 'mongoose';
+
+import { errors } from '~/constants/errors';
+
 import { mongoUrl } from '~/config';
 import logger from '~/middleware/logger/logger';
-import { errors } from '~/constants/errors';
 
 type MongooseGlobalCache = {
   conn: typeof mongoose | null;
   promise: Promise<typeof mongoose> | null;
 };
 
-const cached: MongooseGlobalCache = (global as { mongoose?: MongooseGlobalCache })
-  .mongoose ?? {
+const cached: MongooseGlobalCache = (global as { mongoose?: MongooseGlobalCache }).mongoose ?? {
   conn: null,
-  promise: null,
+  promise: null
 };
 (global as { mongoose?: MongooseGlobalCache }).mongoose = cached;
 
@@ -25,7 +26,7 @@ async function dbConnect() {
   }
   if (!cached.promise) {
     const opts = {
-      bufferCommands: false,
+      bufferCommands: false
     };
     cached.promise = mongoose.connect(mongoUrl, opts).then((mongoose) => {
       return mongoose;

--- a/app/db/connects.test.ts
+++ b/app/db/connects.test.ts
@@ -1,5 +1,6 @@
-import { errors } from '~/constants/errors';
 import type { Mongoose } from 'mongoose';
+
+import { errors } from '~/constants/errors';
 
 type MongooseGlobalCache = {
   conn: Mongoose | null;
@@ -10,26 +11,23 @@ const mockConnection = { connection: { readyState: 1 } };
 
 const mockMongoose = (connectImpl = jest.fn()) => {
   jest.doMock('mongoose', () => ({
-    connect: connectImpl,
+    connect: connectImpl
   }));
 };
 
 const mockConfig = (url: string | undefined) => {
   jest.doMock(require.resolve('~/config'), () => ({
-    mongoUrl: url,
+    mongoUrl: url
   }));
 };
 
-const mockLoggerModule = (loggerMock: {
-  info: jest.Mock;
-  error: jest.Mock;
-}) => {
+const mockLoggerModule = (loggerMock: { info: jest.Mock; error: jest.Mock }) => {
   jest.doMock(require.resolve('~/middleware/logger/logger'), () => loggerMock);
 };
 
 const createLoggerMock = () => ({
   info: jest.fn(),
-  error: jest.fn(),
+  error: jest.fn()
 });
 
 describe('dbConnect', () => {
@@ -75,23 +73,20 @@ describe('dbConnect', () => {
 
     await expect(dbConnect()).rejects.toThrow('Connection failed');
 
-    expect(loggerMock.error).toHaveBeenCalledWith(
-      errors.FAILED_TO_CONNECT_DB,
-      error,
-    );
+    expect(loggerMock.error).toHaveBeenCalledWith(errors.FAILED_TO_CONNECT_DB, error);
   });
 
   it('should connect and cache the connection (mockImplementation)', async () => {
     const loggerMock = createLoggerMock();
 
     const fakeMongoose = {
-      connection: { readyState: 1 },
+      connection: { readyState: 1 }
     } as Partial<Mongoose>;
 
     const connectMock = jest.fn().mockResolvedValue(fakeMongoose);
 
     jest.doMock('mongoose', () => ({
-      connect: connectMock,
+      connect: connectMock
     }));
 
     mockConfig('mongodb://localhost:27017/test-db');
@@ -107,9 +102,7 @@ describe('dbConnect', () => {
     expect(loggerMock.info).toHaveBeenCalledWith('✅ Connected to db');
     expect(conn).toStrictEqual(fakeMongoose);
 
-    const cached = (
-      global as typeof globalThis & { mongoose: MongooseGlobalCache }
-    ).mongoose;
+    const cached = (global as typeof globalThis & { mongoose: MongooseGlobalCache }).mongoose;
     expect(cached).toBeDefined();
     expect(cached.conn).toStrictEqual(fakeMongoose);
     expect(cached.promise).toBeInstanceOf(Promise);
@@ -137,9 +130,7 @@ describe('dbConnect', () => {
     const { default: dbConnect } = await import('~/db/connect');
 
     await expect(dbConnect()).rejects.toThrow('Connection failed');
-    const cached = (
-      global as typeof globalThis & { mongoose: MongooseGlobalCache }
-    ).mongoose;
+    const cached = (global as typeof globalThis & { mongoose: MongooseGlobalCache }).mongoose;
     expect(cached.promise).toBeNull();
   });
 });

--- a/app/lib/utils/apiResponse.test.ts
+++ b/app/lib/utils/apiResponse.test.ts
@@ -1,5 +1,6 @@
-import { successResponse, errorResponse } from '~/utils/apiResponse';
 import { NextResponse } from 'next/server';
+
+import { errorResponse, successResponse } from '~/utils/apiResponse';
 
 jest.mock('next/server', () => ({
   NextResponse: {

--- a/app/lib/utils/audioPlayer.test.ts
+++ b/app/lib/utils/audioPlayer.test.ts
@@ -1,4 +1,4 @@
-import { formatTime, calculateProgress } from './audioPlayer';
+import { calculateProgress, formatTime } from './audioPlayer';
 
 describe('formatTime', () => {
   it('should format seconds into MM:SS format', () => {
@@ -13,13 +13,13 @@ describe('formatTime', () => {
 describe('calculateProgress', () => {
   const mockRef = {
     current: {
-      getBoundingClientRect: () => ({ left: 100, width: 200 }),
-    },
+      getBoundingClientRect: () => ({ left: 100, width: 200 })
+    }
   } as React.RefObject<HTMLDivElement>;
 
   it('should return 0 when ref is null', () => {
     const result = calculateProgress({ clientX: 150 } as MouseEvent, {
-      current: null,
+      current: null
     });
     expect(result).toBe(0);
   });

--- a/app/lib/utils/sanitizeSocialMediaType.test.ts
+++ b/app/lib/utils/sanitizeSocialMediaType.test.ts
@@ -1,5 +1,5 @@
-import { SocialMediaTypes } from '~/types/enums/common.enums';
 import { sanitizeSocialMediaType } from './sanitizeSocialMediaType';
+import { SocialMediaTypes } from '~/types/enums/common.enums';
 
 describe('sanitizeImageType', () => {
   it('should turn a string into a social media type', () => {

--- a/app/lib/utils/validateContactData.test.ts
+++ b/app/lib/utils/validateContactData.test.ts
@@ -1,6 +1,6 @@
-import { validateContactData } from '~/utils/validateContactData';
 import { errors } from '~/constants/errors';
 import { lengths } from '~/constants/validation';
+import { validateContactData } from '~/utils/validateContactData';
 
 describe('validateContactData', () => {
   it('should return no errors for valid input', () => {

--- a/app/lib/utils/validateContactData.ts
+++ b/app/lib/utils/validateContactData.ts
@@ -1,5 +1,5 @@
-import { lengths, regex } from '~/constants/validation';
 import { errors } from '~/constants/errors';
+import { lengths, regex } from '~/constants/validation';
 
 export type ContactFormData = {
   name: unknown;
@@ -11,11 +11,7 @@ export function validateContactData(data: ContactFormData): string[] {
   const { name, email, message } = data;
   const errorsMessages: string[] = [];
 
-  if (
-    typeof name !== 'string' ||
-    name.length < lengths.NAME_MIN_LENGTH ||
-    name.length > lengths.NAME_MAX_LENGTH
-  ) {
+  if (typeof name !== 'string' || name.length < lengths.NAME_MIN_LENGTH || name.length > lengths.NAME_MAX_LENGTH) {
     errorsMessages.push(errors.NAME_ERROR);
   }
 

--- a/app/middleware/logger/logger.ts
+++ b/app/middleware/logger/logger.ts
@@ -1,9 +1,9 @@
-import { createLogger, transports, format } from 'winston';
-import { MongoDB } from 'winston-mongodb';
-import { SEVEN_DAYS_IN_SECONDS } from '~/constants';
-import { mongoUrl } from '~/config';
-
 import type { TransformableInfo } from 'logform';
+import { createLogger, format, transports } from 'winston';
+import { MongoDB } from 'winston-mongodb';
+
+import { mongoUrl } from '~/config';
+import { SEVEN_DAYS_IN_SECONDS } from '~/constants';
 
 const { combine, timestamp, printf, errors, json } = format;
 
@@ -19,8 +19,7 @@ const formatStack = (stack: unknown): string => {
 
 const logFormat = printf((info: TransformableInfo): string => {
   const { level, message, timestamp, stack, ...rest } = info;
-  const meta =
-    Object.keys(rest).length > 0 ? JSON.stringify(rest, null, 2) : '';
+  const meta = Object.keys(rest).length > 0 ? JSON.stringify(rest, null, 2) : '';
   const metaBlock = meta ? '\n' + meta : '';
   return `🕒 ${timestamp} ${level}: ${message}${metaBlock}${formatStack(stack)}`;
 });
@@ -30,7 +29,7 @@ const logger = createLogger({
   transports: [
     new transports.Console({
       format: combine(format.colorize(), logFormat),
-      handleExceptions: true,
+      handleExceptions: true
     }),
 
     new MongoDB({
@@ -38,9 +37,9 @@ const logger = createLogger({
       db: mongoUrl,
       collection: 'logger',
       expireAfterSeconds: SEVEN_DAYS_IN_SECONDS,
-      format: combine(errors({ stack: true }), timestamp(), json()),
-    }),
-  ],
+      format: combine(errors({ stack: true }), timestamp(), json())
+    })
+  ]
 });
 
 export default logger;

--- a/app/shared/components/Footer/Footer.test.tsx
+++ b/app/shared/components/Footer/Footer.test.tsx
@@ -1,5 +1,6 @@
-import Footer from '~/components/Footer/Footer';
 import { render, screen } from '@testing-library/react';
+
+import Footer from '~/components/Footer/Footer';
 
 jest.mock('next-intl/server', () => ({
   getTranslations: jest.fn().mockResolvedValue((key: string) => {

--- a/app/shared/components/Footer/Footer.tsx
+++ b/app/shared/components/Footer/Footer.tsx
@@ -5,9 +5,10 @@ import React from 'react';
 import FooterContactInfo from '~/components/Footer/FooterContactInfo/FooterContactInfo';
 import FooterCopyrights from '~/components/Footer/FooterCopyrights/FooterCopyrights';
 
-import FooterContactAndSupport from './FooterContactAndSupport/FooterContactAndSupport';
-import FooterSocialMedia from './footer-social-media/FooterSocialMedia';
 import { contacts, sections, SocialMedia } from './Footer.consts';
+import FooterSocialMedia from './footer-social-media/FooterSocialMedia';
+import FooterContactAndSupport from './FooterContactAndSupport/FooterContactAndSupport';
+import FooterNavigation from './FooterNavigation/FooterNavigation';
 
 export default async function Footer() {
   const t = await getTranslations('footer');

--- a/app/shared/components/Footer/Footer.tsx
+++ b/app/shared/components/Footer/Footer.tsx
@@ -5,8 +5,6 @@ import React from 'react';
 import FooterContactInfo from '~/components/Footer/FooterContactInfo/FooterContactInfo';
 import FooterCopyrights from '~/components/Footer/FooterCopyrights/FooterCopyrights';
 
-import DonationButton from './DonationButton/DonationButton';
-import FooterNavigation from './FooterNavigation/FooterNavigation';
 import FooterContactAndSupport from './FooterContactAndSupport/FooterContactAndSupport';
 import FooterSocialMedia from './footer-social-media/FooterSocialMedia';
 import { contacts, sections, SocialMedia } from './Footer.consts';

--- a/app/shared/components/Footer/Footer.tsx
+++ b/app/shared/components/Footer/Footer.tsx
@@ -1,8 +1,11 @@
 import { Box } from '@mui/material';
-import React from 'react';
-import FooterCopyrights from '~/components/Footer/FooterCopyrights/FooterCopyrights';
-import FooterContactInfo from '~/components/Footer/FooterContactInfo/FooterContactInfo';
 import { getTranslations } from 'next-intl/server';
+import React from 'react';
+
+import FooterContactInfo from '~/components/Footer/FooterContactInfo/FooterContactInfo';
+import FooterCopyrights from '~/components/Footer/FooterCopyrights/FooterCopyrights';
+
+import DonationButton from './DonationButton/DonationButton';
 import FooterNavigation from './FooterNavigation/FooterNavigation';
 import FooterContactAndSupport from './FooterContactAndSupport/FooterContactAndSupport';
 import FooterSocialMedia from './footer-social-media/FooterSocialMedia';

--- a/app/shared/components/Footer/FooterContactAndSupport/ContactUsButton/ContactUsButton.test.tsx
+++ b/app/shared/components/Footer/FooterContactAndSupport/ContactUsButton/ContactUsButton.test.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
+import React from 'react';
+
 import ContactUsButton from './ContactUsButton';
 
 const mockData = {

--- a/app/shared/components/Footer/FooterContactAndSupport/ContactUsButton/ContactUsButton.tsx
+++ b/app/shared/components/Footer/FooterContactAndSupport/ContactUsButton/ContactUsButton.tsx
@@ -1,8 +1,10 @@
+import Link from 'next/link';
 import React from 'react';
+
+import { ButtonData } from '../types';
+
 import Button from '~/shared/components/design-system/all-components/button/Button';
 import { SvgImage } from '~/shared/components/svg-image/SvgImage';
-import Link from 'next/link';
-import { ButtonData } from '../types';
 
 type ContactUsDataProps = {
   data: ButtonData;

--- a/app/shared/components/Footer/FooterContactAndSupport/DonationButton/DonationButton.test.tsx
+++ b/app/shared/components/Footer/FooterContactAndSupport/DonationButton/DonationButton.test.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
+import React from 'react';
+
 import DonationButton from './DonationButton';
 
 const mockData = {

--- a/app/shared/components/Footer/FooterContactAndSupport/DonationButton/DonationButton.tsx
+++ b/app/shared/components/Footer/FooterContactAndSupport/DonationButton/DonationButton.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
-import Button from '~/ds-components/button/Button';
-import { SvgImage } from '~/components/svg-image/SvgImage';
 import Link from 'next/link';
+import React from 'react';
+
+import { SvgImage } from '~/components/svg-image/SvgImage';
+import Button from '~/ds-components/button/Button';
+
 import { ButtonData } from '../types';
 
 type DonationDataProps = {

--- a/app/shared/components/Footer/FooterContactAndSupport/FooterContactAndSupport.test.tsx
+++ b/app/shared/components/Footer/FooterContactAndSupport/FooterContactAndSupport.test.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import FooterContactAndSupport from './FooterContactAndSupport';
 import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import FooterContactAndSupport from './FooterContactAndSupport';
 import { ButtonData } from './types';
 
 const mockContactUs: ButtonData = {

--- a/app/shared/components/Footer/FooterContactAndSupport/FooterContactAndSupport.tsx
+++ b/app/shared/components/Footer/FooterContactAndSupport/FooterContactAndSupport.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import DonationButton from './DonationButton/DonationButton';
-import ContactUsButton from './ContactUsButton/ContactUsButton';
 import { Box } from '@mui/material';
+import React from 'react';
+
+import ContactUsButton from './ContactUsButton/ContactUsButton';
+import DonationButton from './DonationButton/DonationButton';
 import { styles } from './FooterContactAndSupport.styles';
 import { ButtonData } from './types';
 

--- a/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.test.tsx
+++ b/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.test.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import FooterContactInfo from './FooterContactInfo';
+import React from 'react';
+
 import { useIsMobile } from '~/hooks/is-mobile/useIsMobile';
+
+import FooterContactInfo from './FooterContactInfo';
 
 const contacts = {
   title: 'Test Title',

--- a/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.tsx
+++ b/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.tsx
@@ -1,7 +1,9 @@
 'use client';
+import { Box, Link, Typography } from '@mui/material';
 import React, { FC } from 'react';
-import { Box, Typography, Link } from '@mui/material';
+
 import { useIsMobile } from '~/hooks/is-mobile/useIsMobile';
+
 import { styles } from './FooterContactInfo.styles';
 
 interface FooterContactInfoProps {

--- a/app/shared/components/Footer/FooterCopyrights/FooterCopyrights.test.tsx
+++ b/app/shared/components/Footer/FooterCopyrights/FooterCopyrights.test.tsx
@@ -1,27 +1,24 @@
 import { render, screen } from '@testing-library/react';
+
 import FooterCopyrights from './FooterCopyrights';
 
 describe('FooterCopyrights', () => {
   const mockLinks = {
     text: 'Mock text',
     links: [
-      {label: 'Mock Privacy', href: '/privacy'},
-      {label: 'Mock Terms', href: '/terms'},
+      { label: 'Mock Privacy', href: '/privacy' },
+      { label: 'Mock Terms', href: '/terms' }
     ]
   };
 
   test('should display footer copyright text', () => {
-    render(
-      <FooterCopyrights text={mockLinks.text} links={mockLinks.links} />,
-    );
+    render(<FooterCopyrights text={mockLinks.text} links={mockLinks.links} />);
 
     expect(screen.getByText(mockLinks.text)).toBeInTheDocument();
   });
 
   test('should display all footer links', () => {
-    render(
-      <FooterCopyrights text={mockLinks.text} links={mockLinks.links} />,
-    );
+    render(<FooterCopyrights text={mockLinks.text} links={mockLinks.links} />);
 
     mockLinks.links.forEach(({ label, href }) => {
       const linkElement = screen.getByRole('link', { name: label });

--- a/app/shared/components/Footer/FooterCopyrights/FooterCopyrights.tsx
+++ b/app/shared/components/Footer/FooterCopyrights/FooterCopyrights.tsx
@@ -1,5 +1,6 @@
+import { Box, Link, Typography } from '@mui/material';
 import React from 'react';
-import { Box, Typography, Link } from '@mui/material';
+
 import { styles } from '~/components/Footer/FooterCopyrights/FooterCopyrights.styles';
 
 type LinkItem = {

--- a/app/shared/components/Footer/FooterNavigation/FooterNavigation.test.tsx
+++ b/app/shared/components/Footer/FooterNavigation/FooterNavigation.test.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
+import React from 'react';
+
 import FooterNavigation from './FooterNavigation';
 
 describe('FooterNavigation', () => {

--- a/app/shared/components/Footer/FooterNavigation/FooterNavigation.tsx
+++ b/app/shared/components/Footer/FooterNavigation/FooterNavigation.tsx
@@ -1,5 +1,6 @@
+import { Box, Link, Typography } from '@mui/material';
 import React, { FC } from 'react';
-import { Box, Typography, Link } from '@mui/material';
+
 import { styles } from './FooterNavigation.styles';
 
 type LinkItem = {

--- a/app/shared/components/Footer/footer-social-media/FooterSocialMedia.test.tsx
+++ b/app/shared/components/Footer/footer-social-media/FooterSocialMedia.test.tsx
@@ -1,6 +1,7 @@
-import { SocialMediaTypes } from '~/types/enums/common.enums';
-import FooterSocialMedia from './FooterSocialMedia';
 import { render } from '@testing-library/react';
+
+import FooterSocialMedia from './FooterSocialMedia';
+import { SocialMediaTypes } from '~/types/enums/common.enums';
 
 jest.mock('~/i18n/navigation', () => ({
   Link: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>

--- a/app/shared/components/Footer/footer-social-media/FooterSocialMedia.tsx
+++ b/app/shared/components/Footer/footer-social-media/FooterSocialMedia.tsx
@@ -1,7 +1,9 @@
 import { Box } from '@mui/material';
+
 import { styles } from './FooterSocialMedia.styles';
-import { SocialMediaTypes } from '~/types/enums/common.enums';
 import SocialMediaIcon from './social-media-icon/SocialMediaIcon';
+import { SocialMediaTypes } from '~/types/enums/common.enums';
+
 import { sanitizeSocialMediaType } from '~/lib/utils/sanitizeSocialMediaType';
 type LinkIcon = {
   icon: string | SocialMediaTypes;

--- a/app/shared/components/Footer/footer-social-media/social-media-icon/SocialMediaIcon.tsx
+++ b/app/shared/components/Footer/footer-social-media/social-media-icon/SocialMediaIcon.tsx
@@ -1,7 +1,8 @@
+import { SocialMediaTypes } from '~/types/enums/common.enums';
+
 import { Link } from '~/i18n/navigation';
 import { IconButton } from '~/shared/components/design-system/all-components/icon-button/IconButton';
 import { SvgImage } from '~/shared/components/svg-image/SvgImage';
-import { SocialMediaTypes } from '~/types/enums/common.enums';
 
 interface SocialMediaIconProps {
   icon: SocialMediaTypes;

--- a/app/shared/components/Header/AudioPlayer/AudioPlayer.test.tsx
+++ b/app/shared/components/Header/AudioPlayer/AudioPlayer.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
 import AudioPlayer, { AudioPlayerProps } from './AudioPlayer';
 
 describe('AudioPlayer', () => {
@@ -6,7 +7,7 @@ describe('AudioPlayer', () => {
     src: 'test-audio.mp3',
     trackName: 'Test Track',
     onPlay: jest.fn(),
-    onPause: jest.fn(),
+    onPause: jest.fn()
   };
 
   let props: Partial<AudioPlayerProps>;
@@ -26,9 +27,7 @@ describe('AudioPlayer', () => {
   });
 
   test('should render AudioPlayer component', () => {
-    expect(
-      screen.getByRole('button', { name: /toggle audio player/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /toggle audio player/i })).toBeInTheDocument();
   });
 
   test('should render audio element with given src', () => {
@@ -38,9 +37,7 @@ describe('AudioPlayer', () => {
   });
 
   test('should open popover when button is clicked', () => {
-    fireEvent.click(
-      screen.getByRole('button', { name: /toggle audio player/i }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: /toggle audio player/i }));
     expect(screen.getByText(defaultProps.trackName)).toBeInTheDocument();
   });
 
@@ -51,11 +48,11 @@ describe('AudioPlayer', () => {
       if (audio) {
         Object.defineProperty(audio, 'currentTime', {
           value: 5,
-          writable: true,
+          writable: true
         });
         Object.defineProperty(audio, 'duration', {
           value: 10,
-          writable: true,
+          writable: true
         });
         audio.dispatchEvent(new Event('timeupdate'));
       }
@@ -71,7 +68,7 @@ describe('AudioPlayer', () => {
       if (audio) {
         Object.defineProperty(audio, 'duration', {
           value: 20,
-          writable: true,
+          writable: true
         });
         audio.dispatchEvent(new Event('loadedmetadata'));
       }
@@ -111,7 +108,7 @@ describe('AudioPlayer', () => {
     if (audio) {
       Object.defineProperty(audio, 'duration', {
         value: 100,
-        writable: true,
+        writable: true
       });
 
       act(() => {
@@ -129,14 +126,12 @@ describe('AudioPlayer', () => {
     act(() => {
       Object.defineProperty(audio!, 'paused', {
         value: false,
-        configurable: true,
+        configurable: true
       });
       audio?.dispatchEvent(new Event('play'));
     });
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /toggle audio player/i }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: /toggle audio player/i }));
 
     const animatedBars = screen.getAllByRole('presentation');
     expect(animatedBars.length).toBeGreaterThan(0);
@@ -144,7 +139,7 @@ describe('AudioPlayer', () => {
     act(() => {
       Object.defineProperty(audio!, 'paused', {
         value: true,
-        configurable: true,
+        configurable: true
       });
       audio?.dispatchEvent(new Event('pause'));
     });

--- a/app/shared/components/Header/AudioPlayer/AudioPlayer.tsx
+++ b/app/shared/components/Header/AudioPlayer/AudioPlayer.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { Box, IconButton } from '@mui/material';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
 import { styles } from './AudioPlayer.styles';
 import AudioPlayerPopover from './AudioPlayerPopover/AudioPlayerPopover';
 
@@ -19,16 +20,10 @@ const stickHeights = [
   { id: 'stick-3', height: 30 },
   { id: 'stick-4', height: 13 },
   { id: 'stick-5', height: 22 },
-  { id: 'stick-6', height: 7 },
+  { id: 'stick-6', height: 7 }
 ];
 
-export default function AudioPlayer({
-  src,
-  trackName,
-  loop = false,
-  autoplay = false,
-  className,
-}: AudioPlayerProps) {
+export default function AudioPlayer({ src, trackName, loop = false, autoplay = false, className }: AudioPlayerProps) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -134,7 +129,7 @@ export default function AudioPlayer({
                   ...styles.icon,
                   ...(isPlaying ? styles.iconAnimated : styles.iconStatic),
                   animationDelay: isPlaying ? `${i * 0.1}s` : undefined,
-                  height,
+                  height
                 }}
               />
             ))}

--- a/app/shared/components/Header/AudioPlayer/AudioPlayerPopover/AudioPlayerPopover.test.tsx
+++ b/app/shared/components/Header/AudioPlayer/AudioPlayerPopover/AudioPlayerPopover.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
 import AudioPlayerPopover from './AudioPlayerPopover';
 
 const defaultProps = {
@@ -11,7 +12,7 @@ const defaultProps = {
   onTogglePlay: jest.fn(),
   onSeek: jest.fn(),
   trackName: 'Test Track',
-  error: null,
+  error: null
 };
 
 const mockBoundingClientRect = {
@@ -23,7 +24,7 @@ const mockBoundingClientRect = {
   height: 10,
   x: 0,
   y: 0,
-  toJSON: () => {},
+  toJSON: () => {}
 };
 
 describe('AudioPlayerPopover', () => {
@@ -40,18 +41,12 @@ describe('AudioPlayerPopover', () => {
 
   it('should render pause icon when isPlaying is true', () => {
     render(<AudioPlayerPopover {...defaultProps} isPlaying={true} />);
-    expect(
-      screen.getByRole('button', { name: /Pause audio/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Pause audio/i })).toBeInTheDocument();
   });
 
   it('should not render when anchorEl is null', () => {
-    const { container } = render(
-      <AudioPlayerPopover {...defaultProps} anchorEl={null} />,
-    );
-    expect(
-      container.querySelector('[role="presentation"]'),
-    ).not.toBeInTheDocument();
+    const { container } = render(<AudioPlayerPopover {...defaultProps} anchorEl={null} />);
+    expect(container.querySelector('[role="presentation"]')).not.toBeInTheDocument();
   });
 
   it('should call onTogglePlay when play button is clicked', () => {
@@ -80,19 +75,13 @@ describe('AudioPlayerPopover', () => {
 
       const onSeekMock = jest.fn();
 
-      render(
-        <AudioPlayerPopover
-          {...defaultProps}
-          anchorEl={anchor}
-          onSeek={onSeekMock}
-        />,
-      );
+      render(<AudioPlayerPopover {...defaultProps} anchorEl={anchor} onSeek={onSeekMock} />);
 
       const progressBar = await screen.findByRole('progress');
 
       Object.defineProperty(progressBar, 'getBoundingClientRect', {
         configurable: true,
-        value: () => mockBoundingClientRect,
+        value: () => mockBoundingClientRect
       });
 
       fireEvent.mouseDown(progressBar, { clientX: 150 });

--- a/app/shared/components/Header/AudioPlayer/AudioPlayerPopover/AudioPlayerPopover.tsx
+++ b/app/shared/components/Header/AudioPlayer/AudioPlayerPopover/AudioPlayerPopover.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React, { useRef, useState, useEffect } from 'react';
-import { Box, IconButton, Popover, Typography, Button } from '@mui/material';
-import { styles } from './AudioPlayerPopover.styles';
-import { formatTime, calculateProgress } from '~/utils/audioPlayer';
+import { Box, Button, IconButton, Popover, Typography } from '@mui/material';
 import Image from 'next/image';
+import React, { useEffect, useRef, useState } from 'react';
+
+import { styles } from './AudioPlayerPopover.styles';
+import { calculateProgress, formatTime } from '~/utils/audioPlayer';
 interface AudioPlayerPopoverProps {
   anchorEl: HTMLButtonElement | null;
   isPlaying: boolean;

--- a/app/shared/components/Header/Header.tsx
+++ b/app/shared/components/Header/Header.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material';
-import React from 'react';
 import { getTranslations } from 'next-intl/server';
+import React from 'react';
+
 import AudioPlayer from './AudioPlayer/AudioPlayer';
 import SupportButton from './SupportButton/SupportButton';
 

--- a/app/shared/components/Header/SupportButton/SupportButton.test.tsx
+++ b/app/shared/components/Header/SupportButton/SupportButton.test.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
+import React from 'react';
+
 import SupportButton from './SupportButton';
 
 const mockData = {

--- a/app/shared/components/Header/SupportButton/SupportButton.tsx
+++ b/app/shared/components/Header/SupportButton/SupportButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import Button from '~/shared/components/design-system/all-components/button/Button';
+
 import { Link } from '~/i18n/navigation';
+import Button from '~/shared/components/design-system/all-components/button/Button';
 
 type SupportButtonData = {
   text: string;

--- a/app/shared/components/Quote/Quote.test.tsx
+++ b/app/shared/components/Quote/Quote.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+
 import Quote from './Quote';
 import type { QuoteBlockProps } from '~/types/types/quoteComponent';
 

--- a/app/shared/components/Quote/Quote.tsx
+++ b/app/shared/components/Quote/Quote.tsx
@@ -1,4 +1,5 @@
 import { Box, Typography } from '@mui/material';
+
 import QuoteImage from '../../../../public/images/quote.svg';
 import { styles } from './Quote.styles';
 import { QuoteBlockProps } from '~/types/types/quoteComponent';

--- a/app/shared/components/design-system/all-components/button/Button.test.tsx
+++ b/app/shared/components/design-system/all-components/button/Button.test.tsx
@@ -1,5 +1,6 @@
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+
 import Button from './Button';
 import { colors } from './Button.styles';
 
@@ -11,7 +12,7 @@ describe('Button Component', () => {
     render(
       <Button startIcon={startIcon} endIcon={endIcon}>
         Icons
-      </Button>,
+      </Button>
     );
 
     expect(screen.getByTestId('start-icon')).toBeInTheDocument();
@@ -23,7 +24,7 @@ describe('Button Component', () => {
 
     expect(screen.getByRole('button')).toHaveStyle({
       backgroundColor: colors.yellow[500],
-      color: colors.black,
+      color: colors.black
     });
   });
 
@@ -32,7 +33,7 @@ describe('Button Component', () => {
     render(
       <Button loading onClick={handleClick}>
         Loading
-      </Button>,
+      </Button>
     );
 
     const button = screen.getByRole('button');

--- a/app/shared/components/design-system/all-components/button/Button.tsx
+++ b/app/shared/components/design-system/all-components/button/Button.tsx
@@ -1,17 +1,8 @@
 'use client';
+import { Button as MuiButton, ButtonProps as MuiButtonProps, CircularProgress } from '@mui/material';
 import { forwardRef, ReactNode } from 'react';
-import {
-  Button as MuiButton,
-  CircularProgress,
-  ButtonProps as MuiButtonProps,
-} from '@mui/material';
 
-import {
-  buttonBaseStyles,
-  variantStyles,
-  sizeStyles,
-  typographyStyles,
-} from './Button.styles';
+import { buttonBaseStyles, sizeStyles, typographyStyles, variantStyles } from './Button.styles';
 
 type Size = 'large' | 'medium' | 'small';
 
@@ -34,8 +25,7 @@ type BaseButtonProps = {
     }
 );
 
-export type ButtonProps = BaseButtonProps &
-  Omit<MuiButtonProps, keyof BaseButtonProps>;
+export type ButtonProps = BaseButtonProps & Omit<MuiButtonProps, keyof BaseButtonProps>;
 
 type Ref = MuiButtonProps['ref'];
 
@@ -53,11 +43,9 @@ const Button = forwardRef(
       children,
       ...props
     }: ButtonProps,
-    forwardedRef: Ref,
+    forwardedRef: Ref
   ) => {
-    const loader = (
-      <CircularProgress color="inherit" data-testid="loader" size={25} />
-    );
+    const loader = <CircularProgress color="inherit" data-testid="loader" size={25} />;
     const isDisabled = disabled ?? loading;
 
     const content = (
@@ -74,9 +62,7 @@ const Button = forwardRef(
           ...buttonBaseStyles,
           ...sizeStyles[size],
           ...typographyStyles[color]?.[size],
-          ...(color === 'tertiary'
-            ? variantStyles.tertiary.filled
-            : variantStyles[color]?.[variant]),
+          ...(color === 'tertiary' ? variantStyles.tertiary.filled : variantStyles[color]?.[variant])
         }}
         disabled={isDisabled}
         ref={forwardedRef}
@@ -92,7 +78,7 @@ const Button = forwardRef(
         )}
       </MuiButton>
     );
-  },
+  }
 );
 Button.displayName = 'Button';
 

--- a/app/shared/components/design-system/all-components/checkbox/Checkbox.spec.tsx
+++ b/app/shared/components/design-system/all-components/checkbox/Checkbox.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
-import CustomCheckbox from './Checkbox';
 import userEvent from '@testing-library/user-event';
+
+import CustomCheckbox from './Checkbox';
 
 describe('CustomCheckbox', () => {
   const label = 'Label';
@@ -16,7 +17,6 @@ describe('CustomCheckbox', () => {
     expect(screen.getByRole('checkbox')).toBeChecked();
     await userEvent.click(screen.getByRole('checkbox'));
     expect(screen.queryByRole('checkbox')).not.toBeChecked();
-
   });
   it('should not toggle disabled checkbox', () => {
     render(<CustomCheckbox disabled label={label} />);
@@ -26,5 +26,4 @@ describe('CustomCheckbox', () => {
     render(<CustomCheckbox label={label} defaultChecked />);
     expect(screen.queryByRole('checkbox')).toBeChecked();
   });
-
 });

--- a/app/shared/components/design-system/all-components/checkbox/Checkbox.tsx
+++ b/app/shared/components/design-system/all-components/checkbox/Checkbox.tsx
@@ -1,28 +1,37 @@
 'use client';
 import { Box, Checkbox } from '@mui/material';
-import FormGroup from '@mui/material/FormGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import { CheckboxProps } from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+
 import { checkboxStyles } from './Checkbox.styles';
 
 interface CustomCheckboxProps extends CheckboxProps {
-    label: React.ReactNode;
-    size?: 'medium' | 'large';
+  label: React.ReactNode;
+  size?: 'medium' | 'large';
 }
 type ReadonlyCustomCheckboxProps = Readonly<CustomCheckboxProps>;
-export default function CustomCheckbox({ disabled, defaultChecked, size, label, onChange }: ReadonlyCustomCheckboxProps) {
+export default function CustomCheckbox({
+  disabled,
+  defaultChecked,
+  size,
+  label,
+  onChange
+}: ReadonlyCustomCheckboxProps) {
   return (
     <Box>
       <FormGroup>
-        <FormControlLabel control={
-          <Checkbox
-            sx={checkboxStyles}
-            size={size}
-            disabled={disabled}
-            defaultChecked={defaultChecked}
-            onChange={onChange}
-          />}
-        label={label}
+        <FormControlLabel
+          control={
+            <Checkbox
+              sx={checkboxStyles}
+              size={size}
+              disabled={disabled}
+              defaultChecked={defaultChecked}
+              onChange={onChange}
+            />
+          }
+          label={label}
         />
       </FormGroup>
     </Box>

--- a/app/shared/components/design-system/all-components/dropdown-menu/DropdownMenu.test.tsx
+++ b/app/shared/components/design-system/all-components/dropdown-menu/DropdownMenu.test.tsx
@@ -1,20 +1,18 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import DropdownMenu from './DropdownMenu';
 import { MenuItem } from '@mui/material';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import DropdownMenu from './DropdownMenu';
 
 describe('DropdownMenu', () => {
   it('should render menu items when open is true', () => {
     render(
       <DropdownMenu
         open={true}
-        onClose={() => { }}
+        onClose={() => {}}
         anchorEl={document.body}
-        menuList={[
-          <MenuItem key="1">Item 1</MenuItem>,
-          <MenuItem key="2">Item 2</MenuItem>,
-        ]}
-      />,
+        menuList={[<MenuItem key="1">Item 1</MenuItem>, <MenuItem key="2">Item 2</MenuItem>]}
+      />
     );
 
     expect(screen.getByText('Item 1')).toBeInTheDocument();
@@ -25,10 +23,10 @@ describe('DropdownMenu', () => {
     render(
       <DropdownMenu
         open={false}
-        onClose={() => { }}
+        onClose={() => {}}
         anchorEl={document.body}
         menuList={<MenuItem>Hidden Item</MenuItem>}
-      />,
+      />
     );
 
     expect(screen.queryByText('Hidden Item')).not.toBeInTheDocument();

--- a/app/shared/components/design-system/all-components/dropdown-menu/DropdownMenu.tsx
+++ b/app/shared/components/design-system/all-components/dropdown-menu/DropdownMenu.tsx
@@ -1,7 +1,8 @@
 'use client';
 import Menu, { type MenuProps } from '@mui/material/Menu';
-import { styles } from './DropdownMenu.style';
 import { ReactNode } from 'react';
+
+import { styles } from './DropdownMenu.style';
 import { PositionEnum } from '~/types/enums/common.enums';
 
 interface DropdownMenuProps extends MenuProps {
@@ -15,11 +16,11 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   sx,
   anchorOrigin = {
     vertical: PositionEnum.Bottom,
-    horizontal: PositionEnum.Center,
+    horizontal: PositionEnum.Center
   },
   transformOrigin = {
     vertical: PositionEnum.Top,
-    horizontal: PositionEnum.Center,
+    horizontal: PositionEnum.Center
   },
   ...props
 }) => {
@@ -27,8 +28,8 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
     <Menu
       PaperProps={{
         style: {
-          maxHeight,
-        },
+          maxHeight
+        }
       }}
       anchorOrigin={anchorOrigin}
       transformOrigin={transformOrigin}

--- a/app/shared/components/design-system/all-components/icon-button/IconButton.test.tsx
+++ b/app/shared/components/design-system/all-components/icon-button/IconButton.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+
 import { IconButton } from './IconButton';
 
 describe('IconButton', () => {
@@ -21,7 +22,7 @@ describe('IconButton', () => {
     render(
       <IconButton>
         <span data-testid="menu-icon">Test Value</span>
-      </IconButton>,
+      </IconButton>
     );
     const children = screen.getByTestId('menu-icon');
     expect(children).toBeInTheDocument();

--- a/app/shared/components/design-system/all-components/icon-button/IconButton.tsx
+++ b/app/shared/components/design-system/all-components/icon-button/IconButton.tsx
@@ -1,13 +1,7 @@
-import {
-  CircularProgress,
-  IconButtonProps as MuiIconButtonProps,
-  IconButton as MuiIconButton,
-} from '@mui/material';
+import { CircularProgress, IconButton as MuiIconButton, IconButtonProps as MuiIconButtonProps } from '@mui/material';
+
 import { CreateStyleClasses, IconButtonStyles } from './IconButton.styles';
-import {
-  IconButtonColorVariant,
-  IconButtonVariant,
-} from '~/types/enums/common.enums';
+import { IconButtonColorVariant, IconButtonVariant } from '~/types/enums/common.enums';
 
 interface IconButtonProps extends Omit<MuiIconButtonProps, 'type'> {
   variant?: IconButtonColorVariant;
@@ -36,11 +30,9 @@ export const IconButton: React.FC<IconButtonProps> = ({
   const loaderSizes = {
     small: 16,
     medium: 20,
-    large: 24,
+    large: 24
   };
-  const loader = (
-    <CircularProgress data-testid="loader" size={loaderSizes[size]} />
-  );
+  const loader = <CircularProgress data-testid="loader" size={loaderSizes[size]} />;
   const buttonContent = loading ? loader : children;
   return (
     <MuiIconButton

--- a/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.test.tsx
+++ b/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import LanguageSwitcher from './LanguageSwitcher';
-import { usePathname, useRouter } from '../../../../../../i18n/navigation';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { useLocale } from 'next-intl';
+
+import { usePathname, useRouter } from '../../../../../../i18n/navigation';
+import LanguageSwitcher from './LanguageSwitcher';
 
 jest.mock('~/../i18n/navigation', () => ({
   useRouter: jest.fn(),

--- a/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
+++ b/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
@@ -1,15 +1,17 @@
 'use client';
 
-import React, { useState } from 'react';
 import { MenuItem } from '@mui/material';
-import { IconButton } from '../icon-button/IconButton';
-import Button from '../button/Button';
 import { useLocale } from 'next-intl';
-import { usePathname, useRouter } from '~/../i18n/navigation';
+import React, { useState } from 'react';
+
+import Button from '../button/Button';
 import DropdownMenu from '../dropdown-menu/DropdownMenu';
-import { SvgImage } from '~/shared/components/svg-image/SvgImage';
+import { IconButton } from '../icon-button/IconButton';
 import { styles } from './LanguageSwitcher.styles';
 import { IconButtonColorVariant, IconButtonVariant, PositionEnum } from '~/types/enums/common.enums';
+
+import { usePathname, useRouter } from '~/../i18n/navigation';
+import { SvgImage } from '~/shared/components/svg-image/SvgImage';
 
 const locales = ['uk', 'en'] as const;
 type Locale = (typeof locales)[number];

--- a/app/shared/components/design-system/all-components/logo/Logo.test.tsx
+++ b/app/shared/components/design-system/all-components/logo/Logo.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+
 import Logo from './Logo';
 
 describe('Logo test', () => {

--- a/app/shared/components/design-system/all-components/logo/Logo.tsx
+++ b/app/shared/components/design-system/all-components/logo/Logo.tsx
@@ -1,16 +1,13 @@
-import Link from 'next/link';
 import { Box, BoxProps } from '@mui/material';
 import Image from 'next/image';
+import Link from 'next/link';
 
 interface LogoProps extends BoxProps {
   variant?: 'header' | 'footer';
 }
 
 const Logo: React.FC<LogoProps> = ({ variant = 'header', sx, ...props }) => {
-  const size =
-    variant === 'header'
-      ? { width: 96, height: 40 }
-      : { width: 127, height: 53 };
+  const size = variant === 'header' ? { width: 96, height: 40 } : { width: 127, height: 53 };
 
   return (
     <Box sx={{ display: 'inline-block', ...sx }} {...props}>

--- a/app/shared/components/design-system/all-components/menu-item/MenuItem.tsx
+++ b/app/shared/components/design-system/all-components/menu-item/MenuItem.tsx
@@ -1,5 +1,7 @@
 import { MenuItem, MenuItemProps } from '@mui/material';
+
 import { menuItemStyles } from './MenuItem.styles';
+
 import { SvgImage } from '~/shared/components/svg-image/SvgImage';
 
 interface CustomMenuItemProps extends MenuItemProps {

--- a/app/shared/components/design-system/all-components/person-card/PersonCard.tsx
+++ b/app/shared/components/design-system/all-components/person-card/PersonCard.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
 import { Box, Typography } from '@mui/material';
-import { styles } from './PersonCard.styles';
 import Image from 'next/image';
+import React from 'react';
+
+import { styles } from './PersonCard.styles';
 
 interface PersonCardProps {
   imgURL: string;
@@ -9,22 +10,12 @@ interface PersonCardProps {
   description: string;
 }
 
-const PersonCard: React.FC<PersonCardProps> = ({
-  imgURL,
-  name,
-  description,
-}) => {
+const PersonCard: React.FC<PersonCardProps> = ({ imgURL, name, description }) => {
   return (
     <Box sx={styles.container}>
       <Box sx={styles.cardContent}>
         <Box sx={styles.photoWrapper}>
-          <Image
-            alt={name}
-            src={imgURL}
-            width={185}
-            height={166}
-            style={styles.image}
-          />
+          <Image alt={name} src={imgURL} width={185} height={166} style={styles.image} />
         </Box>
         <Box sx={styles.textWrapper}>
           <Typography sx={styles.name}>{name}</Typography>
@@ -32,7 +23,7 @@ const PersonCard: React.FC<PersonCardProps> = ({
         </Box>
       </Box>
       <Box sx={styles.logoWrapper}>
-        <Box component="img" src='/images/light-logo.svg' alt="Logo" sx={styles.logo} />
+        <Box component="img" src="/images/light-logo.svg" alt="Logo" sx={styles.logo} />
       </Box>
     </Box>
   );

--- a/app/shared/components/design-system/all-components/person-card/PesonalCard.test.tsx
+++ b/app/shared/components/design-system/all-components/person-card/PesonalCard.test.tsx
@@ -1,23 +1,17 @@
 import { render, screen } from '@testing-library/react';
+
 import PersonalCard from './PersonCard';
 
 const person = {
-  imgURL:
-    'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR0fsVF1anYNoKb2rvT998PTshQppsUr9Ydhg&s',
+  imgURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR0fsVF1anYNoKb2rvT998PTshQppsUr9Ydhg&s',
   name: 'Тетяна Гомон',
   description:
-    'Спадкоємиця композитора, співзасновниця і голова Фундації, піаністка-камералістка і музикознавиця, кандидатка мистецтвознавства',
+    'Спадкоємиця композитора, співзасновниця і голова Фундації, піаністка-камералістка і музикознавиця, кандидатка мистецтвознавства'
 };
 
 describe('Personal Card', () => {
   beforeEach(() => {
-    render(
-      <PersonalCard
-        imgURL={person.imgURL}
-        name={person.name}
-        description={person.description}
-      />,
-    );
+    render(<PersonalCard imgURL={person.imgURL} name={person.name} description={person.description} />);
   });
 
   test('should display photo', () => {

--- a/app/shared/components/design-system/all-components/slider/Slider.test.tsx
+++ b/app/shared/components/design-system/all-components/slider/Slider.test.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { DesignSystemSlider, CustomSliderProps } from './Slider';
+import React from 'react';
+
+import { CustomSliderProps, DesignSystemSlider } from './Slider';
 
 describe('DesignSystemSlider', () => {
   const renderComponent = (props: Partial<CustomSliderProps> = {}) =>
@@ -24,7 +25,7 @@ describe('DesignSystemSlider', () => {
     const thumb = document.querySelector('.MuiSlider-thumb');
     expect(thumb).toHaveStyle({
       width: '12px',
-      height: '12px',
+      height: '12px'
     });
   });
 
@@ -56,7 +57,7 @@ describe('DesignSystemSlider', () => {
     const thumb = document.querySelector('.MuiSlider-thumb');
     expect(thumb).toHaveStyle({
       width: '20px',
-      height: '20px',
+      height: '20px'
     });
   });
 });

--- a/app/shared/components/design-system/all-components/slider/Slider.tsx
+++ b/app/shared/components/design-system/all-components/slider/Slider.tsx
@@ -15,9 +15,7 @@ export const DesignSystemSlider: React.FC<CustomSliderProps> = ({
   ...props
 }) => {
   const marks = Array.isArray(value)
-    ? Array.from({ length: Math.floor((max - min) / 5) + 1 }, (_, i) => ({
-        value: min + i * 5
-      }))
+    ? Array.from({ length: Math.floor((max - min) / 5) + 1 }, (_, i) => ({ value: min + i * 5.0 }))
     : undefined;
 
   return (

--- a/app/shared/components/design-system/all-components/slider/Slider.tsx
+++ b/app/shared/components/design-system/all-components/slider/Slider.tsx
@@ -1,5 +1,6 @@
+import { Box, Slider, SliderProps, Typography } from '@mui/material';
 import React from 'react';
-import { Box, Typography, Slider, SliderProps } from '@mui/material';
+
 import { sliderStyles } from './Slider.styles';
 
 export interface CustomSliderProps extends Omit<SliderProps, 'size' | 'valueLabelDisplay'> {
@@ -15,8 +16,8 @@ export const DesignSystemSlider: React.FC<CustomSliderProps> = ({
 }) => {
   const marks = Array.isArray(value)
     ? Array.from({ length: Math.floor((max - min) / 5) + 1 }, (_, i) => ({
-      value: min + i * 5,
-    }))
+        value: min + i * 5
+      }))
     : undefined;
 
   return (
@@ -24,21 +25,21 @@ export const DesignSystemSlider: React.FC<CustomSliderProps> = ({
       {Array.isArray(value) && (
         <Box sx={sliderStyles.valueContainer}>
           <Typography
-            variant='body2'
+            variant="body2"
             sx={{
               ...sliderStyles.valueLabel,
               left: `${((value[0] - min) / (max - min)) * 100}%`,
-              fontSize: sliderStyles.valueLabel.fontSize(size),
+              fontSize: sliderStyles.valueLabel.fontSize(size)
             }}
           >
             {value[0]}
           </Typography>
           <Typography
-            variant='body2'
+            variant="body2"
             sx={{
               ...sliderStyles.valueLabel,
               left: `${((value[1] - min) / (max - min)) * 100}%`,
-              fontSize: sliderStyles.valueLabel.fontSize(size),
+              fontSize: sliderStyles.valueLabel.fontSize(size)
             }}
           >
             {value[1]}
@@ -56,31 +57,31 @@ export const DesignSystemSlider: React.FC<CustomSliderProps> = ({
           '& .MuiSlider-thumb': {
             ...sliderStyles.slider['& .MuiSlider-thumb'],
             width: sliderStyles.slider['& .MuiSlider-thumb'].width(size),
-            height: sliderStyles.slider['& .MuiSlider-thumb'].height(size),
+            height: sliderStyles.slider['& .MuiSlider-thumb'].height(size)
           },
           '& .MuiSlider-track': {
             ...sliderStyles.slider['& .MuiSlider-track'],
-            height: sliderStyles.slider['& .MuiSlider-track'].height(size),
+            height: sliderStyles.slider['& .MuiSlider-track'].height(size)
           },
           '& .MuiSlider-rail': {
             ...sliderStyles.slider['& .MuiSlider-rail'],
-            height: sliderStyles.slider['& .MuiSlider-rail'].height(size),
-          },
+            height: sliderStyles.slider['& .MuiSlider-rail'].height(size)
+          }
         }}
       />
       <Box sx={sliderStyles.minMaxContainer}>
         <Typography
-          variant='body2'
+          variant="body2"
           sx={{
-            fontSize: sliderStyles.minMaxLabel.fontSize(size),
+            fontSize: sliderStyles.minMaxLabel.fontSize(size)
           }}
         >
           {min}
         </Typography>
         <Typography
-          variant='body2'
+          variant="body2"
           sx={{
-            fontSize: sliderStyles.minMaxLabel.fontSize(size),
+            fontSize: sliderStyles.minMaxLabel.fontSize(size)
           }}
         >
           {max}
@@ -89,4 +90,3 @@ export const DesignSystemSlider: React.FC<CustomSliderProps> = ({
     </Box>
   );
 };
-

--- a/app/shared/components/design-system/all-components/switch/Switch.test.tsx
+++ b/app/shared/components/design-system/all-components/switch/Switch.test.tsx
@@ -1,6 +1,6 @@
+import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom';
 
 import Switch from './Switch';
 

--- a/app/shared/components/design-system/all-components/switch/Switch.tsx
+++ b/app/shared/components/design-system/all-components/switch/Switch.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { Switch, SwitchProps } from '@mui/material';
+import React from 'react';
+
 import { switchStyles } from './Switch.styles';
 
 interface CustomSwitchProps extends Omit<SwitchProps, 'onChange'> {

--- a/app/shared/components/design-system/all-components/text-field/CustomTextField.test.tsx
+++ b/app/shared/components/design-system/all-components/text-field/CustomTextField.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
 import CustomTextField from './CustomTextField';
 
 describe('CustomTextField', () => {

--- a/app/shared/components/design-system/all-components/text-field/CustomTextField.tsx
+++ b/app/shared/components/design-system/all-components/text-field/CustomTextField.tsx
@@ -1,6 +1,8 @@
+import { InputAdornment, SxProps, TextField, TextFieldProps as MuiTextFieldProps } from '@mui/material';
 import * as React from 'react';
-import { TextField, InputAdornment, SxProps, TextFieldProps as MuiTextFieldProps } from '@mui/material';
+
 import { outlinedStyles, standardStyles } from './CustomTextField.styles';
+
 import { SvgImage } from '~/shared/components/svg-image/SvgImage';
 
 type CustomBaseProps = {

--- a/app/shared/components/design-system/all-components/theme/ThemeProvider.tsx
+++ b/app/shared/components/design-system/all-components/theme/ThemeProvider.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material';
+
 import { theme } from './Theme';
 interface ThemeProviderProps {
   children: React.ReactNode;

--- a/app/shared/components/design-system/all-components/tooltip/Tooltip.test.tsx
+++ b/app/shared/components/design-system/all-components/tooltip/Tooltip.test.tsx
@@ -1,5 +1,6 @@
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+
 import TooltipCustom from './Tooltip';
 
 describe('TooltipCustom Component', () => {

--- a/app/shared/components/design-system/all-components/tooltip/Tooltip.tsx
+++ b/app/shared/components/design-system/all-components/tooltip/Tooltip.tsx
@@ -1,6 +1,7 @@
+import { Box, Tooltip, Typography } from '@mui/material';
 import React from 'react';
-import { Tooltip, Box, Typography } from '@mui/material';
-import { tooltipStyles, arrowStyles } from './Tooltip.styles';
+
+import { arrowStyles, tooltipStyles } from './Tooltip.styles';
 
 interface TooltipCustomProps {
   showArrow: boolean;
@@ -16,12 +17,10 @@ const TooltipCustom: React.FC<TooltipCustomProps> = ({ showArrow, text }) => {
         arrow={showArrow}
         componentsProps={{
           tooltip: { sx: tooltipStyles },
-          arrow: { sx: arrowStyles },
+          arrow: { sx: arrowStyles }
         }}
       >
-        <Typography>
-          {text}
-        </Typography>
+        <Typography>{text}</Typography>
       </Tooltip>
     </Box>
   );

--- a/app/shared/components/section-title/SectionTitle.test.tsx
+++ b/app/shared/components/section-title/SectionTitle.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
-import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
+
 import SectionTitle from './SectionTitle';
+
+import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
 
 jest.mock('~/shared/hooks/use-breakpoints/useBreakpoints');
 

--- a/app/shared/components/section-title/SectionTitle.tsx
+++ b/app/shared/components/section-title/SectionTitle.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { Box, Typography } from '@mui/material';
+
+import { imageSizes, styles } from './SectionTitle.styles';
+
 import { SvgImage } from '~/shared/components/svg-image/SvgImage';
 import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
-import { imageSizes, styles } from './SectionTitle.styles';
 
 interface SectionTitleProps {
   icon?: boolean;

--- a/app/shared/hooks/use-breakpoints/useBreakpoints.test.tsx
+++ b/app/shared/hooks/use-breakpoints/useBreakpoints.test.tsx
@@ -1,6 +1,7 @@
-import { renderHook } from '@testing-library/react';
-import * as mediaQuery from '@mui/material/useMediaQuery';
 import * as styles from '@mui/material/styles';
+import * as mediaQuery from '@mui/material/useMediaQuery';
+import { renderHook } from '@testing-library/react';
+
 import useBreakpoints from './useBreakpoints';
 
 jest.mock('@mui/material/useMediaQuery', () => jest.fn());

--- a/app/shared/hooks/use-breakpoints/useBreakpoints.tsx
+++ b/app/shared/hooks/use-breakpoints/useBreakpoints.tsx
@@ -1,5 +1,5 @@
-import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 const useBreakpoints = () => {
   const theme = useTheme();

--- a/app/validators/env.schema.ts
+++ b/app/validators/env.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { envErrors } from '~/constants/errors';
 
 export const envSchema = z

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,7 +40,11 @@ const eslintConfig = [
       'simple-import-sort/imports': [
         'error',
         {
-          groups: [['^(\\u0000|@?\\w)'], ['^~/(components|containers|hooks)/'], ['^(~/(utils|constants|styles|types)/|\\.)']]
+          groups: [
+            ['^(\\u0000|@?\\w)'],
+            ['^~/(components|containers|hooks|ds-components)/'],
+            ['^(~/(utils|constants|styles|types)/|\\.)']
+          ]
         }
       ],
       'simple-import-sort/exports': 'error'

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,19 +1,20 @@
+import { FlatCompat } from '@eslint/eslintrc';
+import pluginSimpleImportSort from 'eslint-plugin-simple-import-sort';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const compat = new FlatCompat({
-  baseDirectory: __dirname,
+  baseDirectory: __dirname
 });
 
 const eslintConfig = [
   ...compat.extends('next/core-web-vitals', 'next/typescript'),
 
   {
-    ignores: ['node_modules', '.next', 'coverage', '.idea', '.vscode'],
+    ignores: ['node_modules', '.next', 'coverage', '.idea', '.vscode']
   },
   {
     rules: {
@@ -26,11 +27,25 @@ const eslintConfig = [
         'error',
         {
           argsIgnorePattern: '^_',
-          varsIgnorePattern: '^_',
-        },
-      ],
-    },
+          varsIgnorePattern: '^_'
+        }
+      ]
+    }
   },
+  {
+    plugins: {
+      'simple-import-sort': pluginSimpleImportSort
+    },
+    rules: {
+      'simple-import-sort/imports': [
+        'error',
+        {
+          groups: [['^@?\\w'], ['^~/(components|containers|hooks)/'], ['^(~/(utils|constants|styles|types)/|\\.)']]
+        }
+      ],
+      'simple-import-sort/exports': 'error'
+    }
+  }
 ];
 
 export default eslintConfig;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,7 +40,7 @@ const eslintConfig = [
       'simple-import-sort/imports': [
         'error',
         {
-          groups: [['^@?\\w'], ['^~/(components|containers|hooks)/'], ['^(~/(utils|constants|styles|types)/|\\.)']]
+          groups: [['^(\\u0000|@?\\w)'], ['^~/(components|containers|hooks)/'], ['^(~/(utils|constants|styles|types)/|\\.)']]
         }
       ],
       'simple-import-sort/exports': 'error'

--- a/i18n/navigation.ts
+++ b/i18n/navigation.ts
@@ -1,10 +1,5 @@
-import {createNavigation} from 'next-intl/navigation';
-import {routing} from './routing';
+import { createNavigation } from 'next-intl/navigation';
 
-export const {
-  Link,
-  redirect,
-  usePathname,
-  useRouter,
-  getPathname
-} = createNavigation(routing);
+import { routing } from './routing';
+
+export const { Link, redirect, usePathname, useRouter, getPathname } = createNavigation(routing);

--- a/i18n/next-intl.d.ts
+++ b/i18n/next-intl.d.ts
@@ -1,21 +1,16 @@
 import { type useTranslations } from 'next-intl';
 
-import { type routing } from './routing';
 import { type default as enMessages } from './messages/en.json';
 import { type default as ukMessages } from './messages/uk.json';
+import { type routing } from './routing';
 
-type IsEqual<A, B> =
-    (<T>() => T extends A ? true : false) extends <T>() =>
-            T extends B ? true : false
-        ? true : false;
+type IsEqual<A, B> = (<T>() => T extends A ? true : false) extends <T>() => T extends B ? true : false ? true : false;
 
 declare module 'next-intl' {
-    interface AppConfig {
-        Locale: (typeof routing.locales)[number];
-        Messages: IsEqual<typeof enMessages, typeof ukMessages> extends true
-            ? typeof ukMessages
-            : never;
-    }
+  interface AppConfig {
+    Locale: (typeof routing.locales)[number];
+    Messages: IsEqual<typeof enMessages, typeof ukMessages> extends true ? typeof ukMessages : never;
+  }
 
-    type TranslationKey = Parameters<ReturnType<typeof useTranslations>>[0];
+  type TranslationKey = Parameters<ReturnType<typeof useTranslations>>[0];
 }

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -1,13 +1,12 @@
-import {getRequestConfig} from 'next-intl/server';
-import {hasLocale} from 'next-intl';
-import {routing} from './routing';
-import {notFound} from 'next/navigation';
+import { notFound } from 'next/navigation';
+import { hasLocale } from 'next-intl';
+import { getRequestConfig } from 'next-intl/server';
 
-export default getRequestConfig(async ({requestLocale}) => {
+import { routing } from './routing';
+
+export default getRequestConfig(async ({ requestLocale }) => {
   const requested = await requestLocale;
-  const locale = hasLocale(routing.locales, requested)
-    ? requested
-    : routing.defaultLocale;
+  const locale = hasLocale(routing.locales, requested) ? requested : routing.defaultLocale;
 
   return {
     locale,

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,5 @@
 import createMiddleware from 'next-intl/middleware';
+
 import { routing } from '~/i18n/routing';
 
 export default createMiddleware(routing);

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "commitlint": "^19.8.1",
         "eslint": "^9.26.0",
         "eslint-config-next": "15.3.1",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "husky": "^9.1.6",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -7418,6 +7419,15 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "commitlint": "^19.8.1",
     "eslint": "^9.26.0",
     "eslint-config-next": "15.3.1",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "husky": "^9.1.6",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint --fix --max-warnings=0",
-      "prettier --write"
+      "prettier --write",
+      "eslint --fix --max-warnings=0"
     ]
   }
 }


### PR DESCRIPTION

## Summary of change

Added `eslint-plugin-simple-import-sort` plugin with rules to enforce a consistent and readable import order across the project.

**Imports groups sorted by:**

- libs (e.g. `react`, `next`, etc.)
- component, containers, hooks (e.g. `~/components/...` `~/ds-components/...`, etc.)
- utils,const,styles,types (e.g. `~/types/...`, `~/constants`, etc.)


