### PR TITLE
Implement modal component

### DIFF
--- a/app/shared/components/design-system/all-components/icon-button/IconButton.styles.ts
+++ b/app/shared/components/design-system/all-components/icon-button/IconButton.styles.ts
@@ -16,7 +16,6 @@ const Colors = {
 };
 
 const PrimaryIconStyles = {
-  fontSize: '0',
   color: Colors.black,
   backgroundColor: Colors.white,
   '&:hover': {
@@ -31,7 +30,6 @@ const PrimaryIconStyles = {
 };
 
 const SecondaryIconStyles = {
-  fontSize: '0',
   color: Colors.white,
   backgroundColor: Colors.black,
   '&:hover': {
@@ -61,9 +59,11 @@ export const IconButtonStyles = {
     }
   },
   primaryIcon: {
+    fontSize: '0',
     PrimaryIconStyles
   },
   primaryOutlined: {
+    fontSize: '0',
     PrimaryIconStyles,
     border: '1px black solid'
   },
@@ -80,9 +80,11 @@ export const IconButtonStyles = {
     }
   },
   secondaryIcon: {
+    fontSize: '0',
     SecondaryIconStyles
   },
   secondaryOutlined: {
+    fontSize: '0',
     SecondaryIconStyles,
     border: '1px white solid'
   },

--- a/app/shared/components/design-system/all-components/modal/Modal.styles.ts
+++ b/app/shared/components/design-system/all-components/modal/Modal.styles.ts
@@ -21,13 +21,13 @@ const horizontalPositionStyles = (horizontalAlignment: HorizontalAlignment) =>
 export const style = {
   modal: (
     width: number,
-    height: number,
+    height: number | undefined,
     backgroundColor: Color,
     verticalAlignment: VerticalAlignment,
     horizontalAlignment: HorizontalAlignment
   ) => ({
     width: width,
-    height: height,
+    height: height ? height : 'fit-content',
     backgroundColor: backgroundColor === 'white' ? backgroundColor : mainHexPallete.burgundy[900],
     margin: '50px',
     borderRadius: '32px',

--- a/app/shared/components/design-system/all-components/modal/Modal.styles.ts
+++ b/app/shared/components/design-system/all-components/modal/Modal.styles.ts
@@ -4,19 +4,25 @@ import { PositionEnum } from '~/types/enums/common.enums';
 
 const titleColor = (backgroundColor: Color) => (backgroundColor === 'white' ? 'black' : 'white');
 
-const verticalPositionStyles = (verticalAlignment: VerticalAlignment) =>
-  verticalAlignment === PositionEnum.Top
-    ? { top: 0, marginTop: '20px' }
-    : verticalAlignment === PositionEnum.Bottom
-      ? { top: 'revert-layer', marginBottom: '20px' }
-      : { top: '35%', my: '0' };
+const verticalPositionStyles = (verticalAlignment: VerticalAlignment) => {
+  if (verticalAlignment === PositionEnum.Top) {
+    return { top: 0, marginTop: '20px' };
+  } else if (verticalAlignment === PositionEnum.Bottom) {
+    return { top: 'revert-layer', marginBottom: '20px' };
+  } else {
+    return { top: '35%', my: '0' };
+  }
+};
 
-const horizontalPositionStyles = (horizontalAlignment: HorizontalAlignment) =>
-  horizontalAlignment === PositionEnum.Left
-    ? { left: 0 }
-    : horizontalAlignment === PositionEnum.Right
-      ? { right: 0 }
-      : { left: '50%', marginLeft: '0', transform: 'translateX(-50%)' };
+const horizontalPositionStyles = (horizontalAlignment: HorizontalAlignment) => {
+  if (horizontalAlignment === PositionEnum.Left) {
+    return { left: 0 };
+  } else if (horizontalAlignment === PositionEnum.Right) {
+    return { right: 0 };
+  } else {
+    return { left: '50%', marginLeft: '0', transform: 'translateX(-50%)' };
+  }
+};
 
 export const style = {
   modal: (
@@ -27,7 +33,7 @@ export const style = {
     horizontalAlignment: HorizontalAlignment
   ) => ({
     width: width,
-    height: height ? height : 'fit-content',
+    height: height ?? 'fit-content',
     backgroundColor: backgroundColor === 'white' ? backgroundColor : mainHexPallete.burgundy[900],
     margin: '50px',
     borderRadius: '32px',

--- a/app/shared/components/design-system/all-components/modal/Modal.styles.ts
+++ b/app/shared/components/design-system/all-components/modal/Modal.styles.ts
@@ -4,6 +4,20 @@ import { PositionEnum } from '~/types/enums/common.enums';
 
 const titleColor = (backgroundColor: Color) => (backgroundColor === 'white' ? 'black' : 'white');
 
+const verticalPositionStyles = (verticalAlignment: VerticalAlignment) =>
+  verticalAlignment === PositionEnum.Top
+    ? { top: 0, marginTop: '20px' }
+    : verticalAlignment === PositionEnum.Bottom
+      ? { top: 'revert-layer', marginBottom: '20px' }
+      : { top: '35%', my: '0' };
+
+const horizontalPositionStyles = (horizontalAlignment: HorizontalAlignment) =>
+  horizontalAlignment === PositionEnum.Left
+    ? { left: 0 }
+    : horizontalAlignment === PositionEnum.Right
+      ? { right: 0 }
+      : { left: '50%', marginLeft: '0', transform: 'translateX(-50%)' };
+
 export const style = {
   modal: (
     width: number,
@@ -21,16 +35,8 @@ export const style = {
     boxShadow: 'rgba(0, 0, 0, 0.24) 0px 3px 8px',
     '&:focus': { outline: 'none' },
     padding: width > 1000 ? '40px 110px' : '24px 32px',
-    ...(verticalAlignment === PositionEnum.Top
-      ? { top: 0, marginTop: '20px' }
-      : verticalAlignment === PositionEnum.Bottom
-        ? { top: 'revert-layer', marginBottom: '20px' }
-        : { top: '35%', my: '0' }),
-    ...(horizontalAlignment === PositionEnum.Left
-      ? { left: 0 }
-      : horizontalAlignment === PositionEnum.Right
-        ? { right: 0 }
-        : { left: '50%', marginLeft: '0', transform: 'translateX(-50%)' })
+    ...verticalPositionStyles(verticalAlignment),
+    ...horizontalPositionStyles(horizontalAlignment)
   }),
   content: {
     outline: 'none',

--- a/app/shared/components/design-system/all-components/modal/Modal.styles.ts
+++ b/app/shared/components/design-system/all-components/modal/Modal.styles.ts
@@ -1,0 +1,67 @@
+import { mainHexPallete } from '../theme/colors';
+import { Color, HorizontalAlignment, VerticalAlignment } from './Modal';
+import { PositionEnum } from '~/types/enums/common.enums';
+
+const titleColor = (backgroundColor: Color) => (backgroundColor === 'white' ? 'black' : 'white');
+
+export const style = {
+  modal: (
+    width: number,
+    height: number,
+    backgroundColor: Color,
+    verticalAlignment: VerticalAlignment,
+    horizontalAlignment: HorizontalAlignment
+  ) => ({
+    width: width,
+    height: height,
+    backgroundColor: backgroundColor === 'white' ? backgroundColor : mainHexPallete.burgundy[900],
+    margin: '50px',
+    borderRadius: '32px',
+    outline: 'none',
+    boxShadow: 'rgba(0, 0, 0, 0.24) 0px 3px 8px',
+    '&:focus': { outline: 'none' },
+    padding: width > 1000 ? '40px 110px' : '24px 32px',
+    ...(verticalAlignment === PositionEnum.Top
+      ? { top: 0, marginTop: '20px' }
+      : verticalAlignment === PositionEnum.Bottom
+        ? { top: 'revert-layer', marginBottom: '20px' }
+        : { top: '35%', my: '0' }),
+    ...(horizontalAlignment === PositionEnum.Left
+      ? { left: 0 }
+      : horizontalAlignment === PositionEnum.Right
+        ? { right: 0 }
+        : { left: '50%', marginLeft: '0', transform: 'translateX(-50%)' })
+  }),
+  content: {
+    outline: 'none',
+    border: 'none',
+    padding: '0',
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%'
+  },
+  topSection: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    border: 'none',
+    padding: '0 20px',
+    marginBottom: '60px'
+  },
+  title: (backgroundColor: Color) => ({
+    color: titleColor(backgroundColor)
+  }),
+  topLine: (width: number) => ({
+    width: width,
+    marginLeft: width > 1000 ? '-110px' : '-32px',
+    marginBottom: '20px',
+    height: '2px',
+    backgroundColor: '#FFBC21',
+    transform: 'rotate(-2deg)',
+    transformOrigin: 'left center'
+  }),
+  children: {
+    justifyContent: 'center',
+    padding: '0 20px'
+  }
+};

--- a/app/shared/components/design-system/all-components/modal/Modal.test.tsx
+++ b/app/shared/components/design-system/all-components/modal/Modal.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Modal } from './Modal';
+import { PositionEnum } from '~/types/enums/common.enums';
+
+describe('Modal', () => {
+  it('should render Modal', () => {
+    const expectedTitle = 'testModal';
+    render(<Modal open={true} handleClose={() => {}} title="testModal" />);
+    const titleElement = document.getElementById('modal-modal-title');
+    expect(titleElement).toBeInTheDocument();
+    expect(screen.getByText(expectedTitle)).toBeInTheDocument();
+  });
+
+  it('should not render', () => {
+    render(<Modal open={false} handleClose={() => {}} title="testModal" />);
+    const titleElement = document.getElementById('modal-modal-title');
+    expect(titleElement).not.toBeInTheDocument();
+  });
+
+  it('should render without subTitle', () => {
+    render(<Modal open={true} handleClose={() => {}} title="testModal" />);
+
+    expect(screen.queryByText(/subtitle/i)).not.toBeInTheDocument();
+  });
+
+  it('should render subTitle', () => {
+    const expectedSubtitle = 'testSubtitle';
+    render(<Modal open={true} handleClose={() => {}} title="testModal" subtitle="testSubtitle" />);
+
+    expect(screen.getByText(expectedSubtitle)).toBeInTheDocument();
+  });
+
+  it('should render children', () => {
+    render(
+      <Modal open={true} handleClose={() => {}} title="testModal">
+        TestText
+      </Modal>
+    );
+    expect(screen.getByText('TestText')).toBeInTheDocument();
+  });
+
+  it('should close by clicking on button', async () => {
+    const handleClose = jest.fn();
+    render(<Modal open={true} handleClose={handleClose} title="testModal" />);
+    const btn = screen.getByRole('button');
+    await userEvent.click(btn);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render title correctly', () => {
+    render(<Modal open={true} handleClose={() => {}} title="testModal" />);
+    const title = screen.getByRole('heading', { name: /testModal/i });
+    expect(title.tagName).toBe('H3');
+  });
+
+  it('should render title correctly', () => {
+    render(<Modal open={true} handleClose={() => {}} title="testModal" width={500} />);
+    const title = screen.getByRole('heading', { name: /testModal/i });
+    expect(title.tagName).toBe('H4');
+  });
+
+  it('should correct filter based on backgroundColor for burgundy', () => {
+    render(<Modal open={true} handleClose={() => {}} title="testModal" backgroundColor="burgundy" />);
+
+    const iconWrapper = screen.getByAltText(/closing modal/i).parentElement;
+    expect(iconWrapper).toHaveStyle('filter: brightness(0) invert(1)');
+  });
+
+  it('should correct filter based on backgroundColor for white', () => {
+    render(<Modal open={true} handleClose={() => {}} title="testModal" backgroundColor="white" />);
+
+    const iconWrapper = screen.getByAltText(/closing modal/i).parentElement;
+    expect(iconWrapper).toHaveStyle('filter: brightness(0) saturate(100%)');
+  });
+
+  it('should return correct verticalPositions for top and left', () => {
+    const expectedStyles = {
+      top: '0px',
+      marginTop: '20px',
+      left: '0px'
+    };
+    render(
+      <Modal
+        open={true}
+        handleClose={() => {}}
+        title="testModal"
+        verticalAlignment={PositionEnum.Top}
+        horizontalAlignment={PositionEnum.Left}
+      />
+    );
+    const box = screen.getByTestId('modal');
+
+    expect(box).toHaveStyle(expectedStyles);
+  });
+
+  it('should return correct verticalPositions for bottom and right', () => {
+    const expectedStyles = {
+      top: 'revert-layer',
+      marginBottom: '20px',
+      right: '0px'
+    };
+    render(
+      <Modal
+        open={true}
+        handleClose={() => {}}
+        title="testModal"
+        verticalAlignment={PositionEnum.Bottom}
+        horizontalAlignment={PositionEnum.Right}
+      />
+    );
+    const box = screen.getByTestId('modal');
+
+    expect(box).toHaveStyle(expectedStyles);
+  });
+
+  it('should render topline', () => {
+    const expectedStyles = {
+      marginLeft: '-110px'
+    };
+    render(<Modal open={true} handleClose={() => {}} title="testModal" topLine />);
+    const box = screen.getByTestId('modal-topline');
+
+    expect(box).toHaveStyle(expectedStyles);
+  });
+
+  it('should render topline for smaller modals', () => {
+    const expectedStyles = {
+      marginLeft: '-32px'
+    };
+    render(<Modal open={true} handleClose={() => {}} width={500} title="testModal" topLine />);
+    const box = screen.getByTestId('modal-topline');
+
+    expect(box).toHaveStyle(expectedStyles);
+  });
+});

--- a/app/shared/components/design-system/all-components/modal/Modal.test.tsx
+++ b/app/shared/components/design-system/all-components/modal/Modal.test.tsx
@@ -13,7 +13,7 @@ describe('Modal', () => {
     expect(screen.getByText(expectedTitle)).toBeInTheDocument();
   });
 
-  it('should not render', () => {
+  it('should not render if not opened', () => {
     render(<Modal open={false} handleClose={() => {}} title="testModal" />);
     const titleElement = document.getElementById('modal-modal-title');
     expect(titleElement).not.toBeInTheDocument();
@@ -50,26 +50,26 @@ describe('Modal', () => {
     expect(handleClose).toHaveBeenCalledTimes(1);
   });
 
-  it('should render title correctly', () => {
+  it('should render title correctly for bigger modals', () => {
     render(<Modal open={true} handleClose={() => {}} title="testModal" />);
     const title = screen.getByRole('heading', { name: /testModal/i });
     expect(title.tagName).toBe('H3');
   });
 
-  it('should render title correctly', () => {
+  it('should render title correctly for smaller modals', () => {
     render(<Modal open={true} handleClose={() => {}} title="testModal" width={500} />);
     const title = screen.getByRole('heading', { name: /testModal/i });
     expect(title.tagName).toBe('H4');
   });
 
-  it('should correct filter based on backgroundColor for burgundy', () => {
+  it('should use correct filter based on backgroundColor for burgundy', () => {
     render(<Modal open={true} handleClose={() => {}} title="testModal" backgroundColor="burgundy" />);
 
     const iconWrapper = screen.getByAltText(/closing modal/i).parentElement;
     expect(iconWrapper).toHaveStyle('filter: brightness(0) invert(1)');
   });
 
-  it('should correct filter based on backgroundColor for white', () => {
+  it('should use correct filter based on backgroundColor for white', () => {
     render(<Modal open={true} handleClose={() => {}} title="testModal" backgroundColor="white" />);
 
     const iconWrapper = screen.getByAltText(/closing modal/i).parentElement;

--- a/app/shared/components/design-system/all-components/modal/Modal.tsx
+++ b/app/shared/components/design-system/all-components/modal/Modal.tsx
@@ -14,7 +14,7 @@ interface ModalProps {
   open: boolean;
   handleClose: () => void;
   width?: number;
-  height?: number | undefined;
+  height?: number;
   isBackdrop?: boolean;
   children?: React.ReactNode;
   title: string;
@@ -29,7 +29,7 @@ export const Modal: React.FC<ModalProps> = ({
   open,
   handleClose,
   width = 1080,
-  height,
+  height = undefined,
   isBackdrop = false,
   title,
   subtitle,

--- a/app/shared/components/design-system/all-components/modal/Modal.tsx
+++ b/app/shared/components/design-system/all-components/modal/Modal.tsx
@@ -14,7 +14,7 @@ interface ModalProps {
   open: boolean;
   handleClose: () => void;
   width?: number;
-  height?: number;
+  height?: number | undefined;
   isBackdrop?: boolean;
   children?: React.ReactNode;
   title: string;
@@ -29,11 +29,11 @@ export const Modal: React.FC<ModalProps> = ({
   open,
   handleClose,
   width = 1080,
-  height = 400,
+  height,
   isBackdrop = false,
   title,
   subtitle,
-  backgroundColor = 'burgundy',
+  backgroundColor = 'white',
   topLine = false,
   verticalAlignment,
   horizontalAlignment,

--- a/app/shared/components/design-system/all-components/modal/Modal.tsx
+++ b/app/shared/components/design-system/all-components/modal/Modal.tsx
@@ -45,6 +45,7 @@ export const Modal: React.FC<ModalProps> = ({
     <MuiModal
       open={open}
       onClose={handleClose}
+      data-testid="modal"
       aria-labelledby="modal-modal-title"
       aria-describedby="modal-modal-description"
       hideBackdrop={!isBackdrop}
@@ -53,7 +54,7 @@ export const Modal: React.FC<ModalProps> = ({
       <Box sx={style.content}>
         <Box sx={style.topSection}>
           <Box>
-            <Typography variant={isBigModal ? 'h3' : 'h4'} sx={style.title(backgroundColor)}>
+            <Typography id="modal-modal-title" variant={isBigModal ? 'h3' : 'h4'} sx={style.title(backgroundColor)}>
               {title}
             </Typography>
             {subtitle && (
@@ -77,7 +78,7 @@ export const Modal: React.FC<ModalProps> = ({
             </div>
           </IconButton>
         </Box>
-        {topLine && <Box sx={style.topLine(width)} />}
+        {topLine && <Box data-testid="modal-topline" sx={style.topLine(width)} />}
         <Box sx={style.children}>{children}</Box>
       </Box>
     </MuiModal>

--- a/app/shared/components/design-system/all-components/modal/Modal.tsx
+++ b/app/shared/components/design-system/all-components/modal/Modal.tsx
@@ -16,6 +16,7 @@ interface ModalProps {
   width?: number;
   height?: number;
   isBackdrop?: boolean;
+  disableScrollLock?: boolean;
   children?: React.ReactNode;
   title: string;
   subtitle?: string;
@@ -31,6 +32,7 @@ export const Modal: React.FC<ModalProps> = ({
   width = 1080,
   height = undefined,
   isBackdrop = false,
+  disableScrollLock = true,
   title,
   subtitle,
   backgroundColor = 'white',
@@ -49,6 +51,7 @@ export const Modal: React.FC<ModalProps> = ({
       aria-labelledby="modal-modal-title"
       aria-describedby="modal-modal-description"
       hideBackdrop={!isBackdrop}
+      disableScrollLock={disableScrollLock}
       sx={style.modal(width, height, backgroundColor, verticalAlignment, horizontalAlignment)}
     >
       <Box sx={style.content}>

--- a/app/shared/components/design-system/all-components/modal/Modal.tsx
+++ b/app/shared/components/design-system/all-components/modal/Modal.tsx
@@ -1,0 +1,85 @@
+import { Box, Modal as MuiModal, Typography } from '@mui/material';
+
+import { IconButton } from '../icon-button/IconButton';
+import { style } from './Modal.styles';
+import { IconButtonVariant, PositionEnum } from '~/types/enums/common.enums';
+
+import { SvgImage } from '~/shared/components/svg-image/SvgImage';
+
+export type Color = 'white' | 'burgundy';
+export type VerticalAlignment = PositionEnum.Top | PositionEnum.Bottom | undefined;
+export type HorizontalAlignment = PositionEnum.Left | PositionEnum.Right | undefined;
+
+interface ModalProps {
+  open: boolean;
+  handleClose: () => void;
+  width?: number;
+  height?: number;
+  isBackdrop?: boolean;
+  children?: React.ReactNode;
+  title: string;
+  subtitle?: string;
+  backgroundColor?: Color;
+  topLine?: boolean;
+  verticalAlignment?: VerticalAlignment;
+  horizontalAlignment?: HorizontalAlignment;
+}
+
+export const Modal: React.FC<ModalProps> = ({
+  open,
+  handleClose,
+  width = 1080,
+  height = 400,
+  isBackdrop = false,
+  title,
+  subtitle,
+  backgroundColor = 'burgundy',
+  topLine = false,
+  verticalAlignment,
+  horizontalAlignment,
+  children
+}) => {
+  const isBigModal = width > 1000;
+
+  return (
+    <MuiModal
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+      hideBackdrop={!isBackdrop}
+      sx={style.modal(width, height, backgroundColor, verticalAlignment, horizontalAlignment)}
+    >
+      <Box sx={style.content}>
+        <Box sx={style.topSection}>
+          <Box>
+            <Typography variant={isBigModal ? 'h3' : 'h4'} sx={style.title(backgroundColor)}>
+              {title}
+            </Typography>
+            {subtitle && (
+              <Typography variant="body2" sx={style.title(backgroundColor)}>
+                {subtitle}
+              </Typography>
+            )}
+          </Box>
+          <IconButton type={IconButtonVariant.icon} size="small" onClick={handleClose}>
+            <div
+              style={{
+                filter: backgroundColor === 'burgundy' ? 'brightness(0) invert(1)' : 'brightness(0) saturate(100%)'
+              }}
+            >
+              <SvgImage
+                src="/icons/x.svg"
+                alt="closing modal"
+                width={isBigModal ? 40 : 24}
+                height={isBigModal ? 40 : 24}
+              />
+            </div>
+          </IconButton>
+        </Box>
+        {topLine && <Box sx={style.topLine(width)} />}
+        <Box sx={style.children}>{children}</Box>
+      </Box>
+    </MuiModal>
+  );
+};


### PR DESCRIPTION
Implemented modal element

- styles from the designs in Figma
- different styles for bigger and smaller modals
- behavioural possibilities with choosing modal's position on the page, and props such as isBackdrop, disableScrollLock
- added tests

Example 1 (with white background and auto height):
![image](https://github.com/user-attachments/assets/b96f2937-7577-453b-92f9-ad88cd0b702e)
Example 2 (with set height and width):
![image](https://github.com/user-attachments/assets/fbeb5cbe-62ad-44bd-8ff4-fc323fe0467d)
Example 3 (with subtitle):
![image](https://github.com/user-attachments/assets/b03db6c0-1120-421c-a969-ace1629fd7ec)
Example 4 (with topline):
![image](https://github.com/user-attachments/assets/619832e5-72f8-40c4-9427-c29206924c95)
Example 5 (with burgundy background color):
![image](https://github.com/user-attachments/assets/b30fecf4-859b-4d66-b903-4c72c24f00ae)

Tests:
![image](https://github.com/user-attachments/assets/3d387a2b-00bf-4d72-8bdc-8734486c0a19)

