### PR TITLE
Add responsive label to donation button

### DIFF
--- a/app/shared/components/Footer/Footer.tsx
+++ b/app/shared/components/Footer/Footer.tsx
@@ -54,6 +54,7 @@ export default async function Footer() {
             contactLabel={t('contactUsButton')}
             donation={{
               text: t('donationButton'),
+              shortText: t('donationButtonShort'),
               link: supportButtonLink
             }}
           />

--- a/app/shared/components/Footer/FooterContactAndSupport/DonationButton/DonationButton.test.tsx
+++ b/app/shared/components/Footer/FooterContactAndSupport/DonationButton/DonationButton.test.tsx
@@ -1,44 +1,76 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { ButtonData } from '../types';
 import DonationButton from './DonationButton';
+import { type ButtonData } from '~/types/types/common.types';
 
-jest.mock('@public/icons/donation-button.svg', () => ({
+import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
+
+jest.mock('~/components/svg-image/SvgImage', () => ({
   __esModule: true,
-  default: () => <svg data-testid="donation-icon" />
+  SvgImage: ({ alt, src }: { alt: string; src: string }) => <img data-testid="donation-icon" alt={alt} src={src} />
 }));
 
-const mockData: ButtonData = {
-  text: 'Donate Now',
-  link: '/donate'
-};
+jest.mock('~/ds-components/button/Button', () => ({
+  __esModule: true,
+  default: ({ label, startIcon }: { label: string; startIcon?: React.ReactNode }) => (
+    <button type="button">
+      {startIcon}
+      {label}
+    </button>
+  )
+}));
 
 jest.mock('~/i18n/navigation', () => ({
   Link: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>
 }));
 
-describe('DonationButton', () => {
-  beforeEach(() => {
-    render(<DonationButton data={mockData} />);
-  });
+jest.mock('~/shared/hooks/use-breakpoints/useBreakpoints', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
 
+const mockedUseBreakpoints = useBreakpoints as jest.Mock;
+
+describe('DonationButton', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should render the button with correct label', () => {
-    const button = screen.getByRole('button', { name: /donate now/i });
-    expect(button).toBeInTheDocument();
+  const baseData: ButtonData = {
+    text: 'Donate Now',
+    link: '/donate'
+  };
+
+  it('should render desktop label when not mobile', () => {
+    mockedUseBreakpoints.mockReturnValue({ isMobile: false });
+    render(<DonationButton data={baseData} />);
+    expect(screen.getByRole('button', { name: /donate now/i })).toBeInTheDocument();
   });
 
-  it('should render the donation icon with correct alt text', () => {
-    const icon = screen.getByAltText('Donation Button');
-    expect(icon).toBeInTheDocument();
+  it('should render shortText when mobile and shortText is provided', () => {
+    mockedUseBreakpoints.mockReturnValue({ isMobile: true });
+    const dataWithShort: ButtonData = { ...baseData, shortText: 'Donate' };
+    render(<DonationButton data={dataWithShort} />);
+    expect(screen.getByRole('button', { name: /donate$/i })).toBeInTheDocument();
   });
 
-  it('should have correct link in wrapper', () => {
-    const link = screen.getByRole('link');
-    expect(link).toHaveAttribute('href', '/donate');
+  it('should fallback to text when mobile and shortText is absent', () => {
+    mockedUseBreakpoints.mockReturnValue({ isMobile: true });
+    render(<DonationButton data={baseData} />);
+    expect(screen.getByRole('button', { name: /donate now/i })).toBeInTheDocument();
+  });
+
+  it('should render icon with correct alt text', () => {
+    mockedUseBreakpoints.mockReturnValue({ isMobile: false });
+    render(<DonationButton data={baseData} />);
+    expect(screen.getByAltText('Donation Button')).toBeInTheDocument();
+    expect(screen.getByTestId('donation-icon')).toBeInTheDocument();
+  });
+
+  it('should wrap button with correct link', () => {
+    mockedUseBreakpoints.mockReturnValue({ isMobile: false });
+    render(<DonationButton data={baseData} />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/donate');
   });
 });

--- a/app/shared/components/Footer/FooterContactAndSupport/DonationButton/DonationButton.tsx
+++ b/app/shared/components/Footer/FooterContactAndSupport/DonationButton/DonationButton.tsx
@@ -1,24 +1,31 @@
+'use client';
+
 import React from 'react';
 
 import { SvgImage } from '~/components/svg-image/SvgImage';
 import Button from '~/ds-components/button/Button';
 
-import { ButtonData } from '../types';
+import { type ButtonData } from '~/types/types/common.types';
 
 import { Link } from '~/i18n/navigation';
+import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
 
 type DonationDataProps = {
   data: ButtonData;
 };
 
 const DonationButton: React.FC<DonationDataProps> = ({ data }) => {
+  const { isMobile } = useBreakpoints();
+
+  const label = isMobile && data.shortText ? data.shortText : data.text;
+
   return (
     <Link href={data.link} passHref>
       <Button
         size="medium"
         variant="outlined"
         color="primary"
-        label={data.text}
+        label={label}
         startIcon={<SvgImage src="/icons/donation-button.svg" alt="Donation Button" width={24} height={24} />}
       />
     </Link>

--- a/app/shared/components/Footer/FooterContactAndSupport/FooterContactAndSupport.tsx
+++ b/app/shared/components/Footer/FooterContactAndSupport/FooterContactAndSupport.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ContactUsButton from './ContactUsButton/ContactUsButton';
 import DonationButton from './DonationButton/DonationButton';
 import { styles } from './FooterContactAndSupport.styles';
-import { ButtonData } from './types';
+import { type ButtonData } from '~/types/types/common.types';
 
 type FooterContactAndSupportProps = {
   contactLabel: string;

--- a/app/shared/components/Footer/FooterContactAndSupport/types.ts
+++ b/app/shared/components/Footer/FooterContactAndSupport/types.ts
@@ -1,4 +1,0 @@
-export type ButtonData = {
-  text: string;
-  link: string;
-};

--- a/app/types/types/common.types.ts
+++ b/app/types/types/common.types.ts
@@ -81,3 +81,8 @@ export interface TipTapMarkRenderers {
   [TipTapMarkType.underline]: (children: ReactNode, mark: UnderlineMark) => ReactNode;
   [TipTapMarkType.link]: (children: ReactNode, mark: LinkMark) => ReactNode;
 }
+export type ButtonData = {
+  text: string;
+  link: string;
+  shortText?: string;
+};

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -5,6 +5,7 @@
   },
   "footer": {
     "donationButton": "Support the Foundation",
+    "donationButtonShort": "Support",
     "contactUsButton": "Contact us",
     "opentechLabel": "Developed by",
     "phoneLabel": "Phone",

--- a/i18n/messages/uk.json
+++ b/i18n/messages/uk.json
@@ -5,6 +5,7 @@
   },
   "footer": {
     "donationButton": "Підтримати діяльність фундації",
+    "donationButtonShort": "Підтримати фундацію",
     "contactUsButton": "Напишіть нам",
     "opentechLabel": "Розроблено в",
     "phoneLabel": "Телефон",


### PR DESCRIPTION
## Description

This PR updates the `DonationButton` component to support a shorter label on mobile screens, according to the Figma design.  
- Updated `ButtonData` type to include an optional `shortText` field.  
- Modified `DonationButton` to display `shortText` when on mobile breakpoint, otherwise default to `text`.  
- Adjusted `FooterContactAndSupport` to pass both `text` and `shortText` from translations.  

## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [X] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## Video / Screenshots

<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->

## Checklist

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [X] Branch is up to date with the target branch
- [X] Linked issue/task included
- [X] Task moved to the review column on the board

---
