### PR TITLE
feat: create a component to display TipTap content

### DIFF
--- a/app/shared/components/tip-tap-content/TipTapContent.tsx
+++ b/app/shared/components/tip-tap-content/TipTapContent.tsx
@@ -1,0 +1,36 @@
+import { getBold, getItalic, getLink, getUnderline } from '~/components/tip-tap-content/marks';
+import { getDoc, getHeading, getParagraph, getText } from '~/components/tip-tap-content/nodes';
+import renderNode from '~/components/tip-tap-content/renderNode';
+
+import { TipTapMarkType, TipTapNodeTypes } from '~/types/enums/common.enums';
+import { TipTapDoc, TipTapMarkRenderers, TipTapNodeRenderers } from '~/types/types/common.types';
+
+interface TipTapContentProps {
+  data: TipTapDoc;
+  nodeRenderers?: Partial<TipTapNodeRenderers>;
+  markRenderers?: Partial<TipTapMarkRenderers>;
+}
+
+const TipTapContent: React.FC<TipTapContentProps> = ({ data, nodeRenderers, markRenderers }) => {
+  const TipTapDefaultMarkRenderers: TipTapMarkRenderers = {
+    [TipTapMarkType.bold]: getBold,
+    [TipTapMarkType.italic]: getItalic,
+    [TipTapMarkType.underline]: getUnderline,
+    [TipTapMarkType.link]: getLink
+  };
+
+  const finalMarkRenderers: TipTapMarkRenderers = { ...TipTapDefaultMarkRenderers, ...markRenderers };
+
+  const TipTapDefaultNodeRenderers: TipTapNodeRenderers = {
+    [TipTapNodeTypes.doc]: getDoc,
+    [TipTapNodeTypes.heading]: getHeading,
+    [TipTapNodeTypes.paragraph]: getParagraph,
+    [TipTapNodeTypes.text]: getText(finalMarkRenderers)
+  };
+
+  const finalNodeRenderers: TipTapNodeRenderers = { ...TipTapDefaultNodeRenderers, ...nodeRenderers };
+
+  return renderNode(finalNodeRenderers, data);
+};
+
+export default TipTapContent;

--- a/app/shared/components/tip-tap-content/marks.tsx
+++ b/app/shared/components/tip-tap-content/marks.tsx
@@ -1,0 +1,13 @@
+import { Link } from '@mui/material';
+
+import { TipTapMarkType } from '~/types/enums/common.enums';
+import { TipTapMarkRenderers } from '~/types/types/common.types';
+
+export const getBold: TipTapMarkRenderers[TipTapMarkType.bold] = (children) => <strong>{children}</strong>;
+export const getItalic: TipTapMarkRenderers[TipTapMarkType.italic] = (children) => <em>{children}</em>;
+export const getUnderline: TipTapMarkRenderers[TipTapMarkType.underline] = (children) => <u>{children}</u>;
+export const getLink: TipTapMarkRenderers[TipTapMarkType.link] = (children, mark) => (
+  <Link href={mark.attrs?.href || '#'} underline="hover">
+    {children}
+  </Link>
+);

--- a/app/shared/components/tip-tap-content/nodes.tsx
+++ b/app/shared/components/tip-tap-content/nodes.tsx
@@ -1,0 +1,21 @@
+import { Typography } from '@mui/material';
+
+import renderText from '~/components/tip-tap-content/renderText';
+
+import { TipTapNodeTypes } from '~/types/enums/common.enums';
+import { TextNode, TipTapMarkRenderers, TipTapNodeRenderers } from '~/types/types/common.types';
+
+export const getDoc: TipTapNodeRenderers[TipTapNodeTypes.doc] = (children) => children;
+
+export const getHeading: TipTapNodeRenderers[TipTapNodeTypes.heading] = (children, { attrs }) => {
+  const variant: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' = `h${attrs?.level ?? 2}`;
+  return <Typography variant={variant}>{children}</Typography>;
+};
+
+export const getParagraph: TipTapNodeRenderers[TipTapNodeTypes.paragraph] = (children) => (
+  <Typography variant="body2">{children}</Typography>
+);
+
+type GetText = (renderers: TipTapMarkRenderers) => TipTapNodeRenderers[TipTapNodeTypes.text];
+
+export const getText: GetText = (renderers) => (node: TextNode) => renderText(renderers, node);

