### PR TITLE
Fix any types in useFetchStaticFilters

### DIFF
--- a/app/services/client/tableService.ts
+++ b/app/services/client/tableService.ts
@@ -3,12 +3,12 @@ import { Locale } from 'next-intl';
 import { getFullUrl } from '~/lib/utils/getFullUrl';
 import { baseService } from '~/services/client/baseService';
 
-async function getTableStaticData<T>(pathname: string, locale: Locale): Promise<T[]> {
+async function getTableStaticData<T>(pathname: string, locale: Locale): Promise<T> {
   const url = getFullUrl({
     pathname,
     searchParameters: { locale }
   });
-  return baseService.request<T[]>({
+  return baseService.request<T>({
     method: 'GET',
     url
   });

--- a/app/shared/hooks/use-search/useFetchStaticFilters.ts
+++ b/app/shared/hooks/use-search/useFetchStaticFilters.ts
@@ -12,8 +12,7 @@ export function useFetchStaticFilters<T = unknown>(endpoint: string | null) {
     queryKey: ['static-filters', endpoint ?? 'none', locale],
     queryFn: async (): Promise<T | null> => {
       if (!endpoint) return null;
-      const resp = await tableClientService.getTableStaticData<T>(endpoint, locale);
-      return resp;
+      return await tableClientService.getTableStaticData<T>(endpoint, locale);
     },
     options: {
       staleTime: Infinity

--- a/app/shared/hooks/use-search/useFetchStaticFilters.ts
+++ b/app/shared/hooks/use-search/useFetchStaticFilters.ts
@@ -3,7 +3,7 @@ import { useLocale } from 'next-intl';
 import { tableClientService } from '~/services/client/tableService';
 import useQuery from '~/shared/hooks/query/useQuery';
 
-export type Selector<T> = (response: any) => T;
+export type Selector<TResponse, R = TResponse> = (response: TResponse) => R;
 
 export function useFetchStaticFilters<T = unknown>(endpoint: string | null) {
   const locale = useLocale();
@@ -12,8 +12,8 @@ export function useFetchStaticFilters<T = unknown>(endpoint: string | null) {
     queryKey: ['static-filters', endpoint ?? 'none', locale],
     queryFn: async (): Promise<T | null> => {
       if (!endpoint) return null;
-      const resp = await tableClientService.getTableStaticData<any>(endpoint, locale);
-      return resp as T;
+      const resp = await tableClientService.getTableStaticData<T>(endpoint, locale);
+      return resp;
     },
     options: {
       staleTime: Infinity


### PR DESCRIPTION
## Description

Changed return type in `tableService` to make it more flexible.
Resolved lint warnings related to `useFetchStaticFilters` hook.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Run ESLint on the modified file:
npm exec eslint app/shared/hooks/use-search/useFetchStaticFilters.ts
No warnings should appear.
2. Verify that the static filters are working correctly — go to the `Artistry` page, click the `Filters` button, and confirm that the filters are applied correctly.

## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
**Linked issue**: [#717](https://github.com/orgs/Liatoshynsky-Foundation/projects/1/views/1?filterQuery=label%3A%22good+first+issue%22&pane=issue&itemId=134645838&issue=Liatoshynsky-Foundation%7Clf-client%7C717).
**Story points**: 0.5
