### PR TITLE
Draft and publish page download

### DIFF
--- a/app/[lang]/page.test.tsx
+++ b/app/[lang]/page.test.tsx
@@ -2,6 +2,10 @@ import { render, screen } from '@testing-library/react';
 
 import Home from './page';
 
+jest.mock('next/headers', () => ({
+  draftMode: jest.fn(() => ({ isEnabled: false }))
+}));
+
 jest.mock('~/components/blocks/Liatoshynsky-office/LiatoshynskyOffice', () => {
   const MockLiatoshynskyOffice = () => <div>Liatoshynsky office</div>;
   MockLiatoshynskyOffice.displayName = 'MockLiatoshynskyOffice';
@@ -21,15 +25,15 @@ jest.mock('~/components/blocks/our-mission/OurMission', () => {
 });
 
 jest.mock('~/components/blocks/IntroSection/IntroSection', () => {
-  const MockAboutFoundation = () => <div>Intro section</div>;
-  MockAboutFoundation.displayName = 'MockIntroSection';
-  return MockAboutFoundation;
+  const MockIntroSection = () => <div>Intro section</div>;
+  MockIntroSection.displayName = 'MockIntroSection';
+  return MockIntroSection;
 });
 
 jest.mock('~/components/blocks/FoundationInfo/FoundationInfo', () => {
-  const MockOurGoals = () => <div>Foundation info</div>;
-  MockOurGoals.displayName = 'MockFoundationInfo';
-  return MockOurGoals;
+  const MockFoundationInfo = () => <div>Foundation info</div>;
+  MockFoundationInfo.displayName = 'MockFoundationInfo';
+  return MockFoundationInfo;
 });
 
 jest.mock('~/components/blocks/our-goals/OurGoals', () => {
@@ -47,7 +51,18 @@ jest.mock('~/components/blocks/what-we-do/WhatWeDo', () => {
 jest.mock('~/di/container', () => ({
   createRequestContainer: () => ({
     resolve: () => ({
-      getPageData: jest.fn().mockResolvedValue({
+      getPublishedPageData: jest.fn().mockResolvedValue({
+        blocks: {
+          IntroSection: {},
+          FoundationInfo: {},
+          OurMission: {},
+          OurGoals: {},
+          LiatoshynskyOffice: {},
+          WhatWeDo: {},
+          FoundationFounders: {}
+        }
+      }),
+      getDraftPageData: jest.fn().mockResolvedValue({
         blocks: {
           IntroSection: {},
           FoundationInfo: {},
@@ -69,7 +84,7 @@ jest.mock('next-intl/server', () => ({
 
 describe('Home component', () => {
   it('should render Home component correctly', async () => {
-    render(await Home({ params: Promise.resolve({ lang: 'en' }) }));
+    render(await Home({ params: Promise.resolve({ lang: 'en' }) } as any));
 
     expect(screen.getByText(/Our mission/i)).toBeInTheDocument();
     expect(screen.getByText(/Liatoshynsky office/i)).toBeInTheDocument();

--- a/app/[lang]/page.test.tsx
+++ b/app/[lang]/page.test.tsx
@@ -3,66 +3,55 @@ import { render, screen } from '@testing-library/react';
 import Home from './page';
 
 jest.mock('next/headers', () => ({
-  draftMode: jest.fn(() => ({ isEnabled: false }))
+  draftMode: jest.fn().mockResolvedValue({ isEnabled: false })
 }));
 
 jest.mock('~/components/blocks/Liatoshynsky-office/LiatoshynskyOffice', () => {
-  const MockLiatoshynskyOffice = () => <div>Liatoshynsky office</div>;
-  MockLiatoshynskyOffice.displayName = 'MockLiatoshynskyOffice';
-  return MockLiatoshynskyOffice;
+  const Mock = () => <div>Liatoshynsky office</div>;
+  Mock.displayName = 'MockLiatoshynskyOffice';
+  return Mock;
 });
 
 jest.mock('~/components/blocks/FoundationFounders/FoundationFounders', () => {
-  const MockFoundationFounders = () => <div>Foundation founders</div>;
-  MockFoundationFounders.displayName = 'MockFoundationFounders';
-  return MockFoundationFounders;
+  const Mock = () => <div>Foundation founders</div>;
+  Mock.displayName = 'MockFoundationFounders';
+  return Mock;
 });
 
 jest.mock('~/components/blocks/our-mission/OurMission', () => {
-  const MockOurMission = () => <div>Our mission</div>;
-  MockOurMission.displayName = 'MockOurMission';
-  return MockOurMission;
+  const Mock = () => <div>Our mission</div>;
+  Mock.displayName = 'MockOurMission';
+  return Mock;
 });
 
 jest.mock('~/components/blocks/IntroSection/IntroSection', () => {
-  const MockIntroSection = () => <div>Intro section</div>;
-  MockIntroSection.displayName = 'MockIntroSection';
-  return MockIntroSection;
+  const Mock = () => <div>Intro section</div>;
+  Mock.displayName = 'MockIntroSection';
+  return Mock;
 });
 
 jest.mock('~/components/blocks/FoundationInfo/FoundationInfo', () => {
-  const MockFoundationInfo = () => <div>Foundation info</div>;
-  MockFoundationInfo.displayName = 'MockFoundationInfo';
-  return MockFoundationInfo;
+  const Mock = () => <div>Foundation info</div>;
+  Mock.displayName = 'MockFoundationInfo';
+  return Mock;
 });
 
 jest.mock('~/components/blocks/our-goals/OurGoals', () => {
-  const MockOurGoals = () => <div>Our goals</div>;
-  MockOurGoals.displayName = 'MockOurGoals';
-  return MockOurGoals;
+  const Mock = () => <div>Our goals</div>;
+  Mock.displayName = 'MockOurGoals';
+  return Mock;
 });
 
 jest.mock('~/components/blocks/what-we-do/WhatWeDo', () => {
-  const MockWhatWeDo = () => <div>What we do</div>;
-  MockWhatWeDo.displayName = 'MockWhatWeDo';
-  return MockWhatWeDo;
+  const Mock = () => <div>What we do</div>;
+  Mock.displayName = 'MockWhatWeDo';
+  return Mock;
 });
 
 jest.mock('~/di/container', () => ({
   createRequestContainer: () => ({
     resolve: () => ({
-      getPublishedPageData: jest.fn().mockResolvedValue({
-        blocks: {
-          IntroSection: {},
-          FoundationInfo: {},
-          OurMission: {},
-          OurGoals: {},
-          LiatoshynskyOffice: {},
-          WhatWeDo: {},
-          FoundationFounders: {}
-        }
-      }),
-      getDraftPageData: jest.fn().mockResolvedValue({
+      getPageData: jest.fn().mockResolvedValue({
         blocks: {
           IntroSection: {},
           FoundationInfo: {},
@@ -84,7 +73,8 @@ jest.mock('next-intl/server', () => ({
 
 describe('Home component', () => {
   it('should render Home component correctly', async () => {
-    render(await Home({ params: Promise.resolve({ lang: 'en' }) } as any));
+    const ui = await Home({ params: Promise.resolve({ lang: 'en' }) });
+    render(ui);
 
     expect(screen.getByText(/Our mission/i)).toBeInTheDocument();
     expect(screen.getByText(/Liatoshynsky office/i)).toBeInTheDocument();

--- a/app/[lang]/page.test.tsx
+++ b/app/[lang]/page.test.tsx
@@ -11,77 +11,115 @@ jest.mock('~/components/blocks/Liatoshynsky-office/LiatoshynskyOffice', () => {
   Mock.displayName = 'MockLiatoshynskyOffice';
   return Mock;
 });
-
 jest.mock('~/components/blocks/FoundationFounders/FoundationFounders', () => {
   const Mock = () => <div>Foundation founders</div>;
   Mock.displayName = 'MockFoundationFounders';
   return Mock;
 });
-
 jest.mock('~/components/blocks/our-mission/OurMission', () => {
   const Mock = () => <div>Our mission</div>;
   Mock.displayName = 'MockOurMission';
   return Mock;
 });
-
 jest.mock('~/components/blocks/IntroSection/IntroSection', () => {
   const Mock = () => <div>Intro section</div>;
   Mock.displayName = 'MockIntroSection';
   return Mock;
 });
-
 jest.mock('~/components/blocks/FoundationInfo/FoundationInfo', () => {
   const Mock = () => <div>Foundation info</div>;
   Mock.displayName = 'MockFoundationInfo';
   return Mock;
 });
-
 jest.mock('~/components/blocks/our-goals/OurGoals', () => {
   const Mock = () => <div>Our goals</div>;
   Mock.displayName = 'MockOurGoals';
   return Mock;
 });
-
 jest.mock('~/components/blocks/what-we-do/WhatWeDo', () => {
   const Mock = () => <div>What we do</div>;
   Mock.displayName = 'MockWhatWeDo';
   return Mock;
 });
 
-jest.mock('~/di/container', () => ({
-  createRequestContainer: () => ({
-    resolve: () => ({
-      getPageData: jest.fn().mockResolvedValue({
-        blocks: {
-          IntroSection: {},
-          FoundationInfo: {},
-          OurMission: {},
-          OurGoals: {},
-          LiatoshynskyOffice: {},
-          WhatWeDo: {},
-          FoundationFounders: {}
-        }
-      })
-    })
-  })
-}));
-
 jest.mock('next-intl/server', () => ({
   setRequestLocale: jest.fn(),
-  getTranslations: jest.fn().mockResolvedValue((key: string) => key)
+  getTranslations: jest.fn().mockResolvedValue((k: string) => k)
 }));
 
-describe('Home component', () => {
-  it('should render Home component correctly', async () => {
+jest.mock('~/di/container', () => {
+  const liveGetPageData = jest.fn().mockResolvedValue({
+    blocks: {
+      IntroSection: {},
+      FoundationInfo: {},
+      OurMission: {},
+      OurGoals: {},
+      LiatoshynskyOffice: {},
+      WhatWeDo: {},
+      FoundationFounders: {}
+    }
+  });
+  const draftGetPageData = jest.fn().mockResolvedValue({
+    blocks: {
+      IntroSection: {},
+      FoundationInfo: {},
+      OurMission: {},
+      OurGoals: {},
+      LiatoshynskyOffice: {},
+      WhatWeDo: {},
+      FoundationFounders: {}
+    }
+  });
+
+  const pagesDataService = { getPageData: liveGetPageData };
+  const draftPagesDataService = { getPageData: draftGetPageData };
+
+  return {
+    __esModule: true,
+    __pagesDataService: pagesDataService,
+    __draftPagesDataService: draftPagesDataService,
+    createRequestContainer: () => ({
+      resolve: (token: string) => {
+        if (token === 'draftPagesDataService') return draftPagesDataService;
+        if (token === 'pagesDataService') return pagesDataService;
+        return {};
+      }
+    })
+  };
+});
+
+describe('Home page', () => {
+  const { draftMode } = jest.requireMock('next/headers');
+  const { __pagesDataService, __draftPagesDataService } = jest.requireMock('~/di/container') as {
+    __pagesDataService: { getPageData: jest.Mock };
+    __draftPagesDataService: { getPageData: jest.Mock };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses pagesDataService when draftMode is disabled', async () => {
+    (draftMode as jest.Mock).mockResolvedValueOnce({ isEnabled: false });
+
     const ui = await Home({ params: Promise.resolve({ lang: 'en' }) });
     render(ui);
 
     expect(screen.getByText(/Our mission/i)).toBeInTheDocument();
-    expect(screen.getByText(/Liatoshynsky office/i)).toBeInTheDocument();
-    expect(screen.getByText(/Foundation founders/i)).toBeInTheDocument();
-    expect(screen.getByText(/Intro section/i)).toBeInTheDocument();
-    expect(screen.getByText(/Foundation info/i)).toBeInTheDocument();
-    expect(screen.getByText(/Our goals/i)).toBeInTheDocument();
-    expect(screen.getByText(/What we do/i)).toBeInTheDocument();
+    expect(__pagesDataService.getPageData).toHaveBeenCalledTimes(1);
+    expect(__pagesDataService.getPageData).toHaveBeenCalledWith('about-us', 'en');
+    expect(__draftPagesDataService.getPageData).not.toHaveBeenCalled();
+  });
+
+  it('uses draftPagesDataService when draftMode is enabled', async () => {
+    (draftMode as jest.Mock).mockResolvedValueOnce({ isEnabled: true });
+
+    const ui = await Home({ params: Promise.resolve({ lang: 'uk' }) });
+    render(ui);
+
+    expect(screen.getByText(/Our mission/i)).toBeInTheDocument();
+    expect(__draftPagesDataService.getPageData).toHaveBeenCalledTimes(1);
+    expect(__draftPagesDataService.getPageData).toHaveBeenCalledWith('about-us', 'uk');
+    expect(__pagesDataService.getPageData).not.toHaveBeenCalled();
   });
 });

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -27,11 +27,12 @@ export default async function Home({ params }: Readonly<Language>) {
   setRequestLocale(lang);
 
   const { isEnabled } = await draftMode();
-
-  const pageService = await createRequestContainer().resolve('pageService');
+  const container = createRequestContainer();
+  const pagesDataService = container.resolve('pagesDataService');
+  const draftPagesDataService = container.resolve('draftPagesDataService');
 
   const [page, t] = await Promise.all([
-    isEnabled ? pageService.getDraftPageData('about-us', lang) : pageService.getPublishedPageData('about-us', lang),
+    isEnabled ? draftPagesDataService.getPageData('about-us', lang) : pagesDataService.getPageData('about-us', lang),
     getTranslations('home.liatoshynskyOffice')
   ]);
 

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@mui/material';
+import { draftMode } from 'next/headers';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import React from 'react';
 
@@ -25,16 +26,16 @@ export default async function Home({ params }: Readonly<Language>) {
   const { lang } = await params;
   setRequestLocale(lang);
 
+  const { isEnabled } = await draftMode();
+
   const pageService = await createRequestContainer().resolve('pageService');
 
   const [page, t] = await Promise.all([
-    pageService.getPageData('about-us', lang),
+    isEnabled ? pageService.getDraftPageData('about-us', lang) : pageService.getPublishedPageData('about-us', lang),
     getTranslations('home.liatoshynskyOffice')
   ]);
 
-  if (!page) {
-    return <Box />;
-  }
+  if (!page) return <Box />;
 
   return (
     <>

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -28,11 +28,13 @@ export default async function Home({ params }: Readonly<Language>) {
 
   const { isEnabled } = await draftMode();
   const container = createRequestContainer();
-  const pagesDataService = container.resolve('pagesDataService');
-  const draftPagesDataService = container.resolve('draftPagesDataService');
+
+  const selectedPagesService = isEnabled
+    ? container.resolve('draftPagesDataService')
+    : container.resolve('pagesDataService');
 
   const [page, t] = await Promise.all([
-    isEnabled ? draftPagesDataService.getPageData('about-us', lang) : pagesDataService.getPageData('about-us', lang),
+    selectedPagesService.getPageData('about-us', lang),
     getTranslations('home.liatoshynskyOffice')
   ]);
 

--- a/app/di/modules/composedServices.module.ts
+++ b/app/di/modules/composedServices.module.ts
@@ -3,6 +3,10 @@ import { asFunction } from 'awilix';
 import { createArtistryService } from '~/services/composed/artistry-service/artistryService';
 import { createFooterService } from '~/services/composed/footer-service/footerService';
 import { createHeaderService } from '~/services/composed/header-service/headerService';
+import {
+  createDraftPagesDataService,
+  createPagesDataService
+} from '~/services/composed/pages-data-service/pagesDataService';
 import { createScientificWorksService } from '~/services/composed/scientific-works-service/scientificWorks';
 import { createAzureStorageService } from '~/services/composed/upload-service/upload';
 
@@ -16,9 +20,14 @@ export const registerComposedServices = () => ({
   ).scoped(),
 
   artistryService: asFunction(({ compositionService }) => createArtistryService({ compositionService })).scoped(),
+
   scientificService: asFunction(({ scientificWorksService }) =>
     createScientificWorksService({ scientificWorksService })
   ).scoped(),
 
-  uploadService: asFunction(createAzureStorageService).singleton()
+  uploadService: asFunction(createAzureStorageService).singleton(),
+
+  pagesDataService: asFunction(({ pagesService }) => createPagesDataService(pagesService)).scoped(),
+
+  draftPagesDataService: asFunction(({ draftPagesService }) => createDraftPagesDataService(draftPagesService)).scoped()
 });

--- a/app/di/modules/coreService.module.ts
+++ b/app/di/modules/coreService.module.ts
@@ -1,9 +1,9 @@
 import { asFunction } from 'awilix';
 
-import { createPagesDataService } from '~/services/composed/pages-data-service/pagesDataService';
 import { createCompositionService } from '~/services/core/compositionService';
 import { createFoundationInfoService } from '~/services/core/foundationInfoService';
 import { createNavigationService } from '~/services/core/navigationService';
+import { createDraftPagesService, createPagesService } from '~/services/core/pagesDataService';
 import { createScientificWorksService } from '~/services/core/scientificWorksService';
 
 export const registerCoreServices = () => ({
@@ -21,5 +21,7 @@ export const registerCoreServices = () => ({
     createScientificWorksService(scientificWorksRepository)
   ).scoped(),
 
-  pageService: asFunction(createPagesDataService).scoped()
+  pagesService: asFunction(({ pagesDataRepository }) => createPagesService(pagesDataRepository)).scoped(),
+
+  draftPagesService: asFunction(({ pagesDataRepository }) => createDraftPagesService(pagesDataRepository)).scoped()
 });

--- a/app/domain/repositories/pagesData.repository.ts
+++ b/app/domain/repositories/pagesData.repository.ts
@@ -5,5 +5,6 @@ import { PageSchema as PageZodSchema } from '~/validators/pagesSchemas/pages';
 export type PageDto = z.infer<typeof PageZodSchema>;
 
 export type PagesDataRepository = {
-  getBySlugAndStatus: (slug: string, status: 'draft' | 'published') => Promise<PageDto | null>;
+  getBySlug: (slug: string) => Promise<PageDto | null>;
+  getDraftBySlug: (slug: string) => Promise<PageDto | null>;
 };

--- a/app/domain/repositories/pagesData.repository.ts
+++ b/app/domain/repositories/pagesData.repository.ts
@@ -1,5 +1,9 @@
-import type { PageDataDTO } from '~/domain/dto/pagesData.dto';
+import { z } from 'zod';
+
+import { PageSchema as PageZodSchema } from '~/validators/pagesSchemas/pages';
+
+export type PageDto = z.infer<typeof PageZodSchema>;
 
 export type PagesDataRepository = {
-  getPageData(slug: string): Promise<PageDataDTO>;
+  getBySlugAndStatus: (slug: string, status: 'draft' | 'published') => Promise<PageDto | null>;
 };

--- a/app/infrastructure/models/pages/draftPages.model.ts
+++ b/app/infrastructure/models/pages/draftPages.model.ts
@@ -1,0 +1,40 @@
+import mongoose, { Document, Model, Schema } from 'mongoose';
+
+import { PageStatus } from '~/types/enums/common.enums';
+
+import { Page as PageType } from '~/validators/pagesSchemas/pages';
+
+export interface IDraftPageDocument extends Omit<PageType, '_id'>, Document {}
+
+const draftPageBaseSchema = new Schema(
+  {
+    slug: { type: String, required: true, unique: true, index: true },
+    title: { uk: String, en: String },
+    status: { type: String, enum: [PageStatus.Draft], required: true, default: PageStatus.Draft }
+  },
+  {
+    timestamps: true,
+    collection: 'draftpages',
+    discriminatorKey: 'pageType'
+  }
+);
+
+const DraftPageModel: Model<IDraftPageDocument> =
+  mongoose.models.DraftPage || mongoose.model<IDraftPageDocument>('DraftPage', draftPageBaseSchema);
+
+const draftAboutUsDetailsSchema = new Schema({
+  blocks: { type: Schema.Types.Mixed, required: true }
+});
+
+const draftPrivacyPolicySchema = new Schema({
+  blocks: { type: Schema.Types.Mixed, required: true }
+});
+
+export const DraftAboutUsPageModel =
+  mongoose.models.DraftAboutUsPage || DraftPageModel.discriminator('DraftAboutUsPage', draftAboutUsDetailsSchema);
+
+export const DraftPrivacyPolicyModel =
+  mongoose.models.DraftPrivacyPolicyPage ||
+  DraftPageModel.discriminator('DraftPrivacyPolicyPage', draftPrivacyPolicySchema);
+
+export default DraftPageModel;

--- a/app/infrastructure/models/pages/pages.ts
+++ b/app/infrastructure/models/pages/pages.ts
@@ -4,9 +4,9 @@ import { Page as PageType } from '~/validators/pagesSchemas/pages';
 
 export interface IPageDocument extends Omit<PageType, '_id'>, Document {}
 
-const pageBaseSchema = new Schema(
+const pageBaseSchema = new Schema<IPageDocument>(
   {
-    slug: { type: String, required: true, unique: true, index: true },
+    slug: { type: String, required: true, index: true },
     title: { uk: String, en: String },
     status: { type: String, enum: ['draft', 'published'], required: true, default: 'draft' }
   },
@@ -17,13 +17,17 @@ const pageBaseSchema = new Schema(
   }
 );
 
+pageBaseSchema.index({ slug: 1, status: 1 }, { unique: true, name: 'slug_1_status_1' });
+
 const PageModel: Model<IPageDocument> = mongoose.models.Page || mongoose.model<IPageDocument>('Page', pageBaseSchema);
 
 const aboutUsDetailsSchema = new Schema({
   blocks: { type: Schema.Types.Mixed, required: true }
 });
 
-const privacyPolicySchema = new Schema({ blocks: { type: Schema.Types.Mixed, required: true } });
+const privacyPolicySchema = new Schema({
+  blocks: { type: Schema.Types.Mixed, required: true }
+});
 
 export const AboutUsPageModel =
   mongoose.models.AboutUsPage || PageModel.discriminator('AboutUsPage', aboutUsDetailsSchema);

--- a/app/infrastructure/models/pages/pages.ts
+++ b/app/infrastructure/models/pages/pages.ts
@@ -1,14 +1,16 @@
 import mongoose, { Document, Model, Schema } from 'mongoose';
 
+import { PageStatus } from '~/types/enums/common.enums';
+
 import { Page as PageType } from '~/validators/pagesSchemas/pages';
 
 export interface IPageDocument extends Omit<PageType, '_id'>, Document {}
 
-const pageBaseSchema = new Schema<IPageDocument>(
+const pageBaseSchema = new Schema(
   {
-    slug: { type: String, required: true, index: true },
+    slug: { type: String, required: true, unique: true, index: true },
     title: { uk: String, en: String },
-    status: { type: String, enum: ['draft', 'published'], required: true, default: 'draft' }
+    status: { type: String, enum: [PageStatus.Published], required: true, default: PageStatus.Published }
   },
   {
     timestamps: true,
@@ -16,8 +18,6 @@ const pageBaseSchema = new Schema<IPageDocument>(
     discriminatorKey: 'pageType'
   }
 );
-
-pageBaseSchema.index({ slug: 1, status: 1 }, { unique: true, name: 'slug_1_status_1' });
 
 const PageModel: Model<IPageDocument> = mongoose.models.Page || mongoose.model<IPageDocument>('Page', pageBaseSchema);
 

--- a/app/infrastructure/repositories/pages-data/pagesData.repository.ts
+++ b/app/infrastructure/repositories/pages-data/pagesData.repository.ts
@@ -3,9 +3,9 @@ import PageModel from '~/infrastructure/models/pages/pages';
 import { PageSchema as PageZodSchema } from '~/validators/pagesSchemas/pages';
 
 export const pagesDataRepository = {
-  async getPageData(slug: string) {
+  async getBySlugAndStatus(slug: string, status: 'draft' | 'published') {
     await dbConnect();
-    const page = await PageModel.findOne({ slug }).lean().exec();
+    const page = await PageModel.findOne({ slug, status }).lean().exec();
     if (!page) return null;
     return PageZodSchema.parse(page);
   }

--- a/app/infrastructure/repositories/pages-data/pagesData.repository.ts
+++ b/app/infrastructure/repositories/pages-data/pagesData.repository.ts
@@ -1,12 +1,18 @@
+import { PageStatus } from '~/types/enums/common.enums';
+
 import dbConnect from '~/infrastructure/db/connect';
+import DraftPageModel from '~/infrastructure/models/pages/draftPages.model';
 import PageModel from '~/infrastructure/models/pages/pages';
 import { PageSchema as PageZodSchema } from '~/validators/pagesSchemas/pages';
 
+const getBySlugFactory = (model: typeof PageModel, status: PageStatus) => async (slug: string) => {
+  await dbConnect();
+  const page = await model.findOne({ slug, status }).lean().exec();
+  if (!page) return null;
+  return PageZodSchema.parse(page);
+};
+
 export const pagesDataRepository = {
-  async getBySlugAndStatus(slug: string, status: 'draft' | 'published') {
-    await dbConnect();
-    const page = await PageModel.findOne({ slug, status }).lean().exec();
-    if (!page) return null;
-    return PageZodSchema.parse(page);
-  }
+  getBySlug: getBySlugFactory(PageModel, PageStatus.Published),
+  getDraftBySlug: getBySlugFactory(DraftPageModel, PageStatus.Draft)
 };

--- a/app/infrastructure/repositories/pages-data/pagesData.test.ts
+++ b/app/infrastructure/repositories/pages-data/pagesData.test.ts
@@ -1,6 +1,9 @@
+import { PageStatus } from '~/types/enums/common.enums';
+
+import DraftPageModel from '~/infrastructure/models/pages/draftPages.model';
 import PageModel from '~/infrastructure/models/pages/pages';
 import { pagesDataRepository } from '~/infrastructure/repositories/pages-data/pagesData.repository';
-import { PageSchema } from '~/validators/pagesSchemas/pages';
+import { PageSchema as PageZodSchema } from '~/validators/pagesSchemas/pages';
 
 jest.mock('~/infrastructure/db/connect', () => ({
   __esModule: true,
@@ -9,125 +12,123 @@ jest.mock('~/infrastructure/db/connect', () => ({
 
 jest.mock('~/infrastructure/models/pages/pages', () => ({
   __esModule: true,
-  default: {
-    findOne: jest.fn()
-  }
+  default: { findOne: jest.fn() }
+}));
+
+jest.mock('~/infrastructure/models/pages/draftPages.model', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn() }
 }));
 
 jest.mock('~/validators/pagesSchemas/pages', () => ({
   ...jest.requireActual('~/validators/pagesSchemas/pages'),
-  PageSchema: {
-    parse: jest.fn()
-  }
+  PageSchema: { parse: jest.fn() }
 }));
 
-const mockedParse = PageSchema.parse as jest.Mock;
-const mockedFindOne = PageModel.findOne as jest.Mock;
+const mockedParse = PageZodSchema.parse as jest.Mock;
+const mockedFindOnePublished = (PageModel as unknown as { findOne: jest.Mock }).findOne;
+const mockedFindOneDraft = (DraftPageModel as unknown as { findOne: jest.Mock }).findOne;
 
 describe('pagesDataRepository', () => {
+  const slug = 'about-us';
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  const slug = 'about-us';
-
-  it('should return parsed page data when found and valid', async () => {
-    const mockDbData = {
-      _id: 'db_id',
-      pageType: 'AboutUsPage',
-      slug,
-      title: { uk: 'Про нас', en: 'About Us' },
-      status: 'published',
-      blocks: {
-        IntroSection: {
-          title: { uk: 'Вступ', en: 'Introduction' },
-          image: { url: 'intro.jpg', alt: { uk: 'Вступне зображення', en: 'Intro image' } },
-          quote: { text: { uk: 'Цитата', en: 'Quote' }, author: { uk: 'Автор', en: 'Author' } }
-        },
-        FoundationInfo: {
-          ourOrganisation: { content: 'Org content' },
-          ourName: { content: 'Name content' },
-          ourBelief: { content: 'Belief content' },
-          image: { url: 'foundation.jpg', alt: { uk: 'Фундація', en: 'Foundation' } }
-        },
-        OurMission: {
-          title: { uk: 'Наша місія', en: 'Our Mission' },
-          smallImage: { url: 'small.jpg', alt: { uk: 'Мале зображення', en: 'Small image' } },
-          bigImage: { url: 'big.jpg', alt: { uk: 'Велике зображення', en: 'Big image' } },
-          list: [{ content: 'Mission item' }]
-        },
-        OurGoals: {
-          title: { uk: 'Наші цілі', en: 'Our Goals' },
-          goals: [{ title: { uk: 'Ціль', en: 'Goal' }, description: { content: 'Goal desc' } }]
-        },
-        LiatoshynskyOffice: {
-          quote: { text: { uk: 'Офіс цитата', en: 'Office quote' }, author: { uk: 'Автор', en: 'Author' } }
-        },
-        WhatWeDo: {
-          title: { uk: 'Що,we do', en: 'What We Do' },
-          items: [{ title: { uk: 'Пункт', en: 'Item' }, description: { content: 'Item desc' } }]
-        },
-        FoundationFounders: {
-          titleText: { content: 'Founders intro' },
-          listTitle: { uk: 'Засновники', en: 'Founders' },
-          members: [
-            {
-              photo: { url: 'member.jpg', alt: { uk: 'Фото', en: 'Photo' } },
-              name: { uk: 'Імʼя', en: 'Name' },
-              description: { uk: 'Опис', en: 'Description' }
-            }
-          ]
-        }
-      },
-      createdAt: new Date(),
-      updatedAt: new Date()
-    };
-
-    const mockParsedData = { ...mockDbData };
+  it('should return parsed published page when found and valid', async () => {
+    const mockDbData = { _id: 'db_id', slug, pageType: 'AboutUsPage', status: PageStatus.Published, blocks: {} };
+    const mockParsed = { ...mockDbData };
 
     const execMock = jest.fn().mockResolvedValue(mockDbData);
     const leanMock = jest.fn().mockReturnValue({ exec: execMock });
-    mockedFindOne.mockReturnValue({ lean: leanMock });
+    mockedFindOnePublished.mockReturnValue({ lean: leanMock });
 
-    mockedParse.mockReturnValue(mockParsedData);
+    mockedParse.mockReturnValue(mockParsed);
 
-    const result = await pagesDataRepository.getBySlugAndStatus(slug, 'published');
+    const result = await pagesDataRepository.getBySlug(slug);
 
-    expect(mockedFindOne).toHaveBeenCalledWith({ slug, status: 'published' });
+    expect(mockedFindOnePublished).toHaveBeenCalledWith({ slug, status: PageStatus.Published });
     expect(leanMock).toHaveBeenCalled();
     expect(mockedParse).toHaveBeenCalledWith(mockDbData);
-    expect(result).toEqual(mockParsedData);
+    expect(result).toEqual(mockParsed);
   });
 
-  it('should return null if page is not found in the database', async () => {
+  it('should return null when published page is not found', async () => {
     const execMock = jest.fn().mockResolvedValue(null);
     const leanMock = jest.fn().mockReturnValue({ exec: execMock });
-    mockedFindOne.mockReturnValue({ lean: leanMock });
+    mockedFindOnePublished.mockReturnValue({ lean: leanMock });
 
-    const result = await pagesDataRepository.getBySlugAndStatus(slug, 'published');
+    const result = await pagesDataRepository.getBySlug(slug);
 
     expect(result).toBeNull();
-    expect(mockedFindOne).toHaveBeenCalledWith({ slug, status: 'published' });
+    expect(mockedFindOnePublished).toHaveBeenCalledWith({ slug, status: PageStatus.Published });
     expect(leanMock).toHaveBeenCalled();
     expect(mockedParse).not.toHaveBeenCalled();
   });
 
-  it('should throw an error if page data is invalid', async () => {
-    const invalidDbData = { _id: 'some_id', slug, pageType: 'AboutUsPage' };
-    const validationError = new Error('Zod validation failed');
-
-    const execMock = jest.fn().mockResolvedValue(invalidDbData);
+  it('should throw when published page fails validation', async () => {
+    const invalidDb = { _id: 'x', slug, pageType: 'AboutUsPage' };
+    const execMock = jest.fn().mockResolvedValue(invalidDb);
     const leanMock = jest.fn().mockReturnValue({ exec: execMock });
-    mockedFindOne.mockReturnValue({ lean: leanMock });
+    mockedFindOnePublished.mockReturnValue({ lean: leanMock });
 
+    const err = new Error('Zod validation failed');
     mockedParse.mockImplementation(() => {
-      throw validationError;
+      throw err;
     });
 
-    await expect(pagesDataRepository.getBySlugAndStatus(slug, 'published')).rejects.toThrow(validationError);
-
-    expect(mockedFindOne).toHaveBeenCalledWith({ slug, status: 'published' });
+    await expect(pagesDataRepository.getBySlug(slug)).rejects.toThrow(err);
+    expect(mockedFindOnePublished).toHaveBeenCalledWith({ slug, status: PageStatus.Published });
     expect(leanMock).toHaveBeenCalled();
-    expect(mockedParse).toHaveBeenCalledWith(invalidDbData);
+    expect(mockedParse).toHaveBeenCalledWith(invalidDb);
+  });
+
+  it('should return parsed draft page when found and valid', async () => {
+    const mockDbData = { _id: 'db_id', slug, pageType: 'AboutUsPage', status: PageStatus.Draft, blocks: {} };
+    const mockParsed = { ...mockDbData };
+
+    const execMock = jest.fn().mockResolvedValue(mockDbData);
+    const leanMock = jest.fn().mockReturnValue({ exec: execMock });
+    mockedFindOneDraft.mockReturnValue({ lean: leanMock });
+
+    mockedParse.mockReturnValue(mockParsed);
+
+    const result = await pagesDataRepository.getDraftBySlug(slug);
+
+    expect(mockedFindOneDraft).toHaveBeenCalledWith({ slug, status: PageStatus.Draft });
+    expect(leanMock).toHaveBeenCalled();
+    expect(mockedParse).toHaveBeenCalledWith(mockDbData);
+    expect(result).toEqual(mockParsed);
+  });
+
+  it('should return null when draft page is not found', async () => {
+    const execMock = jest.fn().mockResolvedValue(null);
+    const leanMock = jest.fn().mockReturnValue({ exec: execMock });
+    mockedFindOneDraft.mockReturnValue({ lean: leanMock });
+
+    const result = await pagesDataRepository.getDraftBySlug(slug);
+
+    expect(result).toBeNull();
+    expect(mockedFindOneDraft).toHaveBeenCalledWith({ slug, status: PageStatus.Draft });
+    expect(leanMock).toHaveBeenCalled();
+    expect(mockedParse).not.toHaveBeenCalled();
+  });
+
+  it('should throw when draft page fails validation', async () => {
+    const invalidDb = { _id: 'x', slug, pageType: 'AboutUsPage' };
+    const execMock = jest.fn().mockResolvedValue(invalidDb);
+    const leanMock = jest.fn().mockReturnValue({ exec: execMock });
+    mockedFindOneDraft.mockReturnValue({ lean: leanMock });
+
+    const err = new Error('Zod validation failed');
+    mockedParse.mockImplementation(() => {
+      throw err;
+    });
+
+    await expect(pagesDataRepository.getDraftBySlug(slug)).rejects.toThrow(err);
+    expect(mockedFindOneDraft).toHaveBeenCalledWith({ slug, status: PageStatus.Draft });
+    expect(leanMock).toHaveBeenCalled();
+    expect(mockedParse).toHaveBeenCalledWith(invalidDb);
   });
 });

--- a/app/infrastructure/repositories/pages-data/pagesData.test.ts
+++ b/app/infrastructure/repositories/pages-data/pagesData.test.ts
@@ -91,9 +91,9 @@ describe('pagesDataRepository', () => {
 
     mockedParse.mockReturnValue(mockParsedData);
 
-    const result = await pagesDataRepository.getPageData(slug);
+    const result = await pagesDataRepository.getBySlugAndStatus(slug, 'published');
 
-    expect(mockedFindOne).toHaveBeenCalledWith({ slug });
+    expect(mockedFindOne).toHaveBeenCalledWith({ slug, status: 'published' });
     expect(leanMock).toHaveBeenCalled();
     expect(mockedParse).toHaveBeenCalledWith(mockDbData);
     expect(result).toEqual(mockParsedData);
@@ -104,10 +104,10 @@ describe('pagesDataRepository', () => {
     const leanMock = jest.fn().mockReturnValue({ exec: execMock });
     mockedFindOne.mockReturnValue({ lean: leanMock });
 
-    const result = await pagesDataRepository.getPageData(slug);
+    const result = await pagesDataRepository.getBySlugAndStatus(slug, 'published');
 
     expect(result).toBeNull();
-    expect(mockedFindOne).toHaveBeenCalledWith({ slug });
+    expect(mockedFindOne).toHaveBeenCalledWith({ slug, status: 'published' });
     expect(leanMock).toHaveBeenCalled();
     expect(mockedParse).not.toHaveBeenCalled();
   });
@@ -124,9 +124,9 @@ describe('pagesDataRepository', () => {
       throw validationError;
     });
 
-    await expect(pagesDataRepository.getPageData(slug)).rejects.toThrow(validationError);
+    await expect(pagesDataRepository.getBySlugAndStatus(slug, 'published')).rejects.toThrow(validationError);
 
-    expect(mockedFindOne).toHaveBeenCalledWith({ slug });
+    expect(mockedFindOne).toHaveBeenCalledWith({ slug, status: 'published' });
     expect(leanMock).toHaveBeenCalled();
     expect(mockedParse).toHaveBeenCalledWith(invalidDbData);
   });

--- a/app/services/composed/pages-data-service/pagesDataService.test.ts
+++ b/app/services/composed/pages-data-service/pagesDataService.test.ts
@@ -14,7 +14,7 @@ jest.mock('~/validators/pagesSchemas/pages/about-us.schema', () => ({
 }));
 
 const mockPagesDataRepository = {
-  getPageData: jest.fn()
+  getBySlugAndStatus: jest.fn()
 };
 
 const mockedCreateLocalizedAboutUsPageSchema = createLocalizedAboutUsPageSchema as jest.Mock;
@@ -94,12 +94,12 @@ describe('createPagesDataService', () => {
   const locale: Locale = 'uk';
 
   it('should return null if page data is not found', async () => {
-    mockPagesDataRepository.getPageData.mockResolvedValue(null);
+    mockPagesDataRepository.getBySlugAndStatus.mockResolvedValue(null);
 
-    const result = await service.getPageData(slug, locale);
+    const result = await service.getPublishedPageData(slug, locale);
 
     expect(result).toBeNull();
-    expect(mockPagesDataRepository.getPageData).toHaveBeenCalledWith(slug);
+    expect(mockPagesDataRepository.getBySlugAndStatus).toHaveBeenCalledWith(slug, 'published');
     expect(mockedCreateLocalizedAboutUsPageSchema).not.toHaveBeenCalled();
   });
 
@@ -153,11 +153,11 @@ describe('createPagesDataService', () => {
 
     const mockSchema = { parse: jest.fn().mockReturnValue(localizedPageData) };
     mockedCreateLocalizedAboutUsPageSchema.mockReturnValue(mockSchema);
-    mockPagesDataRepository.getPageData.mockResolvedValue(pageDataFromRepo);
+    mockPagesDataRepository.getBySlugAndStatus.mockResolvedValue(pageDataFromRepo);
 
-    const result = await service.getPageData(slug, locale);
+    const result = await service.getPublishedPageData(slug, locale);
 
-    expect(mockPagesDataRepository.getPageData).toHaveBeenCalledWith(slug);
+    expect(mockPagesDataRepository.getBySlugAndStatus).toHaveBeenCalledWith(slug, 'published');
     expect(mockedCreateLocalizedAboutUsPageSchema).toHaveBeenCalledWith(locale);
     expect(mockSchema.parse).toHaveBeenCalledWith(pageDataFromRepo);
     expect(result).toEqual(localizedPageData);
@@ -171,11 +171,11 @@ describe('createPagesDataService', () => {
       })
     };
     mockedCreateLocalizedAboutUsPageSchema.mockReturnValue(mockSchema);
-    mockPagesDataRepository.getPageData.mockResolvedValue(pageDataFromRepo);
+    mockPagesDataRepository.getBySlugAndStatus.mockResolvedValue(pageDataFromRepo);
 
-    await expect(service.getPageData(slug, locale)).rejects.toThrow(validationError);
+    await expect(service.getPublishedPageData(slug, locale)).rejects.toThrow(validationError);
 
-    expect(mockPagesDataRepository.getPageData).toHaveBeenCalledWith(slug);
+    expect(mockPagesDataRepository.getBySlugAndStatus).toHaveBeenCalledWith(slug, 'published');
     expect(mockedCreateLocalizedAboutUsPageSchema).toHaveBeenCalledWith(locale);
     expect(mockSchema.parse).toHaveBeenCalledWith(pageDataFromRepo);
   });

--- a/app/services/composed/pages-data-service/pagesDataService.test.ts
+++ b/app/services/composed/pages-data-service/pagesDataService.test.ts
@@ -1,182 +1,85 @@
 import { Locale } from 'next-intl';
+import { z } from 'zod';
 
 import { createPagesDataService } from './pagesDataService';
+import { selectSchema } from './selectSchema';
+import type { PageData } from '~/types/page/pagesBase.type';
 
-import { PageServiceDeps } from '~/domain/services/pagesService.type';
-import { createLocalizedAboutUsPageSchema } from '~/validators/pagesSchemas/pages/about-us.schema';
+import type { PagesService } from '~/services/core/pagesDataService';
 
-jest.mock('~/validators/pagesSchemas/pages/privacy-policy.schema', () => ({
-  createLocalizedPrivacyPolicyPageSchema: jest.fn()
-}));
-
-jest.mock('~/validators/pagesSchemas/pages/about-us.schema', () => ({
-  createLocalizedAboutUsPageSchema: jest.fn()
-}));
-
-const mockPagesDataRepository = {
-  getBySlugAndStatus: jest.fn()
-};
-
-const mockedCreateLocalizedAboutUsPageSchema = createLocalizedAboutUsPageSchema as jest.Mock;
+jest.mock('./selectSchema', () => ({ selectSchema: jest.fn() }));
 
 describe('createPagesDataService', () => {
-  let service: ReturnType<typeof createPagesDataService>;
-
-  const pageDataFromRepo = {
-    _id: 'page_id',
-    pageType: 'AboutUsPage',
-    slug: 'about-us',
-    title: { uk: 'Про нас', en: 'About Us' },
-    status: 'published',
-    blocks: {
-      IntroSection: {
-        title: { uk: 'Вступ', en: 'Introduction' },
-        image: { url: 'intro.jpg', alt: { uk: 'Вступне зображення', en: 'Intro image' } },
-        quote: { text: { uk: 'Цитата', en: 'Quote' }, author: { uk: 'Автор', en: 'Author' } }
-      },
-      FoundationInfo: {
-        ourOrganisation: { uk: { content: 'Org content uk' }, en: { content: 'Org content en' } },
-        ourName: { uk: { content: 'Name content uk' }, en: { content: 'Name content en' } },
-        ourBelief: { uk: { content: 'Belief content uk' }, en: { content: 'Belief content en' } },
-        image: { url: 'foundation.jpg', alt: { uk: 'Фундація', en: 'Foundation' } }
-      },
-      OurMission: {
-        title: { uk: 'Наша місія', en: 'Our Mission' },
-        smallImage: { url: 'small.jpg', alt: { uk: 'Мале зображення', en: 'Small image' } },
-        bigImage: { url: 'big.jpg', alt: { uk: 'Велике зображення', en: 'Big image' } },
-        list: [{ uk: { content: 'Mission item uk' }, en: { content: 'Mission item en' } }]
-      },
-      OurGoals: {
-        title: { uk: 'Наші цілі', en: 'Our Goals' },
-        goals: [
-          {
-            title: { uk: 'Ціль', en: 'Goal' },
-            description: { uk: { content: 'Goal desc uk' }, en: { content: 'Goal desc en' } }
-          }
-        ]
-      },
-      LiatoshynskyOffice: {
-        quote: { text: { uk: 'Офіс цитата', en: 'Office quote' }, author: { uk: 'Автор', en: 'Author' } }
-      },
-      WhatWeDo: {
-        title: { uk: 'Що ми робимо', en: 'What We Do' },
-        items: [
-          {
-            title: { uk: 'Пункт', en: 'Item' },
-            description: { uk: { content: 'Item desc uk' }, en: { content: 'Item desc en' } }
-          }
-        ]
-      },
-      FoundationFounders: {
-        titleText: { uk: { content: 'Founders intro uk' }, en: { content: 'Founders intro en' } },
-        listTitle: { uk: 'Засновники', en: 'Founders' },
-        members: [
-          {
-            photo: { url: 'member.jpg', alt: { uk: 'Фото', en: 'Photo' } },
-            name: { uk: 'Імʼя', en: 'Name' },
-            description: { uk: 'Опис', en: 'Description' }
-          }
-        ]
-      }
-    },
-    createdAt: new Date(),
-    updatedAt: new Date()
-  };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    service = createPagesDataService({
-      pagesDataRepository: mockPagesDataRepository
-    } as PageServiceDeps);
-  });
+  const get: jest.MockedFunction<PagesService['getPageData']> = jest.fn();
+  const pagesService: PagesService = { getPageData: get };
 
   const slug = 'about-us';
   const locale: Locale = 'uk';
 
-  it('should return null if page data is not found', async () => {
-    mockPagesDataRepository.getBySlugAndStatus.mockResolvedValue(null);
+  type RepoReturn = Awaited<ReturnType<PagesService['getPageData']>>;
+  const repoPage = { slug } as unknown as NonNullable<RepoReturn>;
 
-    const result = await service.getPublishedPageData(slug, locale);
+  let service: ReturnType<typeof createPagesDataService>;
 
-    expect(result).toBeNull();
-    expect(mockPagesDataRepository.getBySlugAndStatus).toHaveBeenCalledWith(slug, 'published');
-    expect(mockedCreateLocalizedAboutUsPageSchema).not.toHaveBeenCalled();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = createPagesDataService(pagesService);
   });
 
-  it('should return localized page data when page is found', async () => {
-    const localizedPageData = {
-      slug,
-      title: 'Про нас',
-      status: 'published',
-      blocks: {
-        IntroSection: {
-          title: 'Вступ',
-          image: { url: 'intro.jpg', alt: 'Вступне зображення' },
-          quote: { text: 'Цитата', author: 'Автор' }
-        },
-        FoundationInfo: {
-          ourOrganisation: { content: 'Org content uk' },
-          ourName: { content: 'Name content uk' },
-          ourBelief: { content: 'Belief content uk' },
-          image: { url: 'foundation.jpg', alt: 'Фундація' }
-        },
-        OurMission: {
-          title: 'Наша місія',
-          smallImage: { url: 'small.jpg', alt: 'Мале зображення' },
-          bigImage: { url: 'big.jpg', alt: 'Велике зображення' },
-          list: [{ content: 'Mission item uk' }]
-        },
-        OurGoals: {
-          title: 'Наші цілі',
-          goals: [{ title: 'Ціль', description: { content: 'Goal desc uk' } }]
-        },
-        LiatoshynskyOffice: {
-          quote: { text: 'Офіс цитата', author: 'Автор' }
-        },
-        WhatWeDo: {
-          title: 'Що ми робимо',
-          items: [{ title: 'Пункт', description: { content: 'Item desc uk' } }]
-        },
-        FoundationFounders: {
-          titleText: { content: 'Founders intro uk' },
-          listTitle: 'Засновники',
-          members: [
-            {
-              photo: { url: 'member.jpg', alt: 'Фото' },
-              name: 'Імʼя',
-              description: 'Опис'
-            }
-          ]
-        }
-      }
-    };
+  it('should return null when page is not found', async () => {
+    get.mockResolvedValue(null);
 
-    const mockSchema = { parse: jest.fn().mockReturnValue(localizedPageData) };
-    mockedCreateLocalizedAboutUsPageSchema.mockReturnValue(mockSchema);
-    mockPagesDataRepository.getBySlugAndStatus.mockResolvedValue(pageDataFromRepo);
+    const res = await service.getPageData(slug, locale);
 
-    const result = await service.getPublishedPageData(slug, locale);
-
-    expect(mockPagesDataRepository.getBySlugAndStatus).toHaveBeenCalledWith(slug, 'published');
-    expect(mockedCreateLocalizedAboutUsPageSchema).toHaveBeenCalledWith(locale);
-    expect(mockSchema.parse).toHaveBeenCalledWith(pageDataFromRepo);
-    expect(result).toEqual(localizedPageData);
+    expect(res).toBeNull();
+    expect(get).toHaveBeenCalledWith(slug);
+    expect(selectSchema).not.toHaveBeenCalled();
   });
 
-  it('should throw an error if schema parsing fails', async () => {
-    const validationError = new Error('Zod validation failed');
-    const mockSchema = {
-      parse: jest.fn().mockImplementation(() => {
-        throw validationError;
-      })
-    };
-    mockedCreateLocalizedAboutUsPageSchema.mockReturnValue(mockSchema);
-    mockPagesDataRepository.getBySlugAndStatus.mockResolvedValue(pageDataFromRepo);
+  it('should return localized data when schema parses successfully', async () => {
+    const localized = { slug } as unknown as PageData;
+    const schema: z.ZodTypeAny = z.any();
+    const parseSpy = jest.spyOn(schema, 'parse').mockReturnValue(localized);
 
-    await expect(service.getPublishedPageData(slug, locale)).rejects.toThrow(validationError);
+    (selectSchema as jest.MockedFunction<typeof selectSchema>).mockReturnValue(schema);
+    get.mockResolvedValue(repoPage);
 
-    expect(mockPagesDataRepository.getBySlugAndStatus).toHaveBeenCalledWith(slug, 'published');
-    expect(mockedCreateLocalizedAboutUsPageSchema).toHaveBeenCalledWith(locale);
-    expect(mockSchema.parse).toHaveBeenCalledWith(pageDataFromRepo);
+    const res = await service.getPageData(slug, locale);
+
+    expect(get).toHaveBeenCalledWith(slug);
+    expect(selectSchema).toHaveBeenCalledWith(slug, locale);
+    expect(parseSpy).toHaveBeenCalledWith(repoPage);
+    expect(res).toEqual(localized);
+  });
+
+  it('should propagate parsing error', async () => {
+    const err = new Error('Zod validation failed');
+    const schema: z.ZodTypeAny = z.any();
+    jest.spyOn(schema, 'parse').mockImplementation(() => {
+      throw err;
+    });
+
+    (selectSchema as jest.MockedFunction<typeof selectSchema>).mockReturnValue(schema);
+    get.mockResolvedValue(repoPage);
+
+    await expect(service.getPageData(slug, locale)).rejects.toThrow(err);
+    expect(selectSchema).toHaveBeenCalledWith(slug, locale);
+  });
+
+  it('should return null if schema is undefined', async () => {
+    (selectSchema as jest.MockedFunction<typeof selectSchema>).mockReturnValue(undefined as unknown as z.ZodTypeAny);
+    get.mockResolvedValue(repoPage);
+
+    const res = await service.getPageData('unknown-slug', locale);
+
+    expect(res).toBeNull();
+  });
+
+  it('should propagate service errors', async () => {
+    const err = new Error('DB down');
+    get.mockRejectedValue(err);
+
+    await expect(service.getPageData(slug, locale)).rejects.toThrow(err);
+    expect(get).toHaveBeenCalledWith(slug);
   });
 });

--- a/app/services/composed/pages-data-service/pagesDataService.ts
+++ b/app/services/composed/pages-data-service/pagesDataService.ts
@@ -22,16 +22,16 @@ const selectSchema = (slug: string, locale: Locale) => {
 
 export const createPagesDataService = ({ pagesDataRepository }: PageServiceDeps) => ({
   async getPublishedPageData(slug: string, locale: Locale): Promise<PageData | null> {
-    const base = await pagesDataRepository.getBySlugAndStatus(slug, 'published');
-    if (!base) return null;
+    const page = await pagesDataRepository.getBySlugAndStatus(slug, 'published');
+    if (!page) return null;
     const schema = selectSchema(slug, locale);
-    return schema ? schema.parse(base) : null;
+    return schema ? schema.parse(page) : null;
   },
 
   async getDraftPageData(slug: string, locale: Locale): Promise<PageData | null> {
-    const base = await pagesDataRepository.getBySlugAndStatus(slug, 'draft');
-    if (!base) return null;
+    const page = await pagesDataRepository.getBySlugAndStatus(slug, 'draft');
+    if (!page) return null;
     const schema = selectSchema(slug, locale);
-    return schema ? schema.parse(base) : null;
+    return schema ? schema.parse(page) : null;
   }
 });

--- a/app/services/composed/pages-data-service/pagesDataService.ts
+++ b/app/services/composed/pages-data-service/pagesDataService.ts
@@ -1,37 +1,27 @@
 import { Locale } from 'next-intl';
-import { z } from 'zod';
 
-import { PageServiceDeps } from '~/domain/services/pagesService.type';
-import { createLocalizedAboutUsPageSchema } from '~/validators/pagesSchemas/pages/about-us.schema';
-import { createLocalizedPrivacyPolicyPageSchema } from '~/validators/pagesSchemas/pages/privacy-policy.schema';
-import { createLocalizedResearchPageSchema } from '~/validators/pagesSchemas/pages/research.schema';
+import { selectSchema } from './selectSchema';
+import { PageData } from '~/types/page/pagesBase.type';
 
-type AboutUsPage = z.infer<ReturnType<typeof createLocalizedAboutUsPageSchema>>;
-type PrivacyPolicyPage = z.infer<ReturnType<typeof createLocalizedPrivacyPolicyPageSchema>>;
-type ResearchPage = z.infer<ReturnType<typeof createLocalizedResearchPageSchema>>;
-type PageData = AboutUsPage | PrivacyPolicyPage | ResearchPage;
+import type { DraftPagesService, PagesService } from '~/services/core/pagesDataService';
 
-const selectSchema = (slug: string, locale: Locale) => {
-  const map = {
-    'about-us': createLocalizedAboutUsPageSchema(locale),
-    'privacy-policy': createLocalizedPrivacyPolicyPageSchema(locale),
-    research: createLocalizedResearchPageSchema(locale)
-  } as const;
-  return map[slug as keyof typeof map];
+const makeComposed = (get: (slug: string) => Promise<unknown>) => {
+  return async (slug: string, locale: Locale): Promise<PageData | null> => {
+    const page = await get(slug);
+    if (!page) return null;
+
+    const schema = selectSchema(slug, locale);
+    return schema ? schema.parse(page) : null;
+  };
 };
 
-export const createPagesDataService = ({ pagesDataRepository }: PageServiceDeps) => ({
-  async getPublishedPageData(slug: string, locale: Locale): Promise<PageData | null> {
-    const page = await pagesDataRepository.getBySlugAndStatus(slug, 'published');
-    if (!page) return null;
-    const schema = selectSchema(slug, locale);
-    return schema ? schema.parse(page) : null;
-  },
-
-  async getDraftPageData(slug: string, locale: Locale): Promise<PageData | null> {
-    const page = await pagesDataRepository.getBySlugAndStatus(slug, 'draft');
-    if (!page) return null;
-    const schema = selectSchema(slug, locale);
-    return schema ? schema.parse(page) : null;
-  }
+export const createPagesDataService = (service: PagesService) => ({
+  getPageData: makeComposed(service.getPageData)
 });
+
+export const createDraftPagesDataService = (service: DraftPagesService) => ({
+  getPageData: makeComposed(service.getPageData)
+});
+
+export type PagesDataService = ReturnType<typeof createPagesDataService>;
+export type DraftPagesDataService = ReturnType<typeof createDraftPagesDataService>;

--- a/app/services/composed/pages-data-service/pagesDataService.ts
+++ b/app/services/composed/pages-data-service/pagesDataService.ts
@@ -9,21 +9,29 @@ import { createLocalizedResearchPageSchema } from '~/validators/pagesSchemas/pag
 type AboutUsPage = z.infer<ReturnType<typeof createLocalizedAboutUsPageSchema>>;
 type PrivacyPolicyPage = z.infer<ReturnType<typeof createLocalizedPrivacyPolicyPageSchema>>;
 type ResearchPage = z.infer<ReturnType<typeof createLocalizedResearchPageSchema>>;
-
 type PageData = AboutUsPage | PrivacyPolicyPage | ResearchPage;
 
+const selectSchema = (slug: string, locale: Locale) => {
+  const map = {
+    'about-us': createLocalizedAboutUsPageSchema(locale),
+    'privacy-policy': createLocalizedPrivacyPolicyPageSchema(locale),
+    research: createLocalizedResearchPageSchema(locale)
+  } as const;
+  return map[slug as keyof typeof map];
+};
+
 export const createPagesDataService = ({ pagesDataRepository }: PageServiceDeps) => ({
-  async getPageData(slug: string, locale: Locale): Promise<PageData | null> {
-    const pageData = await pagesDataRepository.getPageData(slug);
-    if (!pageData) return null;
+  async getPublishedPageData(slug: string, locale: Locale): Promise<PageData | null> {
+    const base = await pagesDataRepository.getBySlugAndStatus(slug, 'published');
+    if (!base) return null;
+    const schema = selectSchema(slug, locale);
+    return schema ? schema.parse(base) : null;
+  },
 
-    const schemaMap = {
-      'about-us': createLocalizedAboutUsPageSchema(locale),
-      'privacy-policy': createLocalizedPrivacyPolicyPageSchema(locale),
-      research: createLocalizedResearchPageSchema(locale)
-    } as const;
-
-    const schema = schemaMap[slug as keyof typeof schemaMap];
-    return schema ? schema.parse(pageData) : null;
+  async getDraftPageData(slug: string, locale: Locale): Promise<PageData | null> {
+    const base = await pagesDataRepository.getBySlugAndStatus(slug, 'draft');
+    if (!base) return null;
+    const schema = selectSchema(slug, locale);
+    return schema ? schema.parse(base) : null;
   }
 });

--- a/app/services/composed/pages-data-service/selectSchema.test.ts
+++ b/app/services/composed/pages-data-service/selectSchema.test.ts
@@ -1,0 +1,40 @@
+import { Locale } from 'next-intl';
+
+import { selectSchema } from './selectSchema';
+
+jest.mock('~/validators/pagesSchemas/pages/about-us.schema', () => ({
+  createLocalizedAboutUsPageSchema: jest.fn().mockImplementation((locale: Locale) => ({ __schema: 'about-us', locale }))
+}));
+jest.mock('~/validators/pagesSchemas/pages/privacy-policy.schema', () => ({
+  createLocalizedPrivacyPolicyPageSchema: jest
+    .fn()
+    .mockImplementation((locale: Locale) => ({ __schema: 'privacy-policy', locale }))
+}));
+jest.mock('~/validators/pagesSchemas/pages/research.schema', () => ({
+  createLocalizedResearchPageSchema: jest
+    .fn()
+    .mockImplementation((locale: Locale) => ({ __schema: 'research', locale }))
+}));
+
+import { createLocalizedAboutUsPageSchema } from '~/validators/pagesSchemas/pages/about-us.schema';
+import { createLocalizedPrivacyPolicyPageSchema } from '~/validators/pagesSchemas/pages/privacy-policy.schema';
+import { createLocalizedResearchPageSchema } from '~/validators/pagesSchemas/pages/research.schema';
+
+describe('selectSchema', () => {
+  const locale: Locale = 'uk';
+
+  it.each([
+    ['about-us', 'about-us', createLocalizedAboutUsPageSchema],
+    ['privacy-policy', 'privacy-policy', createLocalizedPrivacyPolicyPageSchema],
+    ['research', 'research', createLocalizedResearchPageSchema]
+  ] as const)('returns schema for slug "%s"', (slug, tag, factory) => {
+    const schema = selectSchema(slug, locale);
+
+    expect(factory).toHaveBeenCalledWith(locale);
+    expect(schema).toEqual({ __schema: tag, locale });
+  });
+
+  it('returns undefined for unknown slug', () => {
+    expect(selectSchema('unknown', locale)).toBeUndefined();
+  });
+});

--- a/app/services/composed/pages-data-service/selectSchema.ts
+++ b/app/services/composed/pages-data-service/selectSchema.ts
@@ -1,0 +1,18 @@
+import { Locale } from 'next-intl';
+import { z } from 'zod';
+
+import { createLocalizedAboutUsPageSchema } from '~/validators/pagesSchemas/pages/about-us.schema';
+import { createLocalizedPrivacyPolicyPageSchema } from '~/validators/pagesSchemas/pages/privacy-policy.schema';
+import { createLocalizedResearchPageSchema } from '~/validators/pagesSchemas/pages/research.schema';
+
+export type PageSlug = 'about-us' | 'privacy-policy' | 'research';
+
+export const selectSchema = (slug: string, locale: Locale) => {
+  const map = {
+    'about-us': createLocalizedAboutUsPageSchema(locale),
+    'privacy-policy': createLocalizedPrivacyPolicyPageSchema(locale),
+    research: createLocalizedResearchPageSchema(locale)
+  } as const;
+
+  return map[slug as PageSlug] as z.ZodTypeAny | undefined;
+};

--- a/app/services/composed/pages-data-service/selectSchema.ts
+++ b/app/services/composed/pages-data-service/selectSchema.ts
@@ -5,14 +5,16 @@ import { createLocalizedAboutUsPageSchema } from '~/validators/pagesSchemas/page
 import { createLocalizedPrivacyPolicyPageSchema } from '~/validators/pagesSchemas/pages/privacy-policy.schema';
 import { createLocalizedResearchPageSchema } from '~/validators/pagesSchemas/pages/research.schema';
 
-export type PageSlug = 'about-us' | 'privacy-policy' | 'research';
+export const PAGE_SLUGS = ['about-us', 'privacy-policy', 'research'] as const;
+export type PageSlug = (typeof PAGE_SLUGS)[number];
 
-export const selectSchema = (slug: string, locale: Locale) => {
-  const map = {
-    'about-us': createLocalizedAboutUsPageSchema(locale),
-    'privacy-policy': createLocalizedPrivacyPolicyPageSchema(locale),
-    research: createLocalizedResearchPageSchema(locale)
-  } as const;
-
-  return map[slug as PageSlug] as z.ZodTypeAny | undefined;
+const schemaFactories: Record<PageSlug, (locale: Locale) => z.ZodTypeAny> = {
+  'about-us': createLocalizedAboutUsPageSchema,
+  'privacy-policy': createLocalizedPrivacyPolicyPageSchema,
+  research: createLocalizedResearchPageSchema
 };
+
+const isPageSlug = (slug: string): slug is PageSlug => (PAGE_SLUGS as readonly string[]).includes(slug);
+
+export const selectSchema = (slug: string, locale: Locale): z.ZodTypeAny | undefined =>
+  isPageSlug(slug) ? schemaFactories[slug](locale) : undefined;

--- a/app/services/core/pagesDataService.ts
+++ b/app/services/core/pagesDataService.ts
@@ -1,7 +1,12 @@
 import type { PagesDataRepository } from '~/domain/repositories/pagesData.repository';
 
 export const createPagesService = (repo: PagesDataRepository) => ({
-  getPageData: (slug: string) => repo.getPageData(slug)
+  getPageData: (slug: string) => repo.getBySlug(slug)
 });
 
-export type PagesDataService = ReturnType<typeof createPagesService>;
+export const createDraftPagesService = (repo: PagesDataRepository) => ({
+  getPageData: (slug: string) => repo.getDraftBySlug(slug)
+});
+
+export type PagesService = ReturnType<typeof createPagesService>;
+export type DraftPagesService = ReturnType<typeof createDraftPagesService>;

--- a/app/types/enums/common.enums.ts
+++ b/app/types/enums/common.enums.ts
@@ -48,3 +48,8 @@ export enum TipTapMarkType {
   underline = 'underline',
   link = 'link'
 }
+
+export enum PageStatus {
+  Draft = 'draft',
+  Published = 'published'
+}

--- a/app/types/page/pagesBase.type.ts
+++ b/app/types/page/pagesBase.type.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+import { createLocalizedAboutUsPageSchema } from '~/validators/pagesSchemas/pages/about-us.schema';
+import { createLocalizedPrivacyPolicyPageSchema } from '~/validators/pagesSchemas/pages/privacy-policy.schema';
+import { createLocalizedResearchPageSchema } from '~/validators/pagesSchemas/pages/research.schema';
+
+export type AboutUsPage = z.infer<ReturnType<typeof createLocalizedAboutUsPageSchema>>;
+export type PrivacyPolicyPage = z.infer<ReturnType<typeof createLocalizedPrivacyPolicyPageSchema>>;
+export type ResearchPage = z.infer<ReturnType<typeof createLocalizedResearchPageSchema>>;
+
+export type PageData = AboutUsPage | PrivacyPolicyPage | ResearchPage;

--- a/app/validators/pagesSchemas/pages/about-us.schema.ts
+++ b/app/validators/pagesSchemas/pages/about-us.schema.ts
@@ -1,6 +1,8 @@
 import { Locale } from 'next-intl';
 import { z } from 'zod';
 
+import { PageStatus } from '~/types/enums/common.enums';
+
 import { translatedFieldSchema } from '~/validators/constants';
 import {
   createLocalizedImageSchema,
@@ -80,7 +82,7 @@ export const AboutUsPageSchema = z.object({
   pageType: z.literal('AboutUsPage'),
   slug: z.string(),
   title: translatedFieldSchema,
-  status: z.enum(['draft', 'published']),
+  status: z.nativeEnum(PageStatus),
   blocks: AboutUsBlock,
   createdAt: z.date().optional(),
   updatedAt: z.date().optional(),

--- a/app/validators/pagesSchemas/pages/privacy-policy.schema.ts
+++ b/app/validators/pagesSchemas/pages/privacy-policy.schema.ts
@@ -1,6 +1,8 @@
 import { Locale } from 'next-intl';
 import { z } from 'zod';
 
+import { PageStatus } from '~/types/enums/common.enums';
+
 import { translatedFieldSchema } from '~/validators/constants';
 import { TipTapContentSchema } from '~/validators/pagesSchemas/tiptap.schema';
 
@@ -97,7 +99,7 @@ export const PrivacyPolicyPageSchema = z.object({
   pageType: z.literal('PrivacyPolicyPage'),
   slug: z.string(),
   title: translatedFieldSchema,
-  status: z.enum(['draft', 'published']),
+  status: z.nativeEnum(PageStatus),
   blocks: PrivacyPolicyBlock,
   createdAt: z.date().optional(),
   updatedAt: z.date().optional(),

--- a/app/validators/pagesSchemas/pages/research.schema.ts
+++ b/app/validators/pagesSchemas/pages/research.schema.ts
@@ -1,6 +1,8 @@
 import { Locale } from 'next-intl';
 import { z } from 'zod';
 
+import { PageStatus } from '~/types/enums/common.enums';
+
 import { translatedFieldSchema } from '~/validators/constants';
 import { createLocalizedQuoteSchema, QuoteSchema } from '~/validators/pagesSchemas/pages/_common.schema';
 
@@ -17,7 +19,7 @@ export const ResearchPageSchema = z.object({
   pageType: z.literal('Research'),
   slug: z.string(),
   title: translatedFieldSchema,
-  status: z.enum(['draft', 'published']),
+  status: z.nativeEnum(PageStatus),
   blocks: ResearchBlocksSchema,
   createdAt: z.date().optional(),
   updatedAt: z.date().optional(),


### PR DESCRIPTION
## Description

Adds the ability to fetch and render pages by status. The app now chooses data based on whether Next.js draft mode is enabled:
- Draft mode → render Draft page data.
- Normal mode → render Published page data.

Highlights:

- Separate services for published and draft data: pagesDataService and draftPagesDataService.
- On each request, the correct service is resolved via DI and used to call getPageData(slug, locale).
- Rendering logic stays unchanged; only the data source switches.

## Type of change

- [X] New feature

## How to test

How to test

1. Sync local DB with remote
Ensure your local database contains both published and draft versions of the relevant pages.

2. Create a draft and preview in the admin repo
- Checkout the admin repository branch: feature/183/page-data-update.
- Modify any field on the target page.
- Click “Preview” in the admin UI.
- Expected: a new tab opens showing the page rendered with draft data.

3.Verify published data on the main site
- Open an Incognito window.
- Navigate to the port where the main site is running (e.g., http://localhost:3000).
- Expected: the page shows published data (your draft changes are not visible).

## Video / Screenshots

https://github.com/user-attachments/assets/b662b600-663d-4edd-8ac5-732940d7603c

## Checklist

- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [X] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [X] Branch is up to date with the target branch
- [X] Linked issue/task included
- [X] Task moved to the review column on the board

---