--- a/app/shared/components/tip-tap-content/renderNode.tsx
+++ b/app/shared/components/tip-tap-content/renderNode.tsx
@@ -1,0 +1,37 @@
+import { Fragment, ReactNode } from 'react';
+
+import { TipTapNodeTypes } from '~/types/enums/common.enums';
+import { TipTapNode, TipTapNodeRenderers } from '~/types/types/common.types';
+
+type RenderNode = (renderers: TipTapNodeRenderers, node: TipTapNode) => ReactNode;
+
+const mapChildren = (renderers: TipTapNodeRenderers, content: TipTapNode[]): ReactNode[] =>
+  content.map((n, idx) => <Fragment key={`${n.type}-${idx}`}>{renderNode(renderers, n)}</Fragment>);
+
+const renderNode: RenderNode = (renderers, node) => {
+  switch (node.type) {
+    case TipTapNodeTypes.doc: {
+      const children = mapChildren(renderers, node.content);
+      return renderers.doc(children, node);
+    }
+
+    case TipTapNodeTypes.heading: {
+      const children = node.content ? mapChildren(renderers, node.content) : null;
+      return renderers.heading(children, node);
+    }
+
+    case TipTapNodeTypes.paragraph: {
+      const children = node.content ? mapChildren(renderers, node.content) : null;
+      return renderers.paragraph(children, node);
+    }
+
+    case TipTapNodeTypes.text:
+      return renderers.text(node);
+
+    default: {
+      return null;
+    }
+  }
+};
+
+export default renderNode;

--- a/app/shared/components/tip-tap-content/renderText.tsx
+++ b/app/shared/components/tip-tap-content/renderText.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+
+import { Mark, TextNode, TipTapMarkRenderers } from '~/types/types/common.types';
+
+type RenderText = (renderers: TipTapMarkRenderers, node: TextNode) => ReactNode;
+
+const renderText: RenderText = (finalMarkRenderers, node) => {
+  let result = node.text as ReactNode;
+
+  node.marks?.forEach((mark) => {
+    const wrap = finalMarkRenderers[mark.type] as (n: ReactNode, m: Mark) => ReactNode;
+    if (wrap) {
+      result = wrap(result, mark);
+    }
+  });
+
+  return result;
+};
+
+export default renderText;

--- a/app/types/enums/common.enums.ts
+++ b/app/types/enums/common.enums.ts
@@ -8,17 +8,20 @@ export enum PositionEnum {
   Vertical = 'vertical',
   Center = 'center'
 }
+
 export enum IconButtonColorVariant {
   Primary = 'primary',
   Secondary = 'secondary',
   Tertiary = 'tertiary',
   Error = 'error'
 }
+
 export enum IconButtonVariant {
   filled = 'filled',
   outlined = 'outlined',
   icon = 'icon'
 }
