### PR TITLE
Implemented ImageWithCaption component

### DIFF
--- a/app/lib/utils/generateSizesAttribute.test.ts
+++ b/app/lib/utils/generateSizesAttribute.test.ts
@@ -18,4 +18,13 @@ describe('generateSizesAttribute', () => {
       '(max-width: 376px) 400px, (max-width: 768px) 600px, (max-width: 1024px) 800px, (max-width: 1448px) 1000px, 816px'
     );
   });
+
+  it('should return "100vw" if no valid breakpoints are provided', () => {
+    const input = {
+      width: {}
+    };
+
+    const result = generateSizesAttribute(input);
+    expect(result).toBe('100vw');
+  });
 });

--- a/app/lib/utils/generateSizesAttribute.test.ts
+++ b/app/lib/utils/generateSizesAttribute.test.ts
@@ -15,7 +15,7 @@ describe('generateSizesAttribute', () => {
     const result = generateSizesAttribute(input);
 
     expect(result).toBe(
-      '(max-width: 376px) 400px, (max-width: 768px) 600px, (max-width: 1024px) 800px, (max-width: 1448px) 1000px, 816px'
+      '(max-width: 0px) 400px, (max-width: 768px) 600px, (max-width: 1024px) 800px, (max-width: 1448px) 1000px, 816px'
     );
   });
 

--- a/app/lib/utils/generateSizesAttribute.test.ts
+++ b/app/lib/utils/generateSizesAttribute.test.ts
@@ -1,0 +1,21 @@
+import { generateSizesAttribute } from './generateSizesAttribute';
+
+describe('generateSizesAttribute', () => {
+  it('should return a correct sizes string based on breakpoints', () => {
+    const input = {
+      width: {
+        xs: 400,
+        sm: 600,
+        md: 800,
+        xl: 1000,
+        xxl: 816
+      }
+    };
+
+    const result = generateSizesAttribute(input);
+
+    expect(result).toBe(
+      '(max-width: 376px) 400px, (max-width: 768px) 600px, (max-width: 1024px) 800px, (max-width: 1448px) 1000px, 816px'
+    );
+  });
+});

