### PR TITLE
 (SP:1) Create Switch element aligned with design system

### DIFF
--- a/app/shared/components/design-system/all-components/switch/Switch.styles.ts
+++ b/app/shared/components/design-system/all-components/switch/Switch.styles.ts
@@ -1,0 +1,29 @@
+export const switchStyles = {
+  '& .MuiSwitch-switchBase': {
+    color: '#fcfcfc',
+    '&.Mui-checked': {
+      color: '#FCBD28',
+      '& + .MuiSwitch-track': {
+        backgroundColor: '#FCBD28'
+      },
+      '&:hover': {
+        backgroundColor: '#fcbd280a'
+      },
+      '&.Mui-focusVisible': {
+        backgroundColor: '#fcbd284d'
+      }
+    },
+
+    '&:hover': {
+      backgroundColor: '#190d030a'
+    },
+    '&.Mui-focusVisible': {
+      backgroundColor: '#190d0314'
+    },
+    '&.Mui-disabled': {
+      '& + .MuiSwitch-track': {
+        backgroundColor: '#190d031f'
+      }
+    }
+  }
+};

--- a/app/shared/components/design-system/all-components/switch/Switch.test.tsx
+++ b/app/shared/components/design-system/all-components/switch/Switch.test.tsx
@@ -20,7 +20,7 @@ describe('CustomSwitch', () => {
     const switchRoot = container.querySelector('.MuiSwitch-root');
     expect(switchRoot).toBeInTheDocument();
 
-    await user.click(switchRoot!);
+    await user.click(switchRoot as Element);
 
     expect(handleChange).not.toHaveBeenCalled();
   });

--- a/app/shared/components/design-system/all-components/switch/Switch.test.tsx
+++ b/app/shared/components/design-system/all-components/switch/Switch.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import Switch from './Switch';
+
+const handleChange = jest.fn();
+describe('CustomSwitch', () => {
+  it('should render with checked state when checked prop is true', () => {
+    render(<Switch checked={true} onChange={handleChange} />);
+    const input = screen.getByRole('checkbox');
+    expect(input).toBeChecked();
+  });
+
+  it('should not call onChange when disabled', async () => {
+    const user = userEvent.setup();
+
+    const { container } = render(<Switch checked={false} onChange={handleChange} disabled />);
+
+    const switchRoot = container.querySelector('.MuiSwitch-root');
+    expect(switchRoot).toBeInTheDocument();
+
+    await user.click(switchRoot!);
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('should applie the small size variant', () => {
+    const { container } = render(<Switch checked={false} onChange={handleChange} size="small" />);
+
+    const switchRoot = container.querySelector('.MuiSwitch-root');
+    expect(switchRoot?.className).toMatch(/MuiSwitch-sizeSmall/);
+  });
+});

--- a/app/shared/components/design-system/all-components/switch/Switch.tsx
+++ b/app/shared/components/design-system/all-components/switch/Switch.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Switch, SwitchProps } from '@mui/material';
+import { switchStyles } from './Switch.styles';
+
+interface CustomSwitchProps extends Omit<SwitchProps, 'onChange'> {
+  checked: boolean;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
+  size?: 'small' | 'medium';
+}
+
+const CustomSwitch: React.FC<CustomSwitchProps> = ({
+  checked,
+  onChange,
+  disabled = false,
+  size = 'medium',
+  ...props
+}) => {
+  return <Switch sx={switchStyles} checked={checked} onChange={onChange} disabled={disabled} size={size} {...props} />;
+};
+
+export default CustomSwitch;


### PR DESCRIPTION


## Summary of change

- add custom switch component
- all styles match the layout from figma

## Testing approach
![image](https://github.com/user-attachments/assets/fd498166-c799-4a41-b262-cd29333594a1)

## Result

https://github.com/user-attachments/assets/2d4b8ccc-4de1-427e-946a-212c18d31abd


