### PR TITLE
feat: create a component to display TipTap content

### DIFF
--- a/app/shared/components/tip-tap-node/TipTapNode.tsx
+++ b/app/shared/components/tip-tap-node/TipTapNode.tsx
@@ -1,0 +1,13 @@
+import renderTipTapNode from '~/components/tip-tap-node/renderTipTapNode';
+
+import { Node } from '~/types/types/common.types';
+
+interface TipTapNodeProps {
+  node: Node;
+}
+
+const TipTapNode: React.FC<TipTapNodeProps> = ({ node }) => {
+  return renderTipTapNode(node);
+};
+
+export default TipTapNode;

--- a/app/shared/components/tip-tap-node/TipTapNode.tsx
+++ b/app/shared/components/tip-tap-node/TipTapNode.tsx
@@ -1,13 +1,15 @@
+import { TypographyProps } from '@mui/material';
+
 import renderTipTapNode from '~/components/tip-tap-node/renderTipTapNode';
 
 import { Node } from '~/types/types/common.types';
 
-interface TipTapNodeProps {
+interface TipTapNodeProps extends TypographyProps {
   node: Node;
 }
 
-const TipTapNode: React.FC<TipTapNodeProps> = ({ node }) => {
-  return renderTipTapNode(node);
+const TipTapNode: React.FC<TipTapNodeProps> = ({ node, ...props }) => {
+  return renderTipTapNode(node, props);
 };
 
 export default TipTapNode;

--- a/app/shared/components/tip-tap-node/extentions/Heading.tsx
+++ b/app/shared/components/tip-tap-node/extentions/Heading.tsx
@@ -9,7 +9,7 @@ interface HeadingProps extends TypographyProps {
   node: HeadingNode;
 }
 
-const levelVariantMap: Record<HeadingNode['level'], TypographyProps['variant']> = {
+const levelVariantMap: Record<number, TypographyProps['variant']> = {
   1: 'h1',
   2: 'h2',
   3: 'h3',
@@ -20,7 +20,7 @@ const levelVariantMap: Record<HeadingNode['level'], TypographyProps['variant']> 
 
 export const Heading: React.FC<HeadingProps> = ({ node, ...props }) => {
   return (
-    <Typography variant={levelVariantMap[node.level]} gutterBottom {...props}>
+    <Typography variant={levelVariantMap[node.attrs.level]} gutterBottom {...props}>
       {node.content && renderTipTapNode(node.content)}
     </Typography>
   );

--- a/app/shared/components/tip-tap-node/extentions/Heading.tsx
+++ b/app/shared/components/tip-tap-node/extentions/Heading.tsx
@@ -1,0 +1,27 @@
+import { Typography, TypographyProps } from '@mui/material';
+import React from 'react';
+
+import renderTipTapNode from '~/components/tip-tap-node/renderTipTapNode';
+
+import { HeadingNode } from '~/types/types/common.types';
+
+interface HeadingProps extends TypographyProps {
+  node: HeadingNode;
+}
+
+const levelVariantMap: Record<HeadingNode['level'], TypographyProps['variant']> = {
+  1: 'h1',
+  2: 'h2',
+  3: 'h3',
+  4: 'h4',
+  5: 'h5',
+  6: 'h6'
+};
+
+export const Heading: React.FC<HeadingProps> = ({ node, ...props }) => {
+  return (
+    <Typography variant={levelVariantMap[node.level]} gutterBottom {...props}>
+      {node.content && renderTipTapNode(node.content)}
+    </Typography>
+  );
+};

--- a/app/shared/components/tip-tap-node/extentions/Paragraph.tsx
+++ b/app/shared/components/tip-tap-node/extentions/Paragraph.tsx
@@ -11,7 +11,7 @@ interface ParagraphBlockProps extends Omit<TypographyProps, 'children'> {
 
 export const Paragraph: React.FC<ParagraphBlockProps> = ({ node, ...props }) => {
   return (
-    <Typography variant="body1" component="p" {...props}>
+    <Typography variant="body2" component="p" {...props}>
       {node.content && renderTipTapNode(node.content)}
     </Typography>
   );

--- a/app/shared/components/tip-tap-node/extentions/Paragraph.tsx
+++ b/app/shared/components/tip-tap-node/extentions/Paragraph.tsx
@@ -1,0 +1,18 @@
+import { Typography, TypographyProps } from '@mui/material';
+import React from 'react';
+
+import renderTipTapNode from '~/components/tip-tap-node/renderTipTapNode';
+
+import { ParagraphNode } from '~/types/types/common.types';
+
+interface ParagraphBlockProps extends Omit<TypographyProps, 'children'> {
+  node: ParagraphNode;
+}
+
+export const Paragraph: React.FC<ParagraphBlockProps> = ({ node, ...props }) => {
+  return (
+    <Typography variant="body1" component="p" {...props}>
+      {node.content && renderTipTapNode(node.content)}
+    </Typography>
+  );
+};

--- a/app/shared/components/tip-tap-node/extentions/RichText.tsx
+++ b/app/shared/components/tip-tap-node/extentions/RichText.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
+import TextLink from './TextLink';
 import { TipTapMarkType, TipTapNodeType } from '~/types/enums/common.enums';
-import { Node, TipTapMarkRenderers } from '~/types/types/common.types';
+import { Mark, Node, TipTapMarkRenderers } from '~/types/types/common.types';
 
 interface TextNodeProps {
   node: Node;
@@ -10,8 +11,12 @@ interface TextNodeProps {
 const markRenderers: TipTapMarkRenderers = {
   [TipTapMarkType.bold]: (children) => <strong>{children}</strong>,
   [TipTapMarkType.italic]: (children) => <em>{children}</em>,
-  [TipTapMarkType.underline]: (children) => <em>{children}</em>,
-  [TipTapMarkType.link]: (children) => <a>{children}</a>
+  [TipTapMarkType.underline]: (children) => <u>{children}</u>,
+  [TipTapMarkType.link]: (children, mark) => (
+    <TextLink href={mark.attrs.href || '#'} underline="hover">
+      {children}
+    </TextLink>
+  )
 };
 
 export const RichText: React.FC<TextNodeProps> = ({ node }) => {
@@ -21,8 +26,8 @@ export const RichText: React.FC<TextNodeProps> = ({ node }) => {
 
   if (node.marks) {
     content = node.marks.reduce((acc, mark) => {
-      const wrap = markRenderers[mark.type];
-      return wrap ? wrap(acc) : acc;
+      const wrap = markRenderers[mark.type] as (n: React.ReactNode, m: Mark) => React.ReactNode;
+      return wrap ? wrap(acc, mark) : acc;
     }, content);
   }
 

--- a/app/shared/components/tip-tap-node/extentions/RichText.tsx
+++ b/app/shared/components/tip-tap-node/extentions/RichText.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { TipTapMarkType, TipTapNodeType } from '~/types/enums/common.enums';
+import { Node, TipTapMarkRenderers } from '~/types/types/common.types';
+
+interface TextNodeProps {
+  node: Node;
+}
+
+const markRenderers: TipTapMarkRenderers = {
+  [TipTapMarkType.bold]: (children) => <strong>{children}</strong>,
+  [TipTapMarkType.italic]: (children) => <em>{children}</em>,
+  [TipTapMarkType.underline]: (children) => <em>{children}</em>,
+  [TipTapMarkType.link]: (children) => <a>{children}</a>
+};
+
+export const RichText: React.FC<TextNodeProps> = ({ node }) => {
+  if (node.type !== TipTapNodeType.text) return null;
+
+  let content = (node.text ?? '') as React.ReactNode;
+
+  if (node.marks) {
+    content = node.marks.reduce((acc, mark) => {
+      const wrap = markRenderers[mark.type];
+      return wrap ? wrap(acc) : acc;
+    }, content);
+  }
+
+  return <>{content}</>;
+};

--- a/app/shared/components/tip-tap-node/extentions/TextLink.tsx
+++ b/app/shared/components/tip-tap-node/extentions/TextLink.tsx
@@ -1,0 +1,19 @@
+import { Link, LinkProps, SxProps, Theme } from '@mui/material';
+
+const link: SxProps<Theme> = {
+  textDecoration: 'underline',
+  transition: 'color 0.2s ease',
+  '&:hover': {
+    color: '#5F0E0F'
+  }
+};
+
+const TextLink: React.FC<LinkProps> = ({ children, sx, ...props }) => {
+  return (
+    <Link sx={[link, ...(Array.isArray(sx) ? sx : [sx])]} {...props}>
+      {children}
+    </Link>
+  );
+};
+
+export default TextLink;

--- a/app/shared/components/tip-tap-node/renderTipTapNode.tsx
+++ b/app/shared/components/tip-tap-node/renderTipTapNode.tsx
@@ -1,3 +1,4 @@
+import { TypographyProps } from '@mui/material';
 import React from 'react';
 
 import { Heading } from '~/components/tip-tap-node/extentions/Heading';
@@ -7,22 +8,24 @@ import { RichText } from '~/components/tip-tap-node/extentions/RichText';
 import { TipTapNodeType } from '~/types/enums/common.enums';
 import { Node, TipTapNodeRenderers } from '~/types/types/common.types';
 
+type NodeRenderer = (n: Node, props?: TypographyProps) => React.ReactNode;
+
 export const renderers: TipTapNodeRenderers = {
-  [TipTapNodeType.doc]: (node) => node.content && renderTipTapNode(node.content),
-  [TipTapNodeType.heading]: (node) => <Heading node={node} />,
-  [TipTapNodeType.paragraph]: (node) => <Paragraph node={node} />,
+  [TipTapNodeType.doc]: (node, props) => node.content && renderTipTapNode(node.content, props),
+  [TipTapNodeType.heading]: (node, props) => <Heading node={node} {...props} />,
+  [TipTapNodeType.paragraph]: (node, props) => <Paragraph node={node} {...props} />,
   [TipTapNodeType.text]: (node) => <RichText node={node} />
 };
 
-function renderTipTapNode(node: Node | Node[]) {
+function renderTipTapNode(node: Node | Node[], props?: TypographyProps) {
   if (Array.isArray(node)) {
     return node.map((child, index) => {
-      const renderer = renderers[child.type] as (n: Node) => React.ReactNode;
-      return <React.Fragment key={index}>{renderer ? renderer(child) : null}</React.Fragment>;
+      const renderer = renderers[child.type] as NodeRenderer;
+      return <React.Fragment key={index}>{renderer ? renderer(child, props) : null}</React.Fragment>;
     });
   } else {
-    const renderer = renderers[node.type] as (n: Node) => React.ReactNode;
-    return renderer ? renderer(node) : null;
+    const renderer = renderers[node.type] as NodeRenderer;
+    return renderer ? renderer(node, props) : null;
   }
 }
 

--- a/app/shared/components/tip-tap-node/renderTipTapNode.tsx
+++ b/app/shared/components/tip-tap-node/renderTipTapNode.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { Heading } from '~/components/tip-tap-node/extentions/Heading';
+import { Paragraph } from '~/components/tip-tap-node/extentions/Paragraph';
+import { RichText } from '~/components/tip-tap-node/extentions/RichText';
+
+import { TipTapNodeType } from '~/types/enums/common.enums';
+import { Node, TipTapNodeRenderers } from '~/types/types/common.types';
+
+export const renderers: TipTapNodeRenderers = {
+  [TipTapNodeType.doc]: (node) => node.content && renderTipTapNode(node.content),
+  [TipTapNodeType.heading]: (node) => <Heading node={node} />,
+  [TipTapNodeType.paragraph]: (node) => <Paragraph node={node} />,
+  [TipTapNodeType.text]: (node) => <RichText node={node} />
+};
+
+function renderTipTapNode(node: Node | Node[]) {
+  if (Array.isArray(node)) {
+    return node.map((child, index) => {
+      const renderer = renderers[child.type] as (n: Node) => React.ReactNode;
+      return <React.Fragment key={index}>{renderer ? renderer(child) : null}</React.Fragment>;
+    });
+  } else {
+    const renderer = renderers[node.type] as (n: Node) => React.ReactNode;
+    return renderer ? renderer(node) : null;
+  }
+}
+
+export default renderTipTapNode;

--- a/app/types/enums/common.enums.ts
+++ b/app/types/enums/common.enums.ts
@@ -8,17 +8,20 @@ export enum PositionEnum {
   Vertical = 'vertical',
   Center = 'center'
 }
+
 export enum IconButtonColorVariant {
   Primary = 'primary',
   Secondary = 'secondary',
   Tertiary = 'tertiary',
   Error = 'error'
 }
+
 export enum IconButtonVariant {
   filled = 'filled',
   outlined = 'outlined',
   icon = 'icon'
 }
+
 export enum SocialMediaTypes {
   Instagram = 'instagram',
   Facebook = 'facebook',
@@ -30,4 +33,18 @@ export enum SocialMediaTypes {
   Twitter = 'twitter',
   Whatsapp = 'whatsapp',
   AnotherMedia = 'anotherMedia'
+}
+
+export enum TipTapNodeType {
+  doc = 'doc',
+  heading = 'heading',
+  paragraph = 'paragraph',
+  text = 'text'
+}
+
+export enum TipTapMarkType {
+  bold = 'bold',
+  italic = 'italic',
+  underline = 'underline',
+  link = 'link'
 }

--- a/app/types/types/common.types.ts
+++ b/app/types/types/common.types.ts
@@ -1,5 +1,7 @@
 import { Breakpoint } from '@mui/material';
 
+import { TipTapMarkType, TipTapNodeType } from '~/types/enums/common.enums';
+
 export interface ElementSizes {
   width: Partial<Record<Breakpoint, number>>;
   height: Partial<Record<Breakpoint, number>>;
@@ -11,3 +13,73 @@ export type ButtonGroupPaletteOptions = 'primary' | 'secondary';
 export type ScrollDirection = 'up' | 'down';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export interface BaseMark {
+  type: string;
+  attrs?: { [key: string]: unknown };
+}
+
+export interface BoldMark extends BaseMark {
+  type: TipTapMarkType.bold;
+}
+
+export interface ItalicMark extends BaseMark {
+  type: TipTapMarkType.italic;
+}
+
+export interface UnderlineMark extends BaseMark {
+  type: TipTapMarkType.underline;
+}
+
+export interface LinkMark extends BaseMark {
+  type: TipTapMarkType.link;
+  attrs: {
+    href: string;
+    target?: '_blank' | '_self' | '_parent' | '_top';
+    rel?: string;
+  };
+}
+
+export type Mark = BoldMark | ItalicMark | UnderlineMark | LinkMark;
+
+export interface BaseNode {
+  type: string;
+  attrs?: { [key: string]: never };
+  content?: Node[];
+  marks?: Mark[];
+}
+
+export interface DocumentNode extends BaseNode {
+  type: TipTapNodeType.doc;
+}
+
+export interface HeadingNode extends BaseNode {
+  type: TipTapNodeType.heading;
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+export interface ParagraphNode extends BaseNode {
+  type: TipTapNodeType.paragraph;
+}
+
+export interface TextNode extends BaseNode {
+  type: TipTapNodeType.text;
+  text: string;
+}
+
+export type Node = DocumentNode | HeadingNode | ParagraphNode | TextNode;
+
+export type TipTapNodeTypes = {
+  [TipTapNodeType.doc]: DocumentNode;
+  [TipTapNodeType.heading]: HeadingNode;
+  [TipTapNodeType.paragraph]: ParagraphNode;
+  [TipTapNodeType.text]: TextNode;
+};
+
+export type TipTapNodeRenderers = {
+  [T in TipTapNodeType]: (node: TipTapNodeTypes[T]) => React.ReactNode;
+};
+
+export type TipTapMarkRenderers = {
+  [T in TipTapMarkType]: (children: React.ReactNode) => React.ReactNode;
+};

--- a/app/types/types/common.types.ts
+++ b/app/types/types/common.types.ts
@@ -1,4 +1,5 @@
-import { Breakpoint } from '@mui/material';
+import { Breakpoint, TypographyProps } from '@mui/material';
+import { ReactNode } from 'react';
 
 import { TipTapMarkType, TipTapNodeType } from '~/types/enums/common.enums';
 
@@ -44,7 +45,7 @@ export type Mark = BoldMark | ItalicMark | UnderlineMark | LinkMark;
 
 export interface BaseNode {
   type: string;
-  attrs?: { [key: string]: never };
+  attrs?: { [key: string]: unknown };
   content?: Node[];
   marks?: Mark[];
 }
@@ -55,7 +56,9 @@ export interface DocumentNode extends BaseNode {
 
 export interface HeadingNode extends BaseNode {
   type: TipTapNodeType.heading;
-  level: 1 | 2 | 3 | 4 | 5 | 6;
+  attrs: {
+    level: number;
+  };
 }
 
 export interface ParagraphNode extends BaseNode {
@@ -69,17 +72,16 @@ export interface TextNode extends BaseNode {
 
 export type Node = DocumentNode | HeadingNode | ParagraphNode | TextNode;
 
-export type TipTapNodeTypes = {
-  [TipTapNodeType.doc]: DocumentNode;
-  [TipTapNodeType.heading]: HeadingNode;
-  [TipTapNodeType.paragraph]: ParagraphNode;
-  [TipTapNodeType.text]: TextNode;
-};
-
 export type TipTapNodeRenderers = {
-  [T in TipTapNodeType]: (node: TipTapNodeTypes[T]) => React.ReactNode;
+  [TipTapNodeType.doc]: (node: DocumentNode, props: TypographyProps) => ReactNode;
+  [TipTapNodeType.heading]: (node: HeadingNode, props: TypographyProps) => ReactNode;
+  [TipTapNodeType.paragraph]: (node: ParagraphNode, props: TypographyProps) => ReactNode;
+  [TipTapNodeType.text]: (node: TextNode) => ReactNode;
 };
 
 export type TipTapMarkRenderers = {
-  [T in TipTapMarkType]: (children: React.ReactNode) => React.ReactNode;
+  [TipTapMarkType.bold]: (children: ReactNode, mark: BoldMark) => ReactNode;
+  [TipTapMarkType.italic]: (children: ReactNode, mark: ItalicMark) => ReactNode;
+  [TipTapMarkType.underline]: (children: ReactNode, mark: UnderlineMark) => ReactNode;
+  [TipTapMarkType.link]: (children: ReactNode, mark: LinkMark) => ReactNode;
 };


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of this PR and what was changed -->
The basic functionality of the TipTap library provided excessive wrappers, which made it very difficult to position elements on the page. 
To solve this problem, a custom component was created to display TipTap content without using the library itself.

## How to use

<!-- Describe steps to test this PR locally or link to CI pipeline -->
You can use the "TipTapNode" component:
    `<TipTapNode node={test /*TipTap document*/}  {...props} /*Typography props*/ />`

Or you can use the "renderTipTapNode" function:
   `renderTipTapNode(node /*TipTap document*/, props  /*Typography props*/ )`

Depending on the data content, renders a component from the "extensions" folder.
To add a new component (extension) you need to:

1. Add a name for the new node type (TipTap document type) in the "`.\app\types\enums\common.enums.ts`"
2. Create an interface with properties for the new node and add it to the TipTapNodeRenderers interface in the "`.\app\types\types\common.types.ts`".
3. Add a new render method to the "renderers" object in "`.\app\shared\components\tip-tap-node\renderTipTapNode.tsx`".

Done. Now the render function should be executed for nodes marked with the new type.

## Video / Screenshots

<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->
<img width="867" height="491" alt="image" src="https://github.com/user-attachments/assets/ba140c97-42f1-44a5-9409-391ea6579bff" />


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [x] Task moved to the review column on the board

---
