### PR TITLE
Fix(ui): ensure table rows render without forced rerender

### DIFF
--- a/app/shared/components/enhanced-table/EnhancedTable.tsx
+++ b/app/shared/components/enhanced-table/EnhancedTable.tsx
@@ -106,9 +106,7 @@ export const EnhancedTable = <T extends RowData>({
     manualFiltering: true
   });
 
-  const filteredAndSortedRows = useMemo(() => {
-    return headerTable.getRowModel().rows.map((row) => row.original);
-  }, [headerTable]);
+  const filteredAndSortedRows = headerTable.getRowModel().rows.map((row) => row.original);
 
   const { groupedItems, flatItems } = useMemo(() => {
     const grouped = new Map<string, T[]>();


### PR DESCRIPTION
## Description

Fixes an issue where the EnhancedTable did not render data on initial load.
The table appeared empty until a forced re-render occurred (e.g., opening DevTools or resizing the window).
Removed unnecessary `useMemo` around the row model and now rely on React Table’s internal memoization. No unnecesarry rerenders spotted.

## Type of change

- [x] Bug fix

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open the page with the table.
2. The table should render rows immediately.
4. Apply sorting / filtering — rows update as expected.
5. No need to open DevTools or trigger any external re-render.

## Video / Screenshots

https://github.com/user-attachments/assets/6e695eb7-0632-44b4-b9d6-ca4cb5f17af4


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
