### PR TITLE
fix: removed transform from component, to use it later in parent comp…

### DIFF
--- a/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.styles.ts
+++ b/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.styles.ts
@@ -5,8 +5,7 @@ export const styles = {
     position: 'relative',
     width: width,
     height: height,
-    gridColumn: '1 / -1',
-    transform: 'skewY(-2deg)'
+    gridColumn: '1 / -1'
   }),
   border: (borderWidth: number, height: number) => ({
     display: 'block',


### PR DESCRIPTION
## Description

The component used a transform property that caused a visual bug with a protruding border, since the component can have different sizes on various pages.

A decision was made to remove the transform from this component so that it can be applied at the parent level instead. This approach prevents display issues and ensures the component’s tilt can be correctly adjusted in different contexts.

## Type of change

- [х] Bug fix

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. ...
2. ...

## Video / Screenshots

<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->

## Checklist

- [х] Code compiles and runs correctly
- [х] Tests pass successfully
- [х] Linting checks are clean
- [х] No Sonar issues
- [х] Branch is up to date with the target branch
- [х] Linked issue/task included
- [х] Task moved to the review column on the board

---
