### PR TITLE
Implement button card

### DIFF
--- a/app/shared/components/design-system/all-components/button-card/ButtonCard.styles.ts
+++ b/app/shared/components/design-system/all-components/button-card/ButtonCard.styles.ts
@@ -21,9 +21,9 @@ export const styles = {
   },
   content: {
     position: 'relative',
-    margin: '40px 50px',
-    width: '216px',
-    height: '251px',
+    padding: '48px 40px',
+    width: '296px',
+    height: '351px',
     display: 'flex',
     alignItems: 'flex-end',
     justifyContent: 'flex-start',

--- a/app/shared/components/design-system/all-components/button-card/ButtonCard.styles.ts
+++ b/app/shared/components/design-system/all-components/button-card/ButtonCard.styles.ts
@@ -1,0 +1,32 @@
+export const styles = {
+  container: {
+    position: 'relative',
+    width: '296px',
+    height: '351px',
+    cursor: 'pointer',
+    overflow: 'hidden',
+    '&:hover .background': {
+      transform: 'translate(-50%, -50%) rotate(0deg)'
+    }
+  },
+  background: {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    width: '402px',
+    height: '337px',
+    background: 'rgba(252, 189, 40, 1)',
+    transform: 'translate(-50%, -50%) rotate(-2deg)',
+    transition: 'all 0.3s ease-in-out'
+  },
+  content: {
+    position: 'relative',
+    margin: '40px 50px',
+    width: '216px',
+    height: '251px',
+    display: 'flex',
+    alignItems: 'flex-end',
+    justifyContent: 'flex-start',
+    background: 'transparent'
+  }
+};

--- a/app/shared/components/design-system/all-components/button-card/ButtonCard.test.tsx
+++ b/app/shared/components/design-system/all-components/button-card/ButtonCard.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import ButtonCard from './ButtonCard';
+
+jest.mock('~/i18n/navigation', () => ({
+  Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href} data-testid="mock-link">
+      {children}
+    </a>
+  )
+}));
+
+describe('ButtonCard', () => {
+  const defaultProps = {
+    text: 'Test Button'
+  };
+
+  it('should render with text', () => {
+    render(<ButtonCard {...defaultProps} />);
+
+    expect(screen.getByText('Test Button')).toBeInTheDocument();
+  });
+
+  it('should render without link', () => {
+    render(<ButtonCard {...defaultProps} />);
+
+    expect(screen.queryByTestId('mock-link')).not.toBeInTheDocument();
+    expect(screen.getByText('Test Button')).toBeInTheDocument();
+  });
+
+  it('should render with link', () => {
+    render(<ButtonCard {...defaultProps} link="/test-link" />);
+
+    expect(screen.getByTestId('mock-link')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-link')).toHaveAttribute('href', '/test-link');
+    expect(screen.getByText('Test Button')).toBeInTheDocument();
+  });
+
+  it('should render background element with correct className', () => {
+    const { container } = render(<ButtonCard {...defaultProps} />);
+
+    expect(container.querySelector('.background')).toBeInTheDocument();
+  });
+});

--- a/app/shared/components/design-system/all-components/button-card/ButtonCard.tsx
+++ b/app/shared/components/design-system/all-components/button-card/ButtonCard.tsx
@@ -1,0 +1,25 @@
+import { Box, Typography } from '@mui/material';
+
+import { styles } from './ButtonCard.styles';
+
+import { Link } from '~/i18n/navigation';
+
+interface ButtonCardProps {
+  text: string;
+  link?: string;
+}
+
+const ButtonCard = ({ text, link }: ButtonCardProps) => {
+  const cardContent = (
+    <Box sx={styles.container}>
+      <Box sx={styles.background} className="background" />
+      <Box sx={styles.content}>
+        <Typography variant="customBold20">{text}</Typography>
+      </Box>
+    </Box>
+  );
+
+  return link ? <Link href={link}>{cardContent}</Link> : cardContent;
+};
+
+export default ButtonCard;

--- a/app/shared/components/design-system/all-components/text-card/TextCard.styles.ts
+++ b/app/shared/components/design-system/all-components/text-card/TextCard.styles.ts
@@ -1,20 +1,28 @@
 export const styles = {
   card: {
+    position: 'relative',
     width: '296px',
     height: '351px',
+    cursor: 'pointer',
+    overflow: 'hidden'
+  },
+  background: {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    width: '402px',
+    height: '337px',
     background: 'rgba(237, 232, 223, 1)',
-    transform: 'skewY(-3deg)',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center'
+    transform: 'translate(-50%, -50%) rotate(-2deg)'
   },
   content: {
-    transform: 'skewY(3deg)',
+    position: 'relative',
     padding: '48px 40px',
     width: '100%',
     height: '100%',
     display: 'flex',
-    flexDirection: 'column'
+    flexDirection: 'column',
+    background: 'transparent'
   },
   description: {
     fontFamily: 'Mulish, sans-serif',

--- a/app/shared/components/design-system/all-components/text-card/TextCard.styles.ts
+++ b/app/shared/components/design-system/all-components/text-card/TextCard.styles.ts
@@ -3,7 +3,6 @@ export const styles = {
     position: 'relative',
     width: '296px',
     height: '351px',
-    cursor: 'pointer',
     overflow: 'hidden'
   },
   background: {

--- a/app/shared/components/design-system/all-components/text-card/TextCard.tsx
+++ b/app/shared/components/design-system/all-components/text-card/TextCard.tsx
@@ -10,6 +10,7 @@ interface TextCardProps {
 const TextCard: React.FC<TextCardProps> = ({ title, description }) => {
   return (
     <Box sx={styles.card}>
+      <Box sx={styles.background} />
       <Box sx={styles.content}>
         <Typography sx={styles.description}>{description}</Typography>
 


### PR DESCRIPTION
## Summary of change

- Implemented a ButtonCard component with two props: title (required) and link (optional). The optional link prop enables navigation on button click. Added hover effects as specified in the design mockups.
- Wrote unit tests for the component.
- Updated text card component styles to ensure proper alignment within the design system.

Result: 

https://github.com/user-attachments/assets/4c8ad2a7-0bec-4606-b258-db617e091321





