### PR TITLE
refactor: add data-testid attributes to ContactsInfo component

### DIFF
--- a/app/[lang]/contacts/ContactsInfo/ContactsInfo.tsx
+++ b/app/[lang]/contacts/ContactsInfo/ContactsInfo.tsx
@@ -22,36 +22,48 @@ export default function ContactsInfo({ title, formTitle, contacts, socialLinks }
   const t = useTranslations('contactsInfoPage');
 
   return (
-    <Box sx={styles.root}>
+    <Box sx={styles.root} data-testid="ContactsInfo">
       <Box sx={styles.wrapper}>
         <Box sx={styles.contactsInfoWrapper}>
           {title ? (
-            <Typography sx={styles.title}>{title}</Typography>
+            <Typography sx={styles.title} data-testid="ContactsInfo-title">
+              {title}
+            </Typography>
           ) : (
-            <Typography sx={styles.titleMain} variant="h2">
+            <Typography sx={styles.titleMain} variant="h2" data-testid="ContactsInfo-title">
               {t('contacts')}
             </Typography>
           )}
           <Box sx={styles.contactsDetails}>
-            <Box sx={styles.contacts}>
-              <Typography variant="subtitle1">{t('phoneNumber')}:</Typography>
-              <Link variant="customSemiBold18">{contacts.phone}</Link>
+            <Box sx={styles.contacts} data-testid="ContactsInfo-phoneSection">
+              <Typography variant="subtitle1" data-testid="ContactsInfo-phoneLabel">
+                {t('phoneNumber')}:
+              </Typography>
+              <Link variant="customSemiBold18" data-testid="ContactsInfo-phoneLink">
+                {contacts.phone}
+              </Link>
             </Box>
-            <Box sx={styles.contacts}>
-              <Typography variant="subtitle1">{t('email')}:</Typography>
-              <Link variant="customSemiBold18">{contacts.email}</Link>
+            <Box sx={styles.contacts} data-testid="ContactsInfo-emailSection">
+              <Typography variant="subtitle1" data-testid="ContactsInfo-emailLabel">
+                {t('email')}:
+              </Typography>
+              <Link variant="customSemiBold18" data-testid="ContactsInfo-emailLink">
+                {contacts.email}
+              </Link>
             </Box>
           </Box>
-          <Box sx={styles.socialMediaWrapper}>
-            <Typography variant="subtitle1">{t('socialMedia')}:</Typography>
+          <Box sx={styles.socialMediaWrapper} data-testid="ContactsInfo-socialMediaSection">
+            <Typography variant="subtitle1" data-testid="ContactsInfo-socialMediaLabel">
+              {t('socialMedia')}:
+            </Typography>
             <FooterSocialMedia media={socialLinks} />
           </Box>
         </Box>
-        <PaperComponent sx={styles.formWrapper}>
-          <Typography sx={styles.formTitle} variant="h5">
+        <PaperComponent sx={styles.formWrapper} data-testid="ContactsInfo-formWrapper">
+          <Typography sx={styles.formTitle} variant="h5" data-testid="ContactsInfo-formTitle">
             {formTitle ?? t('formTitle')}
           </Typography>
-          <Typography sx={styles.formSubtitle} variant="subtitle1">
+          <Typography sx={styles.formSubtitle} variant="subtitle1" data-testid="ContactsInfo-formSubtitle">
             {t('formSubtitle')}
           </Typography>
           <ContactForm onSubmit={() => {}} />


### PR DESCRIPTION
## Description

Adds `data-testid` attributes to components on the Contacts page to enable automated testing. All identifiers follow the SUIT CSS naming convention for consistency and predictability.

- Added `data-testid` to ContactsInfo root component
- Added `data-testid` to contact details sections (phone, email)
- Added `data-testid` to social media section
- Added `data-testid` to contact form wrapper and titles
- All naming follows `ComponentName-descendantName` pattern

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Run the project locally
2. Navigate to the Contacts page (`/contacts` or `/en/contacts`)
3. Open browser DevTools
4. Inspect elements on the page
5. Verify that key elements have `data-testid` attributes:
   - Root container: `ContactsInfo`
   - Title: `ContactsInfo-title`
   - Phone section: `ContactsInfo-phoneSection`, `ContactsInfo-phoneLabel`, `ContactsInfo-phoneLink`
   - Email section: `ContactsInfo-emailSection`, `ContactsInfo-emailLabel`, `ContactsInfo-emailLink`
   - Social media: `ContactsInfo-socialMediaSection`, `ContactsInfo-socialMediaLabel`
   - Form wrapper: `ContactsInfo-formWrapper`, `ContactsInfo-formTitle`, `ContactsInfo-formSubtitle`
6. Run tests: `npm run test` - all tests should pass

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