--- a/app/lib/utils/generateSizesAttribute.ts
+++ b/app/lib/utils/generateSizesAttribute.ts
@@ -7,7 +7,7 @@ type BreakpointKey = keyof typeof theme.breakpoints.values;
 export function generateSizesAttribute(sizes: Pick<ElementSizes, 'width'>): string {
   const breakpoints = theme.breakpoints.values;
 
-  const entries = Object.entries(sizes.width || {})
+  const entries = Object.entries(sizes.width)
     .filter(([bp]) => bp in breakpoints)
     .sort((a, b) => breakpoints[a[0] as BreakpointKey] - breakpoints[b[0] as BreakpointKey])
     .map(([bp, val], index, arr) => {

--- a/app/lib/utils/generateSizesAttribute.ts
+++ b/app/lib/utils/generateSizesAttribute.ts
@@ -2,17 +2,19 @@ import { theme } from '~/ds-components/theme/Theme';
 
 import { ElementSizes } from '~/types/types/common.types';
 
+type BreakpointKey = keyof typeof theme.breakpoints.values;
+
 export function generateSizesAttribute(sizes: Pick<ElementSizes, 'width'>): string {
   const breakpoints = theme.breakpoints.values;
 
-  const entries = Object.entries(sizes.width)
+  const entries = Object.entries(sizes.width || {})
     .filter(([bp]) => bp in breakpoints)
-    .sort((a, b) => breakpoints[a[0] as keyof typeof breakpoints] - breakpoints[b[0] as keyof typeof breakpoints])
+    .sort((a, b) => breakpoints[a[0] as BreakpointKey] - breakpoints[b[0] as BreakpointKey])
     .map(([bp, val], index, arr) => {
-      const max = breakpoints[bp as keyof typeof breakpoints];
+      const max = breakpoints[bp as BreakpointKey];
       const isLast = index === arr.length - 1;
       return isLast ? `${val}px` : `(max-width: ${max}px) ${val}px`;
     });
 
-  return entries.join(', ');
+  return entries.length > 0 ? entries.join(', ') : '100vw';
 }

--- a/app/lib/utils/generateSizesAttribute.ts
+++ b/app/lib/utils/generateSizesAttribute.ts
@@ -1,0 +1,17 @@
+import { theme } from '~/ds-components/theme/Theme';
+import { ElementSizes } from '~/types/types/common.types';
+
+export function generateSizesAttribute(sizes: Pick<ElementSizes, 'width'>): string {
+  const breakpoints = theme.breakpoints.values;
+
+  const entries = Object.entries(sizes.width)
+    .filter(([bp]) => bp in breakpoints)
+    .sort((a, b) => breakpoints[a[0] as keyof typeof breakpoints] - breakpoints[b[0] as keyof typeof breakpoints])
+    .map(([bp, val], index, arr) => {
+      const max = breakpoints[bp as keyof typeof breakpoints];
+      const isLast = index === arr.length - 1;
+      return isLast ? `${val}px` : `(max-width: ${max}px) ${val}px`;
+    });
+
+  return entries.join(', ');
+}

--- a/app/lib/utils/generateSizesAttribute.ts
+++ b/app/lib/utils/generateSizesAttribute.ts
@@ -1,4 +1,5 @@
 import { theme } from '~/ds-components/theme/Theme';
+
 import { ElementSizes } from '~/types/types/common.types';
 
 export function generateSizesAttribute(sizes: Pick<ElementSizes, 'width'>): string {

--- a/app/shared/components/image-with-caption/ImageWithCaption.styles.ts
+++ b/app/shared/components/image-with-caption/ImageWithCaption.styles.ts
@@ -1,5 +1,5 @@
-import { ElementSizes } from '~/types/types/common.types';
 import { BorderProps } from './ImageWithCaption';
+import { ElementSizes } from '~/types/types/common.types';
 
 export const styles = {
   container: {

--- a/app/shared/components/image-with-caption/ImageWithCaption.styles.ts
+++ b/app/shared/components/image-with-caption/ImageWithCaption.styles.ts
@@ -1,0 +1,53 @@
+import { ElementSizes } from '~/types/types/common.types';
+import { BorderProps } from './ImageWithCaption';
+
+export const styles = {
+  container: {
+    display: 'grid',
+    gridTemplateColumns: 'subgrid',
+    position: 'relative',
+    gridColumn: { xs: '2 / -1', sm: '4 / -1', md: '6 / -1' },
+    alignSelf: 'start'
+  },
+  border: (border: BorderProps) => ({
+    display: 'block',
+    position: 'absolute',
+    width: { ...border.sizes.width },
+    height: { ...border.sizes.height },
+    top: 0,
+    left: 0,
+    transform: {
+      xs: `translate(-${border.left.xs}px, -${border.top.xs}px)`,
+      sm: `translate(-${border.left.sm}px, -${border.top.sm}px)`,
+      md: `translate(-${border.left.md}px, -${border.top.md}px)`,
+      lg: `translate(-${border.left.lg}px, -${border.top.lg}px)`,
+      xl: `translate(-${border.left.xl}px, -${border.top.xl}px)`,
+      xxl: `translate(-${border.left.xxl}px, -${border.top.xxl}px)`,
+      ultra: `translate(-${border.left.ultra}px, -${border.top.ultra}px)`
+    },
+    backgroundColor: '#FFE099',
+    zIndex: 0
+  }),
+  imageContainer: (sizes: ElementSizes) => ({
+    position: 'relative',
+    width: { ...sizes.width },
+    height: { ...sizes.height },
+    gridColumn: '1 / -1'
+  }),
+  image: {
+    objectFit: 'cover'
+  },
+  caption: (sizes: ElementSizes) => ({
+    fontFamily: 'Mulish',
+    fontWeight: 400,
+    fontSize: { xs: '12px', sm: '14px', md: '16px' },
+    lineHeight: { xs: '130%', sm: '140%' },
+    fontStyle: 'italic',
+    letterSpacing: '0%',
+    textAlign: 'right',
+    color: '#63666E',
+    mt: { xs: '8px', md: '16px' },
+    maxWidth: { ...sizes.width },
+    gridColumn: '1 / -1'
+  })
+};

--- a/app/shared/components/image-with-caption/ImageWithCaption.test.tsx
+++ b/app/shared/components/image-with-caption/ImageWithCaption.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import ImageWithCaption from '~/components/image-with-caption/ImageWithCaption';
+import { ElementSizes } from '~/types/types/common.types';
+
+const sizes: ElementSizes = {
+  width: { xs: 300, sm: 600, md: 900 },
+  height: { xs: 200, sm: 400, md: 600 }
+};
+
+describe('ImageWithCaption', () => {
+  it('should render image with caption', () => {
+    render(<ImageWithCaption src="/test.jpg" alt="Test image" sizes={sizes} caption="Test Caption" />);
+
+    expect(screen.getByAltText('Test image')).toBeInTheDocument();
+    expect(screen.getByText('Test Caption')).toBeInTheDocument();
+  });
+
+  it('should apply sizes attribute correctly', () => {
+    render(<ImageWithCaption src="/test.jpg" alt="Test image" sizes={sizes} caption="Test Caption" />);
+
+    const img = screen.getByAltText('Test image');
+    expect(img).toHaveAttribute('sizes');
+    expect(img.getAttribute('sizes')).toContain('300px');
+  });
+
+  it('should render image with border', () => {
+    const border = {
+      sizes,
+      top: { xs: 20 },
+      left: { xs: 30 }
+    };
+
+    render(<ImageWithCaption src="/test.jpg" alt="Test image" sizes={sizes} caption="Test Caption" border={border} />);
+
+    const borderBox = screen.getByTestId('img-border');
+    expect(borderBox).toBeInTheDocument();
+  });
+});

--- a/app/shared/components/image-with-caption/ImageWithCaption.test.tsx
+++ b/app/shared/components/image-with-caption/ImageWithCaption.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
+
 import ImageWithCaption from '~/components/image-with-caption/ImageWithCaption';
+
 import { ElementSizes } from '~/types/types/common.types';
 
 const sizes: ElementSizes = {

--- a/app/shared/components/image-with-caption/ImageWithCaption.tsx
+++ b/app/shared/components/image-with-caption/ImageWithCaption.tsx
@@ -1,0 +1,45 @@
+import { Box, BoxProps, Breakpoint, Typography, TypographyProps } from '@mui/material';
+import Image from 'next/image';
+import { styles } from './ImageWithCaption.styles';
+import { generateSizesAttribute } from '~/lib/utils/generateSizesAttribute';
+import { ElementSizes } from '~/types/types/common.types';
+
+export interface BorderProps {
+  sizes: ElementSizes;
+  top: Partial<Record<Breakpoint, number>>;
+  left: Partial<Record<Breakpoint, number>>;
+}
+
+interface ImageWithCaptionProps {
+  src: string;
+  alt: string;
+  caption: string;
+  sizes: ElementSizes;
+  border?: BorderProps;
+  containerSx?: BoxProps['sx'];
+  captionSx?: TypographyProps['sx'];
+}
+
+const ImageWithCaption: React.FC<ImageWithCaptionProps> = ({
+  src,
+  alt,
+  sizes,
+  caption,
+  border,
+  containerSx = {},
+  captionSx = {}
+}) => {
+  const sizesAttibute = generateSizesAttribute(sizes);
+
+  return (
+    <Box sx={{ ...containerSx, ...styles.container } as BoxProps['sx']}>
+      {border && <Box sx={styles.border(border)} data-testid="img-border" />}
+      <Box sx={styles.imageContainer(sizes)}>
+        <Image style={styles.image as React.CSSProperties} src={src} fill alt={alt} sizes={sizesAttibute} />
+      </Box>
+      <Typography sx={{ ...captionSx, ...styles.caption(sizes) } as TypographyProps['sx']}>{caption}</Typography>
+    </Box>
+  );
+};
+
+export default ImageWithCaption;

--- a/app/shared/components/image-with-caption/ImageWithCaption.tsx
+++ b/app/shared/components/image-with-caption/ImageWithCaption.tsx
@@ -1,8 +1,10 @@
 import { Box, BoxProps, Breakpoint, Typography, TypographyProps } from '@mui/material';
 import Image from 'next/image';
+
 import { styles } from './ImageWithCaption.styles';
-import { generateSizesAttribute } from '~/lib/utils/generateSizesAttribute';
 import { ElementSizes } from '~/types/types/common.types';
+
+import { generateSizesAttribute } from '~/lib/utils/generateSizesAttribute';
 
 export interface BorderProps {
   sizes: ElementSizes;

--- a/app/shared/components/image-with-caption/ImageWithCaption.tsx
+++ b/app/shared/components/image-with-caption/ImageWithCaption.tsx
@@ -31,13 +31,13 @@ const ImageWithCaption: React.FC<ImageWithCaptionProps> = ({
   containerSx = {},
   captionSx = {}
 }) => {
-  const sizesAttibute = generateSizesAttribute(sizes);
+  const sizesAttribute = generateSizesAttribute(sizes);
 
   return (
     <Box sx={{ ...containerSx, ...styles.container } as BoxProps['sx']}>
       {border && <Box sx={styles.border(border)} data-testid="img-border" />}
       <Box sx={styles.imageContainer(sizes)}>
-        <Image style={styles.image as React.CSSProperties} src={src} fill alt={alt} sizes={sizesAttibute} />
+        <Image style={styles.image as React.CSSProperties} src={src} fill alt={alt} sizes={sizesAttribute} />
       </Box>
       <Typography sx={{ ...captionSx, ...styles.caption(sizes) } as TypographyProps['sx']}>{caption}</Typography>
     </Box>

--- a/app/types/types/common.types.ts
+++ b/app/types/types/common.types.ts
@@ -1,0 +1,6 @@
+import { Breakpoint } from '@mui/material';
+
+export interface ElementSizes {
+  width: Partial<Record<Breakpoint, number>>;
+  height: Partial<Record<Breakpoint, number>>;
+}


### PR DESCRIPTION
Implemented ImageWithCaption component. This is reusable component for images with caption. You can specify sizes for different breakpoints for both image and border.

**Component takes these props:**

- src: string - src of image
- alt: string - alt for image
- caption: string - caption text
- sizes: object - responsive values for width and height
- border: object - placement of border and it's sizes
- containerSx?: sx - sx styles for container
- captionSx?: sx - sx styles for caption

**Completed tasks:**

- [x] Implemented ImageWithCaption component
- [x] Covered component with unit tests
- [x] Ensured it is responsive according to figma mockups

**Demonstration of how it looks:**

https://github.com/user-attachments/assets/9cd486db-d6d1-46bb-a200-0a679648b291

**Used code:**
![image](https://github.com/user-attachments/assets/a3b5b093-b8a1-46c4-9b26-08ba80c76b4a)

**Results of tests:**
![image](https://github.com/user-attachments/assets/bebb9a71-90f6-41a5-935b-74fdc4d4ced5)
![image](https://github.com/user-attachments/assets/c5cbeb74-faff-4648-a8f2-869a5a0857f2)
