### PR TITLE
(SP: 0,5) Bug with local in NotFound page

### DIFF
--- a/app/[lang]/not-found.test.tsx
+++ b/app/[lang]/not-found.test.tsx
@@ -1,11 +1,16 @@
 import { screen, render } from '@testing-library/react';
 import NotFoundPage from './not-found';
+import React from 'react';
+
+jest.mock('~/i18n/navigation', () => ({
+  Link: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>
+}));
 
 jest.mock('next-intl/server', () => ({
   getTranslations: jest.fn().mockResolvedValue((key: string) => {
     const translations: Record<string, string> = {
-      'languageNotFound': '404 Language',
-      'goHome': 'go home',
+      languageNotFound: '404 Language',
+      goHome: 'go home'
     };
     return translations[key];
   })

--- a/app/[lang]/not-found.tsx
+++ b/app/[lang]/not-found.tsx
@@ -1,19 +1,23 @@
-import Link from 'next/link';
+import { Link } from '~/i18n/navigation';
 import { getTranslations } from 'next-intl/server';
 
 export default async function CustomNotFoundPage() {
   const t = await getTranslations('common');
 
-  return<>
-    <section style={{ marginBottom: '20px' }}>
-      {t('languageNotFound')}
-    </section>
-    <Link href='/' passHref style={{
-      color: 'yellow',
-      fontWeight: 'bold',
-      textDecoration: 'underline',
-    }}>
-      {t('goHome')}
-    </Link>
-  </>;
+  return (
+    <>
+      <section style={{ marginBottom: '20px' }}>{t('languageNotFound')}</section>
+      <Link
+        href="/"
+        passHref
+        style={{
+          color: 'yellow',
+          fontWeight: 'bold',
+          textDecoration: 'underline'
+        }}
+      >
+        {t('goHome')}
+      </Link>
+    </>
+  );
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -27,12 +27,12 @@ const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
-    '^~/(.*)$': '<rootDir>/app/$1',
+    '^~/i18n/(.*)$': '<rootDir>/i18n/$1',
     '^~/utils/(.*)$': '<rootDir>/app/lib/utils/$1',
     '^~/ds-components/(.*)$': '<rootDir>/app/shared/components/design-system/all-components/$1',
     '^~/components/(.*)$': '<rootDir>/app/shared/components/$1',
     '^~/hooks/(.*)$': '<rootDir>/app/shared/hooks/$1',
-    '^~/i18n/(.*)$': '<rootDir>/i18n/$1'
+    '^~/(.*)$': '<rootDir>/app/$1'
   },
   modulePaths: ['<rootDir>/app'],
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/dist/'],


### PR DESCRIPTION
## Summary of change
Now after press 'return home' in not found page the local stay same

- Change 
`import Link from "next/link";`    ->    ` import { Link } from "~/i18n/navigation"`

- Added `"~/i18n/navigation"` mock to test
- Change in `jest.config.ts` to fix problem with '~' import in test for i18n folder

https://github.com/user-attachments/assets/fb94dbcb-e480-47c0-95cf-40fe56f22379


