### PR TITLE
(SP: 0.5) Fixed markup on support-us page

### DIFF
--- a/app/shared/components/blocks/support-foundation/SupportFoundation.styles.ts
+++ b/app/shared/components/blocks/support-foundation/SupportFoundation.styles.ts
@@ -1,19 +1,29 @@
 export const styles = {
   wrapper: {
+    display: 'grid',
+    gridTemplateColumns: 'subgrid',
+    gridColumn: '1 / -1',
     mt: '120px'
   },
 
   sectionTitle: {
-    mb: '34px'
+    mb: '34px',
+    gridColumn: '1 / -1'
   },
 
   donationSection: {
-    display: 'flex',
-    gap: '182px'
+    display: 'grid',
+    gridColumn: '1 / -1',
+    gridTemplateColumns: 'subgrid'
   },
 
   donationFormWrapper: {
-    pt: '43px'
+    pt: '43px',
+    gridColumn: '1 / 6'
+  },
+
+  infoSection: {
+    gridColumn: '7 / -1'
   },
 
   sectionSubtitle: {

--- a/app/shared/components/blocks/support-foundation/SupportFoundation.tsx
+++ b/app/shared/components/blocks/support-foundation/SupportFoundation.tsx
@@ -21,7 +21,7 @@ function SupportFoundation() {
         <Box sx={styles.donationFormWrapper}>
           <DonationForm />
         </Box>
-        <Box>
+        <Box sx={styles.infoSection}>
           <Typography variant="body2" sx={styles.sectionSubtitle}>
             {t.rich('subTitle', { b: bold })}
           </Typography>


### PR DESCRIPTION
## Description

Fixed markup on support-us page. Updated `SupportFoundation` component so it uses grid instead of flex which fixes the issue.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

Go to: http://localhost:3000/uk/support-us

## Video / Screenshots

https://github.com/user-attachments/assets/23b868c5-6d55-4fd4-9bf7-5cce0ad276fd

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
