### PR TITLE
Feature/747/update donation presets switch from additive to selectable

### DIFF
--- a/app/shared/components/forms/donation-form/DonationForm.test.tsx
+++ b/app/shared/components/forms/donation-form/DonationForm.test.tsx
@@ -67,13 +67,6 @@ describe('DonationForm', () => {
     expect(screen.getByText('Підписатися')).toBeInTheDocument();
   });
 
-  it('should add suggest sum to input', () => {
-    fireEvent.click(screen.getByText('+200'));
-    expect(screen.getByDisplayValue('200')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('+500'));
-    expect(screen.getByDisplayValue('700')).toBeInTheDocument();
-  });
-
   it('should show entered value', () => {
     const input = screen.getByRole('spinbutton');
     fireEvent.change(input, { target: { value: '100' } });
@@ -84,7 +77,7 @@ describe('DonationForm', () => {
   });
 
   it('should switch currency', () => {
-    fireEvent.click(screen.getByText('+200'));
+    fireEvent.click(screen.getByText('200'));
     expect(screen.getByDisplayValue('200')).toBeInTheDocument();
 
     fireEvent.mouseDown(screen.getByRole('combobox'));

--- a/app/shared/components/forms/donation-form/DonationForm.tsx
+++ b/app/shared/components/forms/donation-form/DonationForm.tsx
@@ -108,12 +108,11 @@ function DonationForm() {
       id={item.toString()}
       variant="outlined"
       onClick={() => {
-        const newSum = (donationSum || 0) + item;
-        setDonationSum(newSum);
-        if (touched) setHasError(newSum === 0);
+        setDonationSum(item);
+        if (touched) setHasError(donationSum === 0);
       }}
     >
-      <Typography variant="customSemiBold18">+{item}</Typography>
+      <Typography variant="customSemiBold18">{item}</Typography>
       <Typography variant="customMedium16" sx={style.currencySuggestion}>
         {currency}
       </Typography>


### PR DESCRIPTION
## Description

Fix incorrect additive behavior of donation presets. Clicking a preset should set the amount (single-select), not add to the current value. Also remove the “+” sign from labels.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1.Open donation form.
2.Click 500 UAH → input becomes 500, preset 500 is highlighted.
3.Click 200 UAH → input becomes 200 (no summation), highlight switches to 200.
4.Ensure no “+” in preset labels.

##Affected areas

~/forms/donation-form/DonationForm.tsx
~/forms/donation-form/DonationForm.test.tsx

##Linked issue

#747 

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
