### PR TITLE
Fix(ui): align "Усі композиції" title and filters in the artistry layout

### DIFF
--- a/app/shared/components/enhanced-table/EnhancedTable.styles.ts
+++ b/app/shared/components/enhanced-table/EnhancedTable.styles.ts
@@ -1,12 +1,16 @@
 import type { Theme } from '@mui/material';
 
 export const enhancedTableStyles = {
-  root: (theme: Theme) => ({
+  root: {
     display: 'flex',
     flexDirection: 'column',
     py: 20,
     gap: 4,
-    gridColumn: '1 / -1',
+    gridColumn: '1 / -1'
+  },
+  container: (theme: Theme) => ({
+    boxShadow: 'none',
+    border: 'none',
 
     marginLeft: `-${theme.spacing(2.5)}`,
     marginRight: `-${theme.spacing(2.5)}`,
@@ -25,12 +29,6 @@ export const enhancedTableStyles = {
     }
   }),
 
-  container: {
-    width: '100%',
-    boxShadow: 'none',
-    border: 'none'
-  },
-
   paginationWrapper: {
     display: 'flex',
     justifyContent: 'center',
@@ -39,11 +37,6 @@ export const enhancedTableStyles = {
     gap: { xs: 3, md: 4 },
     alignItems: 'center'
   },
-
-  title: {
-    pl: 9
-  },
-
   loaderBox: {
     display: 'flex',
     justifyContent: 'center',

--- a/app/shared/components/enhanced-table/control-panel/ControlPanel.styles.ts
+++ b/app/shared/components/enhanced-table/control-panel/ControlPanel.styles.ts
@@ -1,15 +1,10 @@
-import { Theme } from '@mui/material/styles';
-
 import { mainHexPallete } from '~/ds-components//theme/colors';
 
 export const ControlPanelStyles = {
-  root: (theme: Theme) => ({
+  root: {
     display: 'column',
-    gap: 8,
-    pl: 3,
-    [theme.breakpoints.up('sm')]: { pr: '30px' },
-    [theme.breakpoints.up('md')]: { pr: '60px' }
-  }),
+    gap: 8
+  },
   header: {
     display: 'flex',
     justifyContent: 'space-between',
@@ -20,8 +15,7 @@ export const ControlPanelStyles = {
   headerRight: {
     display: 'flex',
     alignItems: 'center',
-    gap: 2,
-    marginRight: '40px'
+    gap: 2
   },
   filtersBadge: {
     '& .MuiBadge-badge': {

--- a/app/shared/components/enhanced-table/control-panel/ControlPanel.tsx
+++ b/app/shared/components/enhanced-table/control-panel/ControlPanel.tsx
@@ -107,7 +107,7 @@ export default function ControlPanel({ tableName, Search, Filters, activeFilters
   );
 
   return (
-    <Box sx={ControlPanelStyles.root(theme)}>
+    <Box sx={ControlPanelStyles.root}>
       <Box sx={ControlPanelStyles.header}>
         <Typography variant={isLessThan405 ? 'customBold25' : 'customBold32'}>{tableName}</Typography>
         <Box sx={ControlPanelStyles.headerRight}>


### PR DESCRIPTION
## Description

Aligned the "Усі композиції" section title and filter controls within the main layout grid.
Removed unintended spacing that caused elements to shift.

## Type of change

- [ ] Bug fix

## How to test

1. Open the artistry page.
2. Resize the window (mobile → tablet → desktop).
3. Ensure the section title and filters stay aligned to the main grid.

## Video / Screenshots

<img width="1443" height="784" alt="image" src="https://github.com/user-attachments/assets/f2961e16-b4c4-4b5d-94a1-2295140b906a" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
