### PR TITLE
fix(ui): fix responsive behavior of images according to grid layout

### DIFF
--- a/app/[lang]/layout.styles.ts
+++ b/app/[lang]/layout.styles.ts
@@ -8,6 +8,7 @@ export const styles = {
     position: 'relative',
     width: '100%',
     maxWidth: '100vw',
-    minHeight: 'calc(100vh + (100vw * 0.035))'
+    minHeight: 'calc(100vh + (100vw * 0.035))',
+    overflowX: 'clip'
   }
 };

--- a/app/shared/components/blocks/FoundationInfo/FoundationInfo.styles.tsx
+++ b/app/shared/components/blocks/FoundationInfo/FoundationInfo.styles.tsx
@@ -118,23 +118,14 @@ export const styles = {
     gridColumn: {
       xs: '2 / -1',
       sm: '4 / 7',
-      md: '6 / 10'
+      md: '6 / 9'
     },
     gridRow: { sm: '3' },
     position: 'relative',
     width: {
-      xs: '199px',
-      sm: '230px',
-      lg: '295px',
-      xl: '337px',
-      xxl: '407px'
-    },
-    height: {
-      xs: '260px',
-      sm: '299px',
-      lg: '350px',
-      xl: '400px',
-      xxl: '484px'
+      xs: '100%',
+      sm: '100%',
+      md: 'calc(100% + 40px)'
     }
   }
 };

--- a/app/shared/components/blocks/FoundationInfo/FoundationInfo.tsx
+++ b/app/shared/components/blocks/FoundationInfo/FoundationInfo.tsx
@@ -64,7 +64,20 @@ export default function FoundationInfo({ data }: { readonly data: IFoundationInf
 
       <Box sx={styles.bodyImage}>
         {image && (
-          <Image src={image.src} alt={image.alt} fill style={{ objectFit: 'contain', objectPosition: 'top' }} />
+          <Image
+            src={image.src}
+            alt={image.alt}
+            fill={false}
+            width={410}
+            height={490}
+            style={{
+              width: '100%',
+              height: 'auto',
+              objectFit: 'cover',
+              objectPosition: 'top',
+              position: 'relative'
+            }}
+          />
         )}
       </Box>
     </Box>

--- a/app/shared/components/blocks/IntroSection/IntroSection.tsx
+++ b/app/shared/components/blocks/IntroSection/IntroSection.tsx
@@ -33,6 +33,7 @@ export function IntroSection({ data }: { readonly data: IIntroSection }) {
             }}
             containerSx={styles.imageContainer}
             captionSx={styles.imageCaption}
+            imageSx={{ width: { xs: '80vw', sm: '60vw', xxl: '980px' } }}
           />
         )}
       </Box>

--- a/app/shared/components/blocks/our-mission/OurMission.tsx
+++ b/app/shared/components/blocks/our-mission/OurMission.tsx
@@ -56,6 +56,7 @@ const OurMission = ({ data }: { data: IOurMission }) => {
             left: { xs: 16, sm: 26, md: 41, lg: 40, xl: 40 }
           }}
           containerSx={styles.bigImg}
+          imageSx={{ width: { xs: '80vw', sm: '60vw', xxl: '816px' } }}
         />
       )}
     </Box>


### PR DESCRIPTION
## Description

Fixeі the adaptability of images on the "ПРо ФундАціЮ" page according to the grid

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the "ПРо ФундАціЮ" page.
2. Resize the window (mobile → tablet → desktop).
3. Make sure the images are aligned to the grid according to the design.

## Video / Screenshots

https://github.com/user-attachments/assets/b5c362dd-6905-4132-a1d5-7513d28b9a55

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board


