### PR TITLE
fix: close dropdown menus on scroll down in header

### DIFF
--- a/app/shared/components/Header/Header.tsx
+++ b/app/shared/components/Header/Header.tsx
@@ -37,7 +37,11 @@ export default function Header() {
       </Box>
 
       <Box sx={styles.navigationContainer}>
-        <NavigationBar navLabels={headerData.navigation} specialNav={headerData.specialNavigation} />
+        <NavigationBar
+          navLabels={headerData.navigation}
+          specialNav={headerData.specialNavigation}
+          scrollDirection={scrollDirection}
+        />
       </Box>
 
       <Box sx={styles.rightActionsContainer}>
@@ -46,6 +50,7 @@ export default function Header() {
             text: t('supportButton'),
             link: headerData.supportButtonLink
           }}
+          scrollDirection={scrollDirection}
         />
       </Box>
     </Box>

--- a/app/shared/components/Header/RightActionsPanel/RightActionsPanel.tsx
+++ b/app/shared/components/Header/RightActionsPanel/RightActionsPanel.tsx
@@ -9,20 +9,22 @@ import useBreakpoints from '~/hooks/use-breakpoints/useBreakpoints';
 import AudioPlayer from '../AudioPlayer/AudioPlayer';
 import SupportButton from '../SupportButton/SupportButton';
 import { styles } from './RightActionsPanel.styles';
+import type { ScrollDirection } from '~/types/types/common.types';
 import { type SupportButtonData } from '~/types/types/header.type';
 
 interface SupportButtonDataProps {
   supportButtonData: SupportButtonData;
+  scrollDirection: ScrollDirection;
 }
 
-export default function RightActionsPanel({ supportButtonData }: Readonly<SupportButtonDataProps>) {
+export default function RightActionsPanel({ supportButtonData, scrollDirection }: Readonly<SupportButtonDataProps>) {
   const { isMobile } = useBreakpoints();
 
   return (
     <Box sx={!isMobile ? styles.backgroundContainer : undefined}>
       <Box sx={styles.controls(isMobile)}>
         <AudioPlayer />
-        <LanguageSwitcher variant="icon" />
+        <LanguageSwitcher variant="icon" scrollDirection={scrollDirection} />
       </Box>
       <SupportButton data={supportButtonData} isMobile={isMobile} />
     </Box>

--- a/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
+++ b/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
@@ -2,13 +2,14 @@
 
 import { MenuItem } from '@mui/material';
 import { useLocale } from 'next-intl';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Button from '../button/Button';
 import DropdownMenu from '../dropdown-menu/DropdownMenu';
 import { IconButton } from '../icon-button/IconButton';
 import { styles } from './LanguageSwitcher.styles';
 import { IconButtonColorVariant, IconButtonVariant, PositionEnum } from '~/types/enums/common.enums';
+import type { ScrollDirection } from '~/types/types/common.types';
 
 import { usePathname, useRouter } from '~/../i18n/navigation';
 import { SvgImage } from '~/shared/components/svg-image/SvgImage';
@@ -18,14 +19,21 @@ type Locale = (typeof locales)[number];
 
 export interface LanguageSwitcherProps {
   variant: 'icon' | 'toggle';
+  scrollDirection?: ScrollDirection;
 }
 
-const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ variant }) => {
+const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ variant, scrollDirection }) => {
   const router = useRouter();
   const pathname = usePathname();
   const currentLocale = useLocale();
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (scrollDirection === 'down' && anchorEl) {
+      handleClose();
+    }
+  }, [scrollDirection, anchorEl]);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);

--- a/app/shared/components/design-system/all-components/navigation-bar/NavigationBar.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/NavigationBar.tsx
@@ -11,15 +11,13 @@ import type { ScrollDirection } from '~/types/types/common.types';
 
 import type { NavigationDTO } from '~/domain/dto/navigation.dto';
 
