### PR TITLE
Fix CookieModalWrapper any type

### DIFF
--- a/app/shared/components/cookie-modal/CookieModalWrapper.tsx
+++ b/app/shared/components/cookie-modal/CookieModalWrapper.tsx
@@ -4,11 +4,16 @@ import React, { useState } from 'react';
 import { CookieModal } from './modal/CookieModal';
 import { CookiePreferencesModal } from './preferances/CookiePreferencesModal';
 
+import type { parseDaConsent } from '~/lib/utils/consent';
 import { consentObj } from '~/lib/utils/consent';
 
 declare global {
   interface Window {
-    gtag: (...args: any[]) => void;
+    gtag: {
+      (command: 'consent', action: 'update', params: ReturnType<typeof consentObj>): void;
+
+      (command: 'consent', action: 'default', params: ReturnType<typeof parseDaConsent>): void;
+    };
   }
 }
 

--- a/app/shared/components/cookie-modal/CookieModalWrapper.tsx
+++ b/app/shared/components/cookie-modal/CookieModalWrapper.tsx
@@ -4,16 +4,13 @@ import React, { useState } from 'react';
 import { CookieModal } from './modal/CookieModal';
 import { CookiePreferencesModal } from './preferances/CookiePreferencesModal';
 
-import type { parseDaConsent } from '~/lib/utils/consent';
 import { consentObj } from '~/lib/utils/consent';
+
+type GtagConsentParams = ReturnType<typeof consentObj>;
 
 declare global {
   interface Window {
-    gtag: {
-      (command: 'consent', action: 'update', params: ReturnType<typeof consentObj>): void;
-
-      (command: 'consent', action: 'default', params: ReturnType<typeof parseDaConsent>): void;
-    };
+    gtag: (command: 'consent', action: 'update' | 'default', params: GtagConsentParams) => void;
   }
 }
 


### PR DESCRIPTION
## Description

Remove the `any` type in `CookieModalWrapper.tsx` and add type-safe overloads for `window.gtag` based on real usage.

## Type of change

- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactoring / Tech debt  
- [ ] CI/CD improvement  
- [ ] Other: <!-- specify -->

## How to test

1. Run ESLint on the modified file:
   npm exec eslint app/shared/components/cookie-modal/CookieModalWrapper.tsx
No warnings should appear.

2. Verify that the cookie modal works correctly on TEST environment — open the main page and confirm that the cookie consent logic still works (“Accept all” and “Configure” actions).


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

**Linked issue:** #712  
**Story Point:** (SP: 0.5)
