### PR TITLE
fix: fixed an issue with the opus icon display

### DIFF
--- a/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.test.tsx
+++ b/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.test.tsx
@@ -11,6 +11,16 @@ type MockRow = {
   group: string;
 };
 
+jest.mock('~/public/icons/chevron-down.svg', () => ({
+  __esModule: true,
+  default: () => <svg data-testid="svg-image" />
+}));
+
+jest.mock('~/public/icons/chevron-right.svg', () => ({
+  __esModule: true,
+  default: () => <svg data-testid="svg-image" />
+}));
+
 jest.mock('./CollapsibleDataRow', () => ({
   CollapsibleDataRow: ({ row }: { row: { original: MockRow } }) => (
     <tr data-testid="collapsible-data-row">
@@ -44,6 +54,7 @@ const columns: ColumnDef<MockRow>[] = [
     cell: () => null
   },
   {
+    id: 'name',
     accessorKey: 'name',
     header: 'Name',
     cell: (info) => info.getValue(),

--- a/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.tsx
+++ b/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.tsx
@@ -4,14 +4,18 @@ import { Box, TableCell, TableRow } from '@mui/material';
 import { type ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import React from 'react';
 
+import { Svg } from '~/components/colored-svg/ColoredSvg';
 import { IconButton } from '~/ds-components/icon-button/IconButton';
+import { mainHexPallete } from '~/ds-components/theme/colors';
 
 import { CollapsibleDataRow } from './CollapsibleDataRow';
 import { collapsibleRowStyles as styles } from './CollapsibleRow.styles';
 import { IconButtonColorVariant } from '~/types/enums/common.enums';
 import type { CollapsibleGroupColumnMeta, RowData } from '~/types/types/enhancedTable';
 
-import { SvgImage } from '~/shared/components/svg-image/SvgImage';
+import chevronDown from '~/public/icons/chevron-down.svg';
+import chevronRight from '~/public/icons/chevron-right.svg';
+
 interface CollapsibleRowProps<T extends RowData> {
   data: T[];
   collapsed: boolean;
@@ -47,11 +51,12 @@ export function CollapsibleRow<T extends RowData>({
               <Box sx={styles.cellInner}>
                 {col.id === 'expander' ? (
                   <IconButton onClick={action} variant={IconButtonColorVariant.Secondary} disableRipple>
-                    <SvgImage
-                      src={collapsed ? '/icons/chevron-down.svg' : '/icons/chevron-right.svg'}
+                    <Svg
+                      Component={collapsed ? chevronDown : chevronRight}
+                      color={mainHexPallete.brown['700']}
                       alt="toggle"
-                      width={24}
-                      height={24}
+                      width="24px"
+                      height="24px"
                     />
                   </IconButton>
                 ) : (

--- a/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.tsx
+++ b/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.tsx
@@ -55,8 +55,6 @@ export function CollapsibleRow<T extends RowData>({
                       Component={collapsed ? chevronDown : chevronRight}
                       color={mainHexPallete.brown['700']}
                       alt="toggle"
-                      width="24px"
-                      height="24px"
                     />
                   </IconButton>
                 ) : (

--- a/public/icons/chevron-first.svg
+++ b/public/icons/chevron-first.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M17 18L11 12L17 6M7 6V18" stroke="#565656" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M17 18L11 12L17 6M7 6V18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/public/icons/chevron-last.svg
+++ b/public/icons/chevron-last.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M7 18L13 12L7 6M17 6V18" stroke="#565656" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M7 18L13 12L7 6M17 6V18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/public/icons/chevron-left.svg
+++ b/public/icons/chevron-left.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M15 18L9 12L15 6" stroke="#FCFCFC" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M15 18L9 12L15 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/public/icons/chevron-right.svg
+++ b/public/icons/chevron-right.svg
@@ -1,3 +1,3 @@
 <svg width="48" height="48" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M9 18L15 12L9 6" stroke="#FCFCFC" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M9 18L15 12L9 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
## Summary of change

- Fixed an issue with the opus open row icon being displayed
- Tests adapted to new functionality
- Edited the settings of some svg icons

Screenshot:
<img width="388" height="204" alt="image" src="https://github.com/user-attachments/assets/943162b1-2fe3-4a40-b987-7cf6bac44f90" />