-const NavigationBar = ({
-  navLabels,
-  specialNav,
-  scrollDirection
-}: {
+interface NavigationBarProps {
   navLabels: NavigationDTO[];
   specialNav: NavigationDTO | null;
   scrollDirection: ScrollDirection;
-}) => {
+}
+
+const NavigationBar = ({ navLabels, specialNav, scrollDirection }: NavigationBarProps) => {
   const { isDesktop } = useBreakpoints();
   const [isMounted, setIsMounted] = useState(false);
 

--- a/app/shared/components/design-system/all-components/navigation-bar/NavigationBar.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/NavigationBar.tsx
@@ -7,10 +7,19 @@ import useBreakpoints from '~/hooks/use-breakpoints/useBreakpoints';
 
 import DesktopNav from './dekstop-nav/DesktopNav';
 import MobileNav from './mobile-nav/MobileNav';
+import type { ScrollDirection } from '~/types/types/common.types';
 
 import type { NavigationDTO } from '~/domain/dto/navigation.dto';
 
-const NavigationBar = ({ navLabels, specialNav }: { navLabels: NavigationDTO[]; specialNav: NavigationDTO | null }) => {
+const NavigationBar = ({
+  navLabels,
+  specialNav,
+  scrollDirection
+}: {
+  navLabels: NavigationDTO[];
+  specialNav: NavigationDTO | null;
+  scrollDirection: ScrollDirection;
+}) => {
   const { isDesktop } = useBreakpoints();
   const [isMounted, setIsMounted] = useState(false);
 
@@ -22,7 +31,11 @@ const NavigationBar = ({ navLabels, specialNav }: { navLabels: NavigationDTO[]; 
     return <CircularProgress />;
   }
 
-  return isDesktop ? <DesktopNav navLabels={navLabels} specialNav={specialNav} /> : <MobileNav />;
+  return isDesktop ? (
+    <DesktopNav navLabels={navLabels} specialNav={specialNav} scrollDirection={scrollDirection} />
+  ) : (
+    <MobileNav />
+  );
 };
 
 export default NavigationBar;

--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
@@ -10,6 +10,7 @@ import CustomMenuItem from '~/ds-components/menu-item/MenuItem';
 import { mainHexPallete } from '~/ds-components/theme/colors';
 
 import { styles } from './DesktopNav.styles';
+import type { ScrollDirection } from '~/types/types/common.types';
 
 import { NavigationDTO } from '~/domain/dto/navigation.dto';
 import { usePathname } from '~/i18n/navigation';
@@ -22,7 +23,15 @@ export interface DropdownItem {
   href: string;
 }
 
-const DesktopNav = ({ navLabels, specialNav }: { navLabels: NavigationDTO[]; specialNav: NavigationDTO | null }) => {
+const DesktopNav = ({
+  navLabels,
+  specialNav,
+  scrollDirection
+}: {
+  navLabels: NavigationDTO[];
+  specialNav: NavigationDTO | null;
+  scrollDirection: ScrollDirection;
+}) => {
   const NAV_ITEMS = useMemo(() => {
     return navLabels.map((group) => {
       const dropdown = group.links.map((link) => ({
@@ -44,6 +53,12 @@ const DesktopNav = ({ navLabels, specialNav }: { navLabels: NavigationDTO[]; spe
   const [temporaryActiveIndex, setTemporaryActiveIndex] = useState<number | null>(null);
   const [openDropdownState, setOpenDropdownState] = useState<{ label: string; items: DropdownItem[] } | null>(null);
   const [activeButton, setActiveButton] = useState<number | undefined>();
+
+  useEffect(() => {
+    if (scrollDirection === 'down' && anchorEl) {
+      handleDropdownClose();
+    }
+  }, [scrollDirection, anchorEl]);
 
   useEffect(() => {
     setTemporaryActiveIndex(null);


### PR DESCRIPTION
## Description

Fixes dropdown menu behavior in header during scrolling.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Run the project
2. Navigate to the homepage or any page with header
3. Open navigation dropdown ("Борис Лятошинський" or "Фундація" button)
4. Without closing the dropdown, scroll down the page
5. Verify that the dropdown automatically closes when scrolling down
6. Repeat steps 3-5 for the language switcher (globe icon)
7. Test other dropdowns on the site (filters, etc.) to ensure they still work as before

## Video / Screenshots

https://github.com/user-attachments/assets/817c0e16-bbd3-4977-bd7c-3f1f395c90a1

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
