### PR TITLE
Add custom image with border component

### DIFF
--- a/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.styles.ts
+++ b/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.styles.ts
@@ -1,0 +1,22 @@
+import { mainHexPallete } from '../theme/colors';
+import { BorderParams } from './ImageWithBorder';
+
+export const styles = {
+  container: (width: number, height: number) => ({
+    position: 'relative',
+    width: width,
+    height: height,
+    gridColumn: '1 / -1',
+    transform: 'skewY(-2deg)'
+  }),
+  border: (border: BorderParams) => ({
+    display: 'block',
+    position: 'absolute',
+    width: border.width,
+    height: border.height,
+    top: 0,
+    left: 0,
+    backgroundColor: mainHexPallete.yellow[300],
+    zIndex: 0
+  })
+};

--- a/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.styles.ts
+++ b/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.styles.ts
@@ -1,5 +1,4 @@
 import { mainHexPallete } from '../theme/colors';
-import { BorderParams } from './ImageWithBorder';
 
 export const styles = {
   container: (width: number, height: number) => ({
@@ -9,11 +8,11 @@ export const styles = {
     gridColumn: '1 / -1',
     transform: 'skewY(-2deg)'
   }),
-  border: (border: BorderParams) => ({
+  border: (borderWidth: number, height: number) => ({
     display: 'block',
     position: 'absolute',
-    width: border.width,
-    height: border.height,
+    width: borderWidth,
+    height: height,
     top: 0,
     left: 0,
     backgroundColor: mainHexPallete.yellow[300],

--- a/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.test.tsx
+++ b/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    return <img {...props} />;
+  }
+}));
+import ImageWithBorder from './ImageWithBorder';
+
+describe('ImageWithBorder', () => {
+  it('should render without crashing with valid props', () => {
+    render(<ImageWithBorder image="/image.png" width={400} height={700} borderWidth={8} alt="Image description" />);
+    expect(screen.getByAltText('Image description')).toBeInTheDocument();
+  });
+  it('should apply correct width and height to the container', () => {
+    const { container } = render(
+      <ImageWithBorder image="/image.png" width={400} height={700} borderWidth={8} alt="Image description" />
+    );
+
+    const outerBox = container.querySelector('div');
+    expect(outerBox).toHaveStyle({ width: '400px', height: '700px' });
+  });
+  it('should render the image with correct src', () => {
+    render(<ImageWithBorder image="/image.png" width={400} height={700} borderWidth={8} alt="Image description" />);
+
+    const image = screen.getByAltText('Image description');
+    expect(image).toHaveAttribute('src', '/image.png');
+  });
+  it('shoud apply correct value for the border width', () => {
+    const { container } = render(
+      <ImageWithBorder image="/image.png" width={400} height={700} borderWidth={8} alt="Image description" />
+    );
+    const boxes = container.querySelectorAll('div');
+    const borderBox = boxes[1];
+    expect(borderBox).toHaveStyle({ width: '8px' });
+  });
+});

--- a/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.test.tsx
+++ b/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.test.tsx
@@ -2,9 +2,11 @@ import { render, screen } from '@testing-library/react';
 jest.mock('next/image', () => ({
   __esModule: true,
   default: (props: any) => {
-    return <img {...props} />;
+    const { alt = '', ...rest } = props;
+    return <img alt={alt} {...rest} />;
   }
 }));
+
 import ImageWithBorder from './ImageWithBorder';
 
 describe('ImageWithBorder', () => {

--- a/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.tsx
+++ b/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.tsx
@@ -1,0 +1,26 @@
+import { Box } from '@mui/material';
+import Image from 'next/image';
+
+import { styles } from './ImageWithBorder.styles';
+
+export interface BorderParams {
+  width: number;
+  height: number;
+}
+
+interface ImageWithBorderProps {
+  image: string;
+  width: number;
+  height: number;
+  border: BorderParams;
+  alt: string;
+}
+
+export default function ImageWithBorder({ image, width, height, border, alt }: ImageWithBorderProps) {
+  return (
+    <Box sx={styles.container(width, height)}>
+      <Box sx={styles.border(border)} />
+      <Image width={width} height={height} alt={alt} src={image} />
+    </Box>
+  );
+}

--- a/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.tsx
+++ b/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.tsx
@@ -7,11 +7,17 @@ interface ImageWithBorderProps {
   image: string;
   width: number;
   height: number;
-  borderWidth: number;
+  borderWidth?: number;
   alt: string;
 }
 
-export default function ImageWithBorder({ image, width, height, borderWidth, alt }: Readonly<ImageWithBorderProps>) {
+export default function ImageWithBorder({
+  image,
+  width,
+  height,
+  borderWidth = 8,
+  alt
+}: Readonly<ImageWithBorderProps>) {
   return (
     <Box sx={styles.container(width, height)}>
       <Box sx={styles.border(borderWidth, height)} />

--- a/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.tsx
+++ b/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.tsx
@@ -3,23 +3,18 @@ import Image from 'next/image';
 
 import { styles } from './ImageWithBorder.styles';
 
-export interface BorderParams {
-  width: number;
-  height: number;
-}
-
 interface ImageWithBorderProps {
   image: string;
   width: number;
   height: number;
-  border: BorderParams;
+  borderWidth: number;
   alt: string;
 }
 
-export default function ImageWithBorder({ image, width, height, border, alt }: ImageWithBorderProps) {
+export default function ImageWithBorder({ image, width, height, borderWidth, alt }: Readonly<ImageWithBorderProps>) {
   return (
     <Box sx={styles.container(width, height)}>
-      <Box sx={styles.border(border)} />
+      <Box sx={styles.border(borderWidth, height)} />
       <Image width={width} height={height} alt={alt} src={image} />
     </Box>
   );


### PR DESCRIPTION
## Description

1. Created an `ImageWithBorder` component that renders an image with a border according to the design.
2. Component accepts the following props:
- `image`
- `alt`
- `width` and `height` – dimensions of the image
- `borderWidth` to configure the border

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

Render the `ImageWithBorder` component with the necessary props.

Example usage:
```
  <ImageWithBorder image="/images/image.png" width={294} height={379} alt="some image" />
  <ImageWithBorder image="/images/rectangle.png" width={618} height={390} alt="some image" />
```


## Video / Screenshots
<img width="343" height="408" alt="Знімок екрана 2025-10-07 о 22 37 48" src="https://github.com/user-attachments/assets/35b4d087-0b74-4343-8481-76941fec7248" />

<img width="651" height="426" alt="Знімок екрана 2025-10-07 о 22 38 28" src="https://github.com/user-attachments/assets/3e02ab6a-dfbd-448c-bad3-212587b45b79" />


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