+
 export enum SocialMediaTypes {
   Instagram = 'instagram',
   Facebook = 'facebook',
@@ -30,4 +33,18 @@ export enum SocialMediaTypes {
   Twitter = 'twitter',
   Whatsapp = 'whatsapp',
   AnotherMedia = 'anotherMedia'
+}
+
+export enum TipTapNodeTypes {
+  doc = 'doc',
+  heading = 'heading',
+  paragraph = 'paragraph',
+  text = 'text'
+}
+
+export enum TipTapMarkType {
+  bold = 'bold',
+  italic = 'italic',
+  underline = 'underline',
+  link = 'link'
 }

--- a/app/types/types/common.types.ts
+++ b/app/types/types/common.types.ts
@@ -1,4 +1,7 @@
 import { Breakpoint } from '@mui/material';
+import { ReactNode } from 'react';
+
+import { TipTapMarkType, TipTapNodeTypes } from '~/types/enums/common.enums';
 
 export interface ElementSizes {
   width: Partial<Record<Breakpoint, number>>;
@@ -19,3 +22,62 @@ export type Breakpoints = {
   isTablet: boolean;
   isMobile: boolean;
 };
+
+export interface BoldMark {
+  type: TipTapMarkType.bold;
+}
+
+export interface ItalicMark {
+  type: TipTapMarkType.italic;
+}
+
+export interface UnderlineMark {
+  type: TipTapMarkType.underline;
+}
+
+export interface LinkMark {
+  type: TipTapMarkType.link;
+  attrs?: { href?: string; target?: string; rel?: string; title?: string };
+}
+
+export type Mark = BoldMark | ItalicMark | UnderlineMark | LinkMark;
+
+export interface TextNode {
+  type: TipTapNodeTypes.text;
+  text: string;
+  marks?: Mark[];
+}
+
+export interface ParagraphNode {
+  type: TipTapNodeTypes.paragraph;
+  content?: TextNode[];
+}
+
+export interface HeadingNode {
+  type: TipTapNodeTypes.heading;
+  attrs?: { level?: 1 | 2 | 3 | 4 | 5 | 6 };
+  content?: TextNode[];
+}
+
+export type TipTapElement = HeadingNode | ParagraphNode;
+
+export interface TipTapDoc {
+  type: TipTapNodeTypes.doc;
+  content: TipTapElement[];
+}
+
+export type TipTapNode = TipTapDoc | HeadingNode | ParagraphNode | TextNode;
+
+export interface TipTapNodeRenderers {
+  [TipTapNodeTypes.doc]: (children: ReactNode, node: TipTapDoc) => ReactNode;
+  [TipTapNodeTypes.heading]: (children: ReactNode, node: HeadingNode) => ReactNode;
+  [TipTapNodeTypes.paragraph]: (children: ReactNode, node: ParagraphNode) => ReactNode;
+  [TipTapNodeTypes.text]: (node: TextNode) => ReactNode;
+}
+
+export interface TipTapMarkRenderers {
+  [TipTapMarkType.bold]: (children: ReactNode, mark: BoldMark) => ReactNode;
+  [TipTapMarkType.italic]: (children: ReactNode, mark: ItalicMark) => ReactNode;
+  [TipTapMarkType.underline]: (children: ReactNode, mark: UnderlineMark) => ReactNode;
+  [TipTapMarkType.link]: (children: ReactNode, mark: LinkMark) => ReactNode;
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,7 @@ const eslintConfig = [
       ],
       quotes: ['error', 'single'],
       semi: ['error', 'always'],
-      indent: ['error', 2],
+      indent: ['error', 2, { SwitchCase: 1 }],
       'no-console': 'warn',
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': [


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this PR and what was changed -->
The basic functionality of the TipTap library provided excessive wrappers, which made it very difficult to position elements on the page.
To solve this problem, a custom component was created to display TipTap content without using the library itself.

## How to use

<!-- Describe steps to test this PR locally or link to CI pipeline -->

The component supports standard rendering components, however, custom ones can be passed if necessary.

Before:
<img width="538" height="179" alt="image" src="https://github.com/user-attachments/assets/434e4c0d-2b8c-4a89-ad71-fbff6ce2ce2b" />

After (default use):
<img width="364" height="69" alt="image" src="https://github.com/user-attachments/assets/b8290e94-5d6e-4dc8-9592-36c75b36acc3" />

After (using with a custom component):
<img width="970" height="329" alt="image" src="https://github.com/user-attachments/assets/1375cce6-c396-483f-be07-b83dd9c380f3" />

Data structure:
<img width="1114" height="509" alt="image" src="https://github.com/user-attachments/assets/7a8bcb63-f42d-4636-8054-135f61ab3c53" />


## Result

<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->

Result with default components:
<img width="702" height="133" alt="image" src="https://github.com/user-attachments/assets/7bd2fb17-3830-4e97-8924-386a9661a0e9" />

Result with overwritten local component:
<img width="744" height="260" alt="image" src="https://github.com/user-attachments/assets/fe6100d1-40f7-46a3-91eb-5078636a22c1" />

## Checklist

- [x] Code compiles and runs correctly
- [ ] Tests pass successfully
- [] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
