### PR TITLE
Add caption support to skewed background

### DIFF
--- a/app/shared/components/blocks/terms-of-use/TermsOfUse.tsx
+++ b/app/shared/components/blocks/terms-of-use/TermsOfUse.tsx
@@ -41,7 +41,7 @@ const TermsOfUse = () => {
         <SkewedBlock
           image="/images/liatoshynsky.png"
           backgroundSize="cover"
-          useBackground
+          isBackground
           height={skewedBlockHeight}
           sx={style.backgroundContainer}
         >

--- a/app/shared/components/blocks/terms-of-use/TermsOfUse.tsx
+++ b/app/shared/components/blocks/terms-of-use/TermsOfUse.tsx
@@ -41,6 +41,7 @@ const TermsOfUse = () => {
         <SkewedBlock
           image="/images/liatoshynsky.png"
           backgroundSize="cover"
+          useBackground
           height={skewedBlockHeight}
           sx={style.backgroundContainer}
         >

--- a/app/shared/components/design-system/all-components/skewed-block/SkewedBlock.styles.ts
+++ b/app/shared/components/design-system/all-components/skewed-block/SkewedBlock.styles.ts
@@ -1,0 +1,22 @@
+import { mainHexPallete } from '../theme/colors';
+export const styles = {
+  mainContainer: {
+    transform: 'skewY(-2deg)',
+    gridColumn: '1 / -1',
+    marginBotton: '100px',
+    position: 'relative',
+    left: '50%',
+    marginLeft: '-50vw',
+    width: '100vw'
+  },
+  caption: (align: 'left' | 'right') => ({
+    fontSize: { xs: '12px', sm: '14px', md: '16px' },
+    textAlign: align,
+    color: mainHexPallete.blue[700],
+    gridColumn: '1 / -1',
+    transform: 'skewY(2deg)',
+    paddingRight: '24px',
+    mt: '8px',
+    display: 'block'
+  })
+};

--- a/app/shared/components/design-system/all-components/skewed-block/SkewedBlock.test.tsx
+++ b/app/shared/components/design-system/all-components/skewed-block/SkewedBlock.test.tsx
@@ -9,14 +9,14 @@ describe('SkewedBlock', () => {
     expect(screen.getByTestId('skewed-block')).toBeInTheDocument();
   });
   it('should apply correct background image', () => {
-    render(<SkewedBlock image="/image.svg" useBackground backgroundSize="cover" height={{ xs: 200 }} />);
+    render(<SkewedBlock image="/image.svg" isBackground backgroundSize="cover" height={{ xs: 200 }} />);
     expect(screen.getByTestId('skewed-block')).toHaveStyle('background-image: url(/image.svg)');
   });
   it('should apply custom styles from sx prop', () => {
     render(
       <SkewedBlock
         image="/image.svg"
-        useBackground
+        isBackground
         backgroundSize="cover"
         height={{ xs: 200 }}
         sx={{ backgroundPosition: 'center' }}

--- a/app/shared/components/design-system/all-components/skewed-block/SkewedBlock.test.tsx
+++ b/app/shared/components/design-system/all-components/skewed-block/SkewedBlock.test.tsx
@@ -4,26 +4,41 @@ import React from 'react';
 import { SkewedBlock } from './SkewedBlock';
 
 describe('SkewedBlock', () => {
-  beforeEach(() => {
-    render(
-      <SkewedBlock image="/image.svg" backgroundSize="cover" height={{ xs: 200 }} sx={{ backgroundPosition: 'center' }}>
-        <div data-testid="child">Test content</div>
-      </SkewedBlock>
-    );
-  });
   it('should render with basic props', () => {
+    render(<SkewedBlock image="/image.svg" backgroundSize="cover" height={{ xs: 200 }} />);
     expect(screen.getByTestId('skewed-block')).toBeInTheDocument();
   });
   it('should apply correct background image', () => {
+    render(<SkewedBlock image="/image.svg" useBackground backgroundSize="cover" height={{ xs: 200 }} />);
     expect(screen.getByTestId('skewed-block')).toHaveStyle('background-image: url(/image.svg)');
   });
   it('should apply custom styles from sx prop', () => {
+    render(
+      <SkewedBlock
+        image="/image.svg"
+        useBackground
+        backgroundSize="cover"
+        height={{ xs: 200 }}
+        sx={{ backgroundPosition: 'center' }}
+      />
+    );
     expect(screen.getByTestId('skewed-block')).toHaveStyle('background-position: center');
   });
   it('should apply correct background size', () => {
-    expect(screen.getByTestId('skewed-block')).toHaveStyle('background-size: cover');
+    render(<SkewedBlock image="/image.svg" backgroundSize="contain" sx={{ objectFit: 'contain' }} />);
+    const img = screen.queryByLabelText('image-with-caption');
+    expect(img).toHaveStyle('object-fit: contain');
   });
   it('should render children correctly', () => {
+    render(
+      <SkewedBlock image="/image.svg" backgroundSize="cover" height={{ xs: 200 }}>
+        <div data-testid="child">Test content</div>
+      </SkewedBlock>
+    );
     expect(screen.getByTestId('child')).toHaveTextContent('Test content');
+  });
+  it('should render the caption if the caption prop is passed', () => {
+    render(<SkewedBlock image="/image.svg" backgroundSize="contain" caption="Some caption" />);
+    expect(screen.getByText(/Some caption/)).toBeInTheDocument();
   });
 });

--- a/app/shared/components/design-system/all-components/skewed-block/SkewedBlock.tsx
+++ b/app/shared/components/design-system/all-components/skewed-block/SkewedBlock.tsx
@@ -1,31 +1,86 @@
-import { Box } from '@mui/system';
+import { Box, Typography } from '@mui/material';
+import Image from 'next/image';
 import type { ReactNode } from 'react';
 
-type SkewedBlockProps = {
+import { styles } from './SkewedBlock.styles';
+
+type BaseProps = {
   image: string;
-  backgroundSize: 'cover' | 'contain';
-  height: object;
+  useBackground?: boolean;
+  width?: number | string;
   sx?: object;
   children?: ReactNode;
+  caption?: string;
+  align?: 'left' | 'right';
 };
-export const SkewedBlock = ({ image, backgroundSize, height, sx, children }: SkewedBlockProps) => {
+
+type CoverProps = BaseProps & {
+  backgroundSize: 'cover';
+  height: number | string | object;
+};
+
+type ContainProps = BaseProps & {
+  backgroundSize: 'contain';
+  height?: number | string | object;
+};
+
+export type SkewedBlockProps = CoverProps | ContainProps;
+
+export const SkewedBlock = ({
+  image,
+  useBackground = false,
+  backgroundSize,
+  width = '100%',
+  height = 'auto',
+  sx,
+  children,
+  caption,
+  align = 'right'
+}: SkewedBlockProps) => {
+  const isCover = backgroundSize === 'cover';
+
   return (
     <Box
       data-testid="skewed-block"
       sx={{
-        backgroundImage: `url(${image})`,
-        backgroundRepeat: 'no-repeat',
-        backgroundSize,
-        gridColumn: '1 / -1',
-        position: 'relative',
-        left: '50%',
-        marginLeft: '-50vw',
-        width: '100vw',
+        ...styles.mainContainer,
         height,
-        transform: 'skewY(-2deg)',
-        ...sx
+        ...(useBackground && {
+          backgroundImage: `url(${image})`,
+          backgroundSize,
+          backgroundPosition: 'center',
+          backgroundRepeat: 'no-repeat',
+          ...sx
+        })
       }}
     >
+      {!useBackground && (
+        <Box sx={{ display: 'inline-block', width, textAlign: 'center' }}>
+          <Box sx={{ position: 'relative', width: '100%', height: isCover ? height : 'auto' }}>
+            <Image
+              aria-label="image-with-caption"
+              src={image}
+              alt={caption || ''}
+              fill={isCover}
+              width={isCover ? undefined : 600}
+              height={isCover ? undefined : 400}
+              style={{
+                objectFit: backgroundSize,
+                width: '100%',
+                height: isCover ? undefined : 'auto',
+                ...sx
+              }}
+            />
+          </Box>
+
+          {caption && (
+            <Typography variant="caption" sx={styles.caption(align)}>
+              {caption}
+            </Typography>
+          )}
+        </Box>
+      )}
+
       {children}
     </Box>
   );

--- a/app/shared/components/design-system/all-components/skewed-block/SkewedBlock.tsx
+++ b/app/shared/components/design-system/all-components/skewed-block/SkewedBlock.tsx
@@ -58,7 +58,7 @@ export const SkewedBlock = ({
         <Box sx={{ display: 'inline-block', width, textAlign: 'center' }}>
           <Box sx={{ position: 'relative', width: '100%', height: isCover ? height : 'auto' }}>
             <Image
-              aria-label="image-with-caption"
+              aria-label={caption || 'image-with-caption'}
               src={image}
               alt={caption || ''}
               fill={isCover}

--- a/app/shared/components/design-system/all-components/skewed-block/SkewedBlock.tsx
+++ b/app/shared/components/design-system/all-components/skewed-block/SkewedBlock.tsx
@@ -6,7 +6,7 @@ import { styles } from './SkewedBlock.styles';
 
 type BaseProps = {
   image: string;
-  useBackground?: boolean;
+  isBackground?: boolean;
   width?: number | string;
   sx?: object;
   children?: ReactNode;
@@ -28,7 +28,7 @@ export type SkewedBlockProps = CoverProps | ContainProps;
 
 export const SkewedBlock = ({
   image,
-  useBackground = false,
+  isBackground = false,
   backgroundSize,
   width = '100%',
   height = 'auto',
@@ -45,7 +45,7 @@ export const SkewedBlock = ({
       sx={{
         ...styles.mainContainer,
         height,
-        ...(useBackground && {
+        ...(isBackground && {
           backgroundImage: `url(${image})`,
           backgroundSize,
           backgroundPosition: 'center',
@@ -54,7 +54,7 @@ export const SkewedBlock = ({
         })
       }}
     >
-      {!useBackground && (
+      {!isBackground && (
         <Box sx={{ display: 'inline-block', width, textAlign: 'center' }}>
           <Box sx={{ position: 'relative', width: '100%', height: isCover ? height : 'auto' }}>
             <Image
@@ -62,8 +62,7 @@ export const SkewedBlock = ({
               src={image}
               alt={caption || ''}
               fill={isCover}
-              width={isCover ? undefined : 600}
-              height={isCover ? undefined : 400}
+              {...(!isCover && { width: 600, height: 400 })}
               style={{
                 objectFit: backgroundSize,
                 width: '100%',

--- a/app/shared/components/design-system/all-components/switch/Switch.test.tsx
+++ b/app/shared/components/design-system/all-components/switch/Switch.test.tsx
@@ -8,7 +8,7 @@ const handleChange = jest.fn();
 describe('CustomSwitch', () => {
   it('should render with checked state when checked prop is true', () => {
     render(<Switch checked={true} onChange={handleChange} />);
-    const input = screen.getByRole('checkbox');
+    const input = screen.getByRole('switch');
     expect(input).toBeChecked();
   });
 

--- a/app/shared/components/design-system/all-components/switch/Switch.test.tsx
+++ b/app/shared/components/design-system/all-components/switch/Switch.test.tsx
@@ -8,7 +8,7 @@ const handleChange = jest.fn();
 describe('CustomSwitch', () => {
   it('should render with checked state when checked prop is true', () => {
     render(<Switch checked={true} onChange={handleChange} />);
-    const input = screen.getByRole('switch');
+    const input = screen.getByRole('checkbox');
     expect(input).toBeChecked();
   });
 


### PR DESCRIPTION
## Description

Add support for captions in `SkewedBlock` with flexible handling for different image types:
- **Cover**: requires explicit `height` values.
- **Contain**: `height` automatically set to `auto`.
- **Background**: use the `useBackground` prop to apply properties like `backgroundSize`, `backgroundImage`, `backgroundPosition`, etc.
- **Caption**: optional `caption` prop for displaying text below the image.


## Summary
The following logic is implemented this way because:
```
fill={isCover}
width={isCover ? undefined : 600}
height={isCover ? undefined : 400}
```
- For `cover` images, we use `fill={true}` with `objectFit: "cover"` so the image fully fills the container without fixed width/height.

But:
- For `contain` images, the container can be taller than the image, which creates extra space between the image and the caption. Just like this:
<img width="400" height="438" alt="Знімок екрана 2025-09-25 о 00 40 16" src="https://github.com/user-attachments/assets/dfb8118f-ebe7-4ce0-b739-d6a185614c7c" />

- The same issue happens with `backgroundImage`, so we can’t rely only on that approach.

So to fix this:
- We set fallback `width` and `height` `(600x400)` for `contain` images.
- The `height` is set to `'auto'` for contain images to keep the layout flexible.

## How to test

### Cover Example:
```
<SkewedBlock
  image="/images/cover-image.png"
  caption="Борис Лятошинський. 1950-ті роки"
  backgroundSize="cover"
  height={{
    xs: '357px',
    sm: '465px',
    md: '602px',
    lg: '767px',
    xl: '835px',
    ultra: '852px'
  }}
/>
```
<img width="447" height="410" alt="Знімок екрана 2025-09-24 о 19 58 30" src="https://github.com/user-attachments/assets/25a6598c-2a04-4c02-bd18-4171e50d7554" />

### Contain Example:
```
<SkewedBlock
  image="/images/contain-image.png"
  caption="Борис Лятошинський вдома в робочому кабінеті. 1960-ті роки"
  backgroundSize="contain"
/>
```
<img width="424" height="283" alt="Знімок екрана 2025-09-24 о 19 58 35" src="https://github.com/user-attachments/assets/b65a92fd-24ba-402b-bda5-75f9462ce116" />


### Background Example:
```
<SkewedBlock
  image="/images/background-image.png"
  backgroundSize="cover"
  useBackground
  height={{
    xs: '357px',
    sm: '465px',
    md: '602px',
    lg: '767px',
    xl: '835px',
    ultra: '852px'
  }}
/>
```

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [ ] Task moved to the review column on the board

---
