### PR TITLE
Add unit tests for useFetchStaticFilters hook

### DIFF
--- a/app/shared/hooks/use-search/useFetchStaticFilters.test.tsx
+++ b/app/shared/hooks/use-search/useFetchStaticFilters.test.tsx
@@ -32,7 +32,7 @@ describe('useFetchStaticFilters', () => {
     useQueryMock.mockImplementation((opts: any) => ({ data: opts.queryFn() }));
   });
 
-  it('returns null data when endpoint is null', async () => {
+  it('should return null data when endpoint is null', async () => {
     const { result } = renderHook(() => useFetchStaticFilters(null));
 
     const data = await result.current.data;
@@ -40,7 +40,7 @@ describe('useFetchStaticFilters', () => {
     expect(getTableStaticDataMock).not.toHaveBeenCalled();
   });
 
-  it('calls getTableStaticData when endpoint is provided', async () => {
+  it('should call getTableStaticData and return its result when endpoint is provided', async () => {
     const endpoint = '/api/static/filters';
     const mockData = { genres: [{ name: 'rock' }] };
     getTableStaticDataMock.mockResolvedValueOnce(mockData);
@@ -53,7 +53,7 @@ describe('useFetchStaticFilters', () => {
     expect(data).toEqual(mockData);
   });
 
-  it('includes locale in queryKey', () => {
+  it('should include locale in queryKey', () => {
     const endpoint = '/api/static/filters';
     useQueryMock.mockImplementation(() => ({ data: null }));
 

--- a/app/shared/hooks/use-search/useFetchStaticFilters.test.tsx
+++ b/app/shared/hooks/use-search/useFetchStaticFilters.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react';
+import { useLocale } from 'next-intl';
+
+import { useFetchStaticFilters } from './useFetchStaticFilters';
+
+import { tableClientService } from '~/services/client/tableService';
+import useQuery from '~/shared/hooks/query/useQuery';
+
+jest.mock('next-intl', () => ({
+  useLocale: jest.fn()
+}));
+
+jest.mock('~/shared/hooks/query/useQuery', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+jest.mock('~/services/client/tableService', () => ({
+  tableClientService: {
+    getTableStaticData: jest.fn()
+  }
+}));
+
+describe('useFetchStaticFilters', () => {
+  const useQueryMock = useQuery as jest.Mock;
+  const useLocaleMock = useLocale as jest.Mock;
+  const getTableStaticDataMock = tableClientService.getTableStaticData as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useLocaleMock.mockReturnValue('en');
+    useQueryMock.mockImplementation((opts: any) => ({ data: opts.queryFn() }));
+  });
+
+  it('returns null data when endpoint is null', async () => {
+    const { result } = renderHook(() => useFetchStaticFilters(null));
+
+    const data = await result.current.data;
+    expect(data).toBeNull();
+    expect(getTableStaticDataMock).not.toHaveBeenCalled();
+  });
+
+  it('calls getTableStaticData when endpoint is provided', async () => {
+    const endpoint = '/api/static/filters';
+    const mockData = { genres: [{ name: 'rock' }] };
+    getTableStaticDataMock.mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() => useFetchStaticFilters(endpoint));
+
+    const data = await result.current.data;
+
+    expect(getTableStaticDataMock).toHaveBeenCalledWith(endpoint, 'en');
+    expect(data).toEqual(mockData);
+  });
+
+  it('includes locale in queryKey', () => {
+    const endpoint = '/api/static/filters';
+    useQueryMock.mockImplementation(() => ({ data: null }));
+
+    renderHook(() => useFetchStaticFilters(endpoint));
+
+    const callArgs = useQueryMock.mock.calls[0][0];
+    expect(callArgs.queryKey).toEqual(['static-filters', endpoint, 'en']);
+  });
+});


### PR DESCRIPTION
## Description

Write unit tests for useFetchStaticFilters hook

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [x] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open the project, go to the lf-client\app\shared\hooks\use-search and run npm run test(-- coverage)
2. You can also open an index html file lf-client\coverage\shared\hooks\use-search\index.html to view tested area

## Video / Screenshots

<img width="881" height="48" alt="image" src="https://github.com/user-attachments/assets/68999b64-740c-4d87-b21c-74a300e168de" />


## Checklist

- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
