### PR TITLE
Add reusable quote component

### DIFF
--- a/app/shared/components/excerpt-block/ExcerptBlock.styles.ts
+++ b/app/shared/components/excerpt-block/ExcerptBlock.styles.ts
@@ -1,0 +1,53 @@
+import { mainHexPallete } from '../design-system/all-components/theme/colors';
+
+const container = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(12, 1fr)'
+};
+
+export const styles = {
+  desktopView: {
+    ...container,
+    gridColumn: '1 / -1',
+    gridTemplateRows: 'repeat(6, auto)',
+    columnGap: '44px',
+    width: '100%',
+    position: 'relative'
+  },
+  mobileView: {
+    gridColumn: '1 / -1',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '18px'
+  },
+  quoteContainer: {
+    position: 'relative',
+    color: mainHexPallete.burgundy[800],
+    '&::before': {
+      content: '""',
+      display: 'block',
+      width: '24px',
+      height: '20px',
+      backgroundImage: 'url(/icons/quote.svg)',
+      backgroundSize: 'contain',
+      backgroundRepeat: 'no-repeat',
+      float: 'left',
+      marginRight: '32px'
+    }
+  },
+  icon: {
+    gridColumn: '1/2'
+  },
+  sourceText: (isTablet: boolean) => ({
+    gridColumn: isTablet ? '1/6' : '2/6',
+    position: 'absolute',
+    bottom: 0,
+    textAlign: 'right',
+    fontSize: '14px'
+  }),
+  quoteText: {
+    gridColumn: '6/-1',
+    color: mainHexPallete.burgundy[800],
+    textIndent: '112px'
+  }
+};

--- a/app/shared/components/excerpt-block/ExcerptBlock.test.tsx
+++ b/app/shared/components/excerpt-block/ExcerptBlock.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+
+import ExcerptBlock from './ExcerptBlock';
+
+import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
+
+jest.mock('~/shared/hooks/use-breakpoints/useBreakpoints', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+describe('ExcerptBlock', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders mobile view', () => {
+    (useBreakpoints as jest.Mock).mockReturnValue({ isMobile: true });
+
+    render(<ExcerptBlock quote="Some quote" source="Some source" />);
+
+    expect(screen.getByText('Some quote')).toBeInTheDocument();
+    expect(screen.getByText('Some source')).toBeInTheDocument();
+  });
+
+  it('renders desktop view', () => {
+    (useBreakpoints as jest.Mock).mockReturnValue({ isMobile: false });
+
+    render(<ExcerptBlock quote="Some quote" source="Some source" />);
+
+    expect(screen.getByText('Some quote')).toBeInTheDocument();
+    expect(screen.getByText('Some source')).toBeInTheDocument();
+    expect(screen.getByAltText('Quote icon')).toBeInTheDocument();
+  });
+  it('applies correct class for mobile', () => {
+    (useBreakpoints as jest.Mock).mockReturnValue({ isMobile: true });
+
+    render(<ExcerptBlock quote="Some quote" source="Some source" />);
+    const quote = screen.getByText('Some quote');
+    const source = screen.getByText('Some source');
+
+    expect(quote.className).toMatch(/MuiTypography-customItalic18/);
+    expect(source.className).toMatch(/MuiTypography-customItalic14/);
+  });
+
+  it('applies correct class for desktop', () => {
+    (useBreakpoints as jest.Mock).mockReturnValue({ isMobile: false });
+
+    render(<ExcerptBlock quote="Some quote" source="Some source" />);
+    const quote = screen.getByText('Some quote');
+    const source = screen.getByText('Some source');
+
+    expect(quote.className).toMatch(/MuiTypography-h5/);
+    expect(source.className).toMatch(/MuiTypography-customItalic14/);
+  });
+});

--- a/app/shared/components/excerpt-block/ExcerptBlock.tsx
+++ b/app/shared/components/excerpt-block/ExcerptBlock.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Box, Typography } from '@mui/material';
+
+import { SvgImage } from '../svg-image/SvgImage';
+import { styles } from './ExcerptBlock.styles';
+
+import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
+
+interface ExcerptBlockProps {
+  quote: string;
+  source: string;
+}
+
+export default function ExcerptBlock({ quote, source }: ExcerptBlockProps) {
+  const { isMobile, isTablet } = useBreakpoints();
+
+  return isMobile ? (
+    <Box sx={styles.mobileView}>
+      <Typography sx={styles.quoteContainer} variant="customItalic18" fontWeight={700}>
+        {quote}
+      </Typography>
+      <Typography variant="customItalic14" fontWeight={500}>
+        {source}
+      </Typography>
+    </Box>
+  ) : (
+    <Box sx={styles.desktopView}>
+      <Box sx={styles.icon}>
+        <SvgImage src="/icons/quote.svg" alt="Quote icon" width={40} height={34} />
+      </Box>
+
+      <Typography sx={styles.sourceText(isTablet)} variant="customItalic14" fontWeight={500}>
+        {source}
+      </Typography>
+      <Typography variant="h5" fontStyle={'italic'} sx={styles.quoteText}>
+        {quote}
+      </Typography>
+    </Box>
+  );
+}

--- a/public/icons/quote.svg
+++ b/public/icons/quote.svg
@@ -1,0 +1,3 @@
+<svg width="40" height="34" viewBox="0 0 40 34" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M33.4722 34H20.8333L28.75 0H40L33.4722 34ZM12.7778 34H0L8.05556 0H19.1667L12.7778 34Z" fill="#FCBD28"/>
+</svg>


### PR DESCRIPTION
## Description

Created ExcerptBlock component with responsive design, following the provided styles. Accepts quote and source props.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

```
      <ExcerptBlock
        quote="Я вже казав, що записався ще на два іспити. Обидві книжки я вже купив. Дуже великі і жахливо гидкі книжки. Особливо римське право. Такої гидоти я ще ніколи в житті не бачив! Ох уже ці римляни!"
        source="Лист Бориса Лятошинського Маргариті Царевич, 5 травня 1916. Саратов"
      />

```
## Video / Screenshots

https://github.com/user-attachments/assets/a2018e84-517d-4aa3-92ca-729c7d485b67



## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
