### PR TITLE
Define and Add Custom Typography Variants to Theme

### DIFF
--- a/app/constants/typography.ts
+++ b/app/constants/typography.ts
@@ -151,12 +151,5 @@ export const AppTypography: TypographyVariantsOptions = {
     fontSize: '14px',
     fontStyle: 'italic',
     lineHeight: '140%'
-  },
-  customBold25: {
-    fontFamily: 'Mulish',
-    fontWeight: 700,
-    fontSize: '25px',
-    lineHeight: '140%',
-    letterSpacing: '0px'
   }
 };

--- a/app/shared/components/design-system/all-components/theme/Theme.ts
+++ b/app/shared/components/design-system/all-components/theme/Theme.ts
@@ -43,7 +43,13 @@ declare module '@mui/material' {
     customItalic16: true;
     customItalic14: true;
     customSemiBold18: true;
-    customBold25: true;
+    customBold24Tight: true;
+    customMedium22: true;
+    customRegular20: true;
+    customRegular18Tight: true;
+    customMedium18Tight: true;
+    customRegular16: true;
+    customRegular14: true;
   }
 }
 declare module '@mui/material/styles' {
@@ -56,10 +62,15 @@ declare module '@mui/material/styles' {
     customBold16?: React.CSSProperties;
     customMedium16?: React.CSSProperties;
     customItalic16?: React.CSSProperties;
-    customCaption?: React.CSSProperties;
     customItalic14?: React.CSSProperties;
     customSemiBold18?: React.CSSProperties;
-    customBold25: React.CSSProperties;
+    customBold24Tight?: React.CSSProperties;
+    customMedium22?: React.CSSProperties;
+    customRegular20?: React.CSSProperties;
+    customRegular18Tight?: React.CSSProperties;
+    customMedium18Tight?: React.CSSProperties;
+    customRegular16?: React.CSSProperties;
+    customRegular14?: React.CSSProperties;
   }
   interface TypographyVariants {
     customBold32: React.CSSProperties;
@@ -70,10 +81,15 @@ declare module '@mui/material/styles' {
     customBold16: React.CSSProperties;
     customMedium16: React.CSSProperties;
     customItalic16: React.CSSProperties;
-    customCaption: React.CSSProperties;
     customItalic14: React.CSSProperties;
     customSemiBold18: React.CSSProperties;
-    customBold25: React.CSSProperties;
+    customBold24Tight: React.CSSProperties;
+    customMedium22: React.CSSProperties;
+    customRegular20: React.CSSProperties;
+    customRegular18Tight: React.CSSProperties;
+    customMedium18Tight: React.CSSProperties;
+    customRegular16: React.CSSProperties;
+    customRegular14: React.CSSProperties;
   }
 }
 
@@ -259,13 +275,6 @@ export const theme = createTheme({
       lineHeight: '140%',
       letterSpacing: '0px'
     },
-    customBold25: {
-      fontFamily: mulish.style.fontFamily,
-      fontWeight: 700,
-      fontSize: '25px',
-      lineHeight: '140%',
-      letterSpacing: '0px'
-    },
     customSemiBold18: {
       fontSize: '18px',
       fontWeight: 600,
@@ -331,6 +340,55 @@ export const theme = createTheme({
       lineHeight: '140%',
       letterSpacing: '0px',
       fontFamily: mulish.style.fontFamily
+    },
+    customBold24Tight: {
+      fontSize: '24px',
+      fontWeight: 700,
+      lineHeight: '120%',
+      letterSpacing: '0px',
+      fontFamily: mulish.style.fontFamily
+    },
+    customMedium22: {
+      fontSize: '22px',
+      fontWeight: 500,
+      lineHeight: '135%',
+      letterSpacing: '0px',
+      fontFamily: mulish.style.fontFamily
+    },
+    customRegular20: {
+      fontSize: '20px',
+      fontWeight: 400,
+      lineHeight: '140%',
+      letterSpacing: '0px',
+      fontFamily: mulish.style.fontFamily
+    },
+    customRegular18Tight: {
+      fontSize: '18px',
+      fontWeight: 400,
+      lineHeight: '135%',
+      letterSpacing: '0px',
+      fontFamily: mulish.style.fontFamily
+    },
+    customMedium18Tight: {
+      fontSize: '18px',
+      fontWeight: 500,
+      lineHeight: '135%',
+      letterSpacing: '0px',
+      fontFamily: mulish.style.fontFamily
+    },
+    customRegular16: {
+      fontSize: '16px',
+      fontWeight: 400,
+      lineHeight: '150%',
+      letterSpacing: '0px',
+      fontFamily: mulish.style.fontFamily
+    },
+    customRegular14: {
+      fontSize: '14px',
+      fontWeight: 400,
+      lineHeight: '140%',
+      letterSpacing: '0px',
+      fontFamily: mulish.style.fontFamily
     }
   },
   components: {
@@ -345,7 +403,14 @@ export const theme = createTheme({
           customBold16: 'p',
           customMedium16: 'p',
           customItalic16: 'p',
-          customItalic14: 'p'
+          customItalic14: 'p',
+          customBold24Tight: 'p',
+          customMedium22: 'p',
+          customRegular20: 'p',
+          customRegular18Tight: 'p',
+          customMedium18Tight: 'p',
+          customRegular16: 'p',
+          customRegular14: 'p'
         }
       }
     },
@@ -774,16 +839,16 @@ export const theme = createTheme({
         root: {
           borderRadius: '24px',
           width: '100%',
-          maxWidth: '744px',
+          maxWidth: '742px',
+          marginTop: '16px',
+          marginLeft: '16px',
           boxShadow: 'none',
           transition: 'all 0.3s ease',
           backgroundColor: accordionColorsRgb.summary.backgroundColor,
           color: accordionColorsRgb.summary.color,
           '&.Mui-expanded': {
+            backgroundColor: accordionColorsRgb.accordion.expanded.backgroundColor,
             color: accordionColorsRgb.accordion.expanded.color
-          },
-          '&:before': {
-            display: 'none'
           }
         }
       },
@@ -800,7 +865,10 @@ export const theme = createTheme({
           borderRadius: '24px',
           padding: '16px 16px 16px 24px',
           backgroundColor: accordionColorsRgb.summary.backgroundColor,
-          color: accordionColorsRgb.summary.color
+          color: accordionColorsRgb.summary.color,
+          '&.Mui-expanded': {
+            backgroundColor: accordionColorsRgb.summary.expanded.backgroundColor
+          }
         },
         content: {
           margin: 0
@@ -810,9 +878,9 @@ export const theme = createTheme({
     MuiAccordionDetails: {
       styleOverrides: {
         root: {
-          padding: '8px 64px 32px 40px',
+          padding: '16px 16px 16px 24px',
           borderRadius: '0 0 24px 24px',
-          backgroundColor: accordionColorsRgb.summary.backgroundColor,
+          backgroundColor: accordionColorsRgb.accordion.expanded.backgroundColor,
           color: accordionColorsRgb.accordion.expanded.color
         }
       }

--- a/app/shared/components/enhanced-table/control-panel/ControlPanel.tsx
+++ b/app/shared/components/enhanced-table/control-panel/ControlPanel.tsx
@@ -52,7 +52,7 @@ const CompositionsControlPanel = ({
       }}
     >
       <Box display="flex" justifyContent="space-between" alignItems="center" sx={{ width: '100%', mb: 2 }}>
-        <Typography variant={isExtraSmall ? 'customBold25' : 'customBold32'}>{tableName}</Typography>
+        <Typography variant={isExtraSmall ? 'customBold24Tight' : 'customBold32'}>{tableName}</Typography>
         {isMobile ? (
           <Box sx={{ marginRight: '30px' }}>
             <IconButton


### PR DESCRIPTION
## Description

Add missing typography styles used in the admin panel to the shared design system theme in lf-client. Introduced new MUI custom typography variants (sizes/weights/line-heights) for consistency and reuse; removed unused leftover declaration (customCaption). Updated interface augmentations and MuiTypography variant mapping.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Pull branch feature/56/custom-typography.
2. Run npm install if needed.
3 .Start app: npm run dev and navigate through pages using text styles (headings, buttons, modals, alerts).
4. Inspect elements using new variants (customBold24Tight, customMedium22, customRegular20, customRegular18Tight, customMedium18Tight, customRegular16, customRegular14) to ensure correct font-size, weight, and line-height.
5. Run tests: npm test (ensure only unrelated GA mock issue, if any, is resolved).
6. Verify no TypeScript errors regarding typography variants (try <Typography variant=\"customMedium22\">Test</Typography>).

## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
