### PR TITLE
Add Header animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,19 +3,15 @@
   --foreground: #171717;
 }
 
-html,
-body {
-  height: 100%;
-  max-width: 100vw;
-  overflow-x: hidden;
-}
-
 body {
   color: var(--foreground);
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  height: 100%;
+  max-width: 100vw;
+  overflow-x: hidden;
 }
 
 * {

--- a/app/shared/components/Header/Header.styles.ts
+++ b/app/shared/components/Header/Header.styles.ts
@@ -1,16 +1,26 @@
 export const styles = {
   mainContainer: {
-    maxHeight: '52px',
     display: 'flex',
+    position: 'fixed',
+    left: 0,
+    right: 0,
+    zIndex: 1000,
     alignItems: 'center',
-    justifyContent: 'space-between'
-  },
-  navigationContainer: {
-    marginRight: { xl: '35px', xxl: '70px' },
-    fontSize: { md: '15px', lg: '16px' }
+    justifyContent: 'space-between',
+    maxWidth: '1920px',
+    maxHeight: '52px',
+    mx: 'auto',
+    px: 9,
+    pointerEvents: 'auto'
   },
   logoContainer: {
     position: 'relative',
     right: '22px'
-  }
+  },
+  navigationContainer: (isVisible: boolean) => ({
+    marginRight: { xl: '35px', xxl: '70px' },
+    fontSize: { md: '15px', lg: '16px' },
+    transition: 'transform 0.4s ease',
+    transform: isVisible ? 'translateY(0)' : 'translateY(-150%)'
+  })
 };

--- a/app/shared/components/Header/Header.tsx
+++ b/app/shared/components/Header/Header.tsx
@@ -1,6 +1,8 @@
+'use client';
+
 import { Box } from '@mui/material';
-import { getLocale, getTranslations } from 'next-intl/server';
-import React from 'react';
+import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
 
 import Logo from '~/ds-components/logo/Logo';
 import NavigationBar from '~/ds-components/navigation-bar/NavigationBar';
@@ -8,13 +10,16 @@ import NavigationBar from '~/ds-components/navigation-bar/NavigationBar';
 import { styles } from './Header.styles';
 import RightActionsPanel from './RightActionsPanel/RightActionsPanel';
 
-import { createRequestContainer } from '~/di/container';
+import { useScrollDirection } from '~/shared/hooks/use-scroll-direction/useScrollDirection';
 
-export default async function Header() {
-  const t = await getTranslations('header');
-  const locale = await getLocale();
+export default function Header() {
+  const [isNavVisible, setIsNavVisible] = useState(true);
+  const scrollDirection = useScrollDirection(100);
+  const t = useTranslations('header');
 
-  const { supportButtonLink } = await createRequestContainer().resolve('headerService').getHeaderData(locale);
+  useEffect(() => {
+    setIsNavVisible(scrollDirection !== 'down');
+  }, [scrollDirection]);
 
   const navLabels = {
     liatoshynsky: t('navLabels.liatoshynsky'),
@@ -29,13 +34,15 @@ export default async function Header() {
     collaboration: t('navLabels.collaboration')
   };
 
+  const supportButtonLink = '/support-us';
+
   return (
     <Box component="header" sx={styles.mainContainer}>
       <Box sx={styles.logoContainer}>
         <Logo />
       </Box>
 
-      <Box sx={styles.navigationContainer}>
+      <Box sx={styles.navigationContainer(isNavVisible)}>
         <NavigationBar navLabels={navLabels} />
       </Box>
 

--- a/app/shared/hooks/use-scroll-direction/useScrollDirection.ts
+++ b/app/shared/hooks/use-scroll-direction/useScrollDirection.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { ScrollDirection } from '~/types/types/common.types';
+
+export function useScrollDirection(threshold = 0) {
+  const [scrollDirection, setScrollDirection] = useState<ScrollDirection>('up');
+  const lastScrollTopRef = useRef(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollTop = window.scrollY;
+      const lastScrollTop = lastScrollTopRef.current;
+
+      if (Math.abs(currentScrollTop - lastScrollTop) < threshold) {
+        return;
+      }
+
+      setScrollDirection(currentScrollTop > lastScrollTop ? 'down' : 'up');
+      lastScrollTopRef.current = currentScrollTop;
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [threshold]);
+
+  return scrollDirection;
+}

--- a/app/types/types/common.types.ts
+++ b/app/types/types/common.types.ts
@@ -7,3 +7,5 @@ export interface ElementSizes {
 
 export type ButtonGroupSizeOptions = 'small' | 'big';
 export type ButtonGroupPaletteOptions = 'primary' | 'secondary';
+
+export type ScrollDirection = 'up' | 'down';


### PR DESCRIPTION
## Description

Refactored the Header component to support scroll-based navigation visibility using the useScrollDirection hook.
Moved inline styles into a centralized Header.styles.ts file.
Integrated client-side translations using next-intl hooks (useTranslations).
Now only the navigation bar hides on scroll down and reappears on scroll up, while the header remains fixed.

## Type of change

- [X] New feature
- [X] Refactoring / Tech debt

## How to test

1. Open any page with the Header component.

2. Scroll down — navigation should slide up and hide.

3. Scroll up — navigation should slide back into view.

## Video / Screenshots


https://github.com/user-attachments/assets/929a60d3-284e-40e0-971d-50fde571fe18



## Checklist

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [X] Linked issue/task included
- [X] Task moved to the review column on the board

---
