### PR TITLE
refactor: add ContactLink component

### DIFF
--- a/app/[lang]/contacts/ContactsInfo/ContactsInfo.tsx
+++ b/app/[lang]/contacts/ContactsInfo/ContactsInfo.tsx
@@ -45,7 +45,7 @@ export default function ContactsInfo({ title, formTitle, contacts, socialLinks }
                 value={contacts.phone}
                 isMobile={isMobile}
                 direction="column"
-                data-testid="ContactsInfo-phone"
+                data-testid="ContactsInfo-phoneLink"
               />
             </Box>
             <Box sx={styles.contacts} data-testid="ContactsInfo-emailSection">
@@ -54,7 +54,7 @@ export default function ContactsInfo({ title, formTitle, contacts, socialLinks }
                 label={t('email')}
                 value={contacts.email}
                 direction="column"
-                data-testid="ContactsInfo-email"
+                data-testid="ContactsInfo-emailLink"
               />
             </Box>
           </Box>

--- a/app/[lang]/contacts/ContactsInfo/ContactsInfo.tsx
+++ b/app/[lang]/contacts/ContactsInfo/ContactsInfo.tsx
@@ -1,12 +1,14 @@
 'use client';
-import { Box, Link, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 
 import { styles } from './ContactsInfo.styles';
 
+import { ContactLink } from '~/shared/components/contact-link/ContactLink';
 import FooterSocialMedia, { LinkIcon } from '~/shared/components/Footer/footer-social-media/FooterSocialMedia';
 import ContactForm from '~/shared/components/forms/contact-form/ContactForm';
 import PaperComponent from '~/shared/components/paper-component/PaperComponent';
+import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
 
 interface IContactInfoProps {
   title?: string;
@@ -20,6 +22,7 @@ interface IContactInfoProps {
 
 export default function ContactsInfo({ title, formTitle, contacts, socialLinks }: Readonly<IContactInfoProps>) {
   const t = useTranslations('contactsInfoPage');
+  const { isMobile } = useBreakpoints();
 
   return (
     <Box sx={styles.root} data-testid="ContactsInfo">
@@ -36,20 +39,23 @@ export default function ContactsInfo({ title, formTitle, contacts, socialLinks }
           )}
           <Box sx={styles.contactsDetails}>
             <Box sx={styles.contacts} data-testid="ContactsInfo-phoneSection">
-              <Typography variant="subtitle1" data-testid="ContactsInfo-phoneLabel">
-                {t('phoneNumber')}:
-              </Typography>
-              <Link variant="customSemiBold18" data-testid="ContactsInfo-phoneLink">
-                {contacts.phone}
-              </Link>
+              <ContactLink
+                type="phone"
+                label={t('phoneNumber')}
+                value={contacts.phone}
+                isMobile={isMobile}
+                direction="column"
+                data-testid="ContactsInfo-phone"
+              />
             </Box>
             <Box sx={styles.contacts} data-testid="ContactsInfo-emailSection">
-              <Typography variant="subtitle1" data-testid="ContactsInfo-emailLabel">
-                {t('email')}:
-              </Typography>
-              <Link variant="customSemiBold18" data-testid="ContactsInfo-emailLink">
-                {contacts.email}
-              </Link>
+              <ContactLink
+                type="email"
+                label={t('email')}
+                value={contacts.email}
+                direction="column"
+                data-testid="ContactsInfo-email"
+              />
             </Box>
           </Box>
           <Box sx={styles.socialMediaWrapper} data-testid="ContactsInfo-socialMediaSection">

--- a/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.styles.ts
+++ b/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.styles.ts
@@ -8,26 +8,6 @@ const commonTextStyle = {
   fontSize: { xs: '16px', sm: '16px' }
 };
 
-const commonLinkStyle = {
-  textDecoration: 'underline',
-  transition: 'color 0.2s ease',
-
-  '&:hover': {
-    color: '#5F0E0F',
-    cursor: 'pointer'
-  },
-
-  '&:active': {
-    color: mainHexPallete.black
-  },
-
-  '&.Mui-disabled, &[aria-disabled="true"], &:disabled': {
-    color: mainHexPallete.blue[500],
-    pointerEvents: 'none',
-    textDecoration: 'underline'
-  }
-};
-
 export const styles = {
   container: {
     width: '100%',
@@ -48,16 +28,6 @@ export const styles = {
     ...commonTextStyle,
     fontWeight: 400,
     lineHeight: '150%'
-  },
-  weakText: {
-    ...commonTextStyle,
-    color: mainHexPallete.brown[700],
-    marginRight: '10px'
-  },
-  link: {
-    ...commonTextStyle,
-    ...commonLinkStyle,
-    marginTop: '2px'
   },
   linkContainer: {
     display: 'flex'

--- a/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.tsx
+++ b/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.tsx
@@ -1,9 +1,11 @@
 'use client';
-import { Box, Link, Typography } from '@mui/material';
+
+import { Box, Typography } from '@mui/material';
 import React, { FC } from 'react';
 
 import { useIsMobile } from '~/hooks/is-mobile/useIsMobile';
 
+import { ContactLink } from '../../contact-link/ContactLink';
 import { styles } from './FooterContactInfo.styles';
 
 interface FooterContactInfoProps {
@@ -22,13 +24,6 @@ interface FooterContactInfoProps {
 const FooterContactInfo: FC<FooterContactInfoProps> = ({ contacts, labels, alertMsg }) => {
   const isMobile = useIsMobile();
 
-  const copyPhoneToClipboard = () => {
-    navigator.clipboard.writeText(contacts.phone);
-    alert(alertMsg);
-  };
-
-  const telLinkProps = isMobile ? { href: `tel:${contacts.phone}` } : { onClick: copyPhoneToClipboard, href: '#' };
-
   return (
     <Box sx={styles.container}>
       <Box sx={styles.titleAndAddressCont}>
@@ -38,18 +33,21 @@ const FooterContactInfo: FC<FooterContactInfoProps> = ({ contacts, labels, alert
         </Box>
       </Box>
       <Box>
-        <Box sx={styles.linkContainer} style={{ marginBottom: '4px' }}>
-          <Typography sx={styles.weakText}>{labels.phoneLabel}:</Typography>
-          <Link sx={styles.link} {...telLinkProps}>
-            {contacts.phone}
-          </Link>
-        </Box>
-        <Box sx={styles.linkContainer}>
-          <Typography sx={styles.weakText}>Email: </Typography>
-          <Link sx={styles.link} href={`mailto:${contacts.email}`}>
-            {contacts.email}
-          </Link>
-        </Box>
+        <ContactLink
+          type="phone"
+          value={contacts.phone}
+          label={labels.phoneLabel}
+          alertMsg={alertMsg}
+          isMobile={isMobile}
+          linkSx={{ fontWeight: 400 }}
+        />
+        <ContactLink
+          type="email"
+          value={contacts.email}
+          label="Email"
+          alertMsg={alertMsg}
+          linkSx={{ fontWeight: 400 }}
+        />
       </Box>
     </Box>
   );

--- a/app/shared/components/blocks/FAQ/FAQ.styles.ts
+++ b/app/shared/components/blocks/FAQ/FAQ.styles.ts
@@ -1,5 +1,3 @@
-import { mainHexPallete } from '~/ds-components/theme/colors';
-
 export const styles = {
   gridContainer: {
     display: 'grid',
@@ -39,34 +37,6 @@ export const styles = {
     display: 'flex',
     gap: '8px',
     alignItems: 'center'
-  },
-  linkItem: {
-    fontFamily: 'Mulish',
-    fontSize: '16px',
-    fontWeight: 600,
-    lineHeight: '110%',
-    textDecoration: 'underline',
-
-    '&:hover': {
-      color: '#5F0E0F',
-      cursor: 'pointer'
-    },
-
-    '&:active': {
-      color: mainHexPallete.black
-    },
-
-    '&.Mui-disabled, &[aria-disabled="true"], &:disabled': {
-      color: mainHexPallete.blue[500],
-      pointerEvents: 'none',
-      textDecoration: 'underline'
-    }
-  },
-  iconButton: {
-    backgroundColor: 'rgba(25, 13, 3, 0.1)',
-    '&:disabled': {
-      backgroundColor: 'rgba(25, 13, 3, 0.1)'
-    }
   },
   faq: {
     gridColumn: { xs: '1 / -1', sm: '4 / -1', md: '6 / -1' },

--- a/app/shared/components/blocks/FAQ/FAQ.tsx
+++ b/app/shared/components/blocks/FAQ/FAQ.tsx
@@ -1,14 +1,12 @@
 'use client';
 
-import { Box, Link, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 
-import { Svg } from '~/components/colored-svg/ColoredSvg';
 import SectionTitle from '~/components/section-title/SectionTitle';
 import { FaqAccordion } from '~/ds-components/faq-accordion/FaqAccordion';
-import { IconButton } from '~/ds-components/icon-button/IconButton';
-import { mainHexPallete } from '~/ds-components/theme/colors';
 
+import { ContactLink } from '../../contact-link/ContactLink';
 import { styles } from './FAQ.styles';
 
 import MailIcon from '~/public/icons/mail.svg';
@@ -34,13 +32,6 @@ const Faq = ({ data }: { readonly data: Readonly<FaqProps> }) => {
   const t = useTranslations('supportUs.faq');
   const { isMobile } = useBreakpoints();
 
-  const copyPhoneToClipboard = () => {
-    navigator.clipboard.writeText(contacts.phone);
-    alert(t('phoneCopiedAlert'));
-  };
-
-  const telLinkProps = isMobile ? { href: `tel:${contacts.phone}` } : { onClick: copyPhoneToClipboard, href: '#' };
-
   const faqItems = faq.map((item) => {
     return <FaqAccordion key={item.title} title={item.title} content={item.content} />;
   });
@@ -57,20 +48,16 @@ const Faq = ({ data }: { readonly data: Readonly<FaqProps> }) => {
         <Typography sx={styles.typography}>{t('subtitle.answer')}</Typography>
         <Box sx={styles.contactsList}>
           <Box sx={styles.contactsItem}>
-            <IconButton customStyles={styles.iconButton} disabled>
-              <Svg Component={PhoneIcon} stroke={mainHexPallete.black} alt="phone icon" width="20px" height="20px" />
-            </IconButton>
-            <Link sx={styles.linkItem} {...telLinkProps}>
-              {contacts.phone}
-            </Link>
+            <ContactLink
+              type="phone"
+              icon={PhoneIcon}
+              value={contacts.phone}
+              isMobile={isMobile}
+              alertMsg={t('phoneCopiedAlert')}
+            />
           </Box>
           <Box sx={styles.contactsItem}>
-            <IconButton customStyles={styles.iconButton} disabled>
-              <Svg Component={MailIcon} stroke={mainHexPallete.black} alt="mail icon" width="20px" height="20px" />
-            </IconButton>
-            <Link sx={styles.linkItem} href={`mailto:${contacts.email}`}>
-              {contacts.email}
-            </Link>
+            <ContactLink type="email" icon={MailIcon} value={contacts.email} />
           </Box>
         </Box>
       </Box>

--- a/app/shared/components/contact-link/ContactLink.styles.ts
+++ b/app/shared/components/contact-link/ContactLink.styles.ts
@@ -1,0 +1,64 @@
+import { mainHexPallete, rgbButtonColors } from '~/ds-components/theme/colors';
+
+const commonLinkBaseStyles = {
+  fontFamily: 'Mulish, Sans-serif',
+  fontSize: '16px',
+  fontWeight: 600,
+  lineHeight: '110%',
+  textDecoration: 'underline',
+  transition: 'color 0.2s ease'
+};
+
+const commonTextStyle = {
+  fontFamily: 'Mulish, Sans-serif',
+  color: mainHexPallete.black,
+  letterSpacing: '0px',
+  whiteSpace: 'pre-line',
+  fontSize: { xs: '16px', sm: '16px' }
+};
+
+const getCommonLinkStates = (palette = mainHexPallete) => ({
+  color: palette.black,
+  '&:hover': {
+    color: '#5F0E0F',
+    cursor: 'pointer'
+  },
+
+  '&:active': {
+    color: palette.black
+  },
+
+  '&.Mui-disabled, &[aria-disabled="true"]': {
+    color: palette.blue[500],
+    pointerEvents: 'none',
+    textDecoration: 'none'
+  }
+});
+
+const commonLinkStates = getCommonLinkStates(mainHexPallete);
+const pressedBg = rgbButtonColors.primaryOutlinedPressedBackground;
+
+export const styles = {
+  wrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px'
+  },
+
+  iconButton: {
+    backgroundColor: pressedBg,
+    '&:disabled': {
+      backgroundColor: pressedBg
+    }
+  },
+
+  weakText: {
+    ...commonTextStyle,
+    color: mainHexPallete.brown[700]
+  },
+
+  link: {
+    ...commonLinkBaseStyles,
+    ...commonLinkStates
+  }
+};

--- a/app/shared/components/contact-link/ContactLink.test.tsx
+++ b/app/shared/components/contact-link/ContactLink.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ContactLink } from './ContactLink';
+
+const mockWriteText = jest.fn();
+Object.assign(navigator, {
+  clipboard: { writeText: mockWriteText }
+});
+
+const IconMock = (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="mock-icon" {...props} />;
+
+describe('ContactLink component', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with label', () => {
+    render(<ContactLink type="email" value="test@example.com" label="Email" />);
+
+    expect(screen.getByText('Email:')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /test@example.com/i })).toHaveAttribute('href', 'mailto:test@example.com');
+  });
+
+  it('renders with icon', () => {
+    render(<ContactLink type="phone" value="+380123456789" icon={IconMock} isMobile />);
+
+    expect(screen.getByTestId('mock-icon')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'tel:+380123456789');
+  });
+
+  it('copies phone to clipboard when clicked on desktop', async () => {
+    render(<ContactLink type="phone" label="Phone" value="+380123456789" isMobile={false} />);
+
+    const link = screen.getByRole('link');
+    fireEvent.click(link);
+
+    expect(mockWriteText).toHaveBeenCalledWith('+380123456789');
+  });
+
+  it('does nothing when disabled', () => {
+    render(<ContactLink type="phone" label="Phone" value="+380111111111" disabled />);
+
+    const link = screen.getByRole('link');
+    fireEvent.click(link);
+
+    expect(mockWriteText).not.toHaveBeenCalled();
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+    expect(link).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('renders in column direction correctly', () => {
+    render(<ContactLink type="email" value="column@example.com" label="Email" direction="column" />);
+
+    const box = screen.getByText('Email:').parentElement;
+    expect(box).toHaveStyle({ flexDirection: 'column' });
+  });
+
+  it('applies custom linkSx styles', () => {
+    render(<ContactLink type="email" value="style@example.com" label="Email" linkSx={{ color: 'red' }} />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveStyle({ color: 'red' });
+  });
+});

--- a/app/shared/components/contact-link/ContactLink.test.tsx
+++ b/app/shared/components/contact-link/ContactLink.test.tsx
@@ -14,21 +14,21 @@ describe('ContactLink component', () => {
     jest.clearAllMocks();
   });
 
-  it('renders with label', () => {
+  it('Should render with label', () => {
     render(<ContactLink type="email" value="test@example.com" label="Email" />);
 
     expect(screen.getByText('Email:')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /test@example.com/i })).toHaveAttribute('href', 'mailto:test@example.com');
   });
 
-  it('renders with icon', () => {
+  it('Should render with icon', () => {
     render(<ContactLink type="phone" value="+380123456789" icon={IconMock} isMobile />);
 
     expect(screen.getByTestId('mock-icon')).toBeInTheDocument();
     expect(screen.getByRole('link')).toHaveAttribute('href', 'tel:+380123456789');
   });
 
-  it('copies phone to clipboard when clicked on desktop', async () => {
+  it('Should copy phone to clipboard when clicked on desktop', async () => {
     render(<ContactLink type="phone" label="Phone" value="+380123456789" isMobile={false} />);
 
     const link = screen.getByRole('link');
@@ -37,7 +37,7 @@ describe('ContactLink component', () => {
     expect(mockWriteText).toHaveBeenCalledWith('+380123456789');
   });
 
-  it('does nothing when disabled', () => {
+  it('Should do nothing when disabled', () => {
     render(<ContactLink type="phone" label="Phone" value="+380111111111" disabled />);
 
     const link = screen.getByRole('link');
@@ -48,14 +48,14 @@ describe('ContactLink component', () => {
     expect(link).toHaveAttribute('tabindex', '-1');
   });
 
-  it('renders in column direction correctly', () => {
+  it('Should render in column direction correctly', () => {
     render(<ContactLink type="email" value="column@example.com" label="Email" direction="column" />);
 
     const box = screen.getByText('Email:').parentElement;
     expect(box).toHaveStyle({ flexDirection: 'column' });
   });
 
-  it('applies custom linkSx styles', () => {
+  it('Should apply custom linkSx styles', () => {
     render(<ContactLink type="email" value="style@example.com" label="Email" linkSx={{ color: 'red' }} />);
 
     const link = screen.getByRole('link');

--- a/app/shared/components/contact-link/ContactLink.tsx
+++ b/app/shared/components/contact-link/ContactLink.tsx
@@ -1,0 +1,88 @@
+import { Box, Link, Typography } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+import { Svg } from '~/components/colored-svg/ColoredSvg';
+import { IconButton } from '~/ds-components/icon-button/IconButton';
+import { mainHexPallete } from '~/ds-components/theme/colors';
+
+import { styles } from './ContactLink.styles';
+
+import { sxToArray } from '~/lib/utils/sxToArray';
+
+type ContactLinkType = 'phone' | 'email';
+type ContactLinkDirection = 'row' | 'column';
+type ContactIconType = React.ComponentType<React.SVGProps<SVGSVGElement>>;
+
+interface ContactLinkProps {
+  type: ContactLinkType;
+  value: string;
+  label?: string;
+  icon?: ContactIconType;
+  alertMsg?: string;
+  isMobile?: boolean;
+  disabled?: boolean;
+  linkSx?: SxProps<Theme>;
+  direction?: ContactLinkDirection;
+}
+
+type LinkProps = {
+  href: string;
+  onClick?: () => void;
+};
+
+type GetLinkPropsType = (type: ContactLinkType, value: string, isMobile: boolean, handleCopy: () => void) => LinkProps;
+
+const getLinkProps: GetLinkPropsType = (type, value, isMobile, handleCopy) => {
+  if (type === 'phone') {
+    return isMobile ? { href: `tel:${value}` } : { href: '#', onClick: handleCopy };
+  }
+  return { href: `mailto:${value}` };
+};
+
+export const ContactLink = ({
+  type,
+  value,
+  label,
+  icon,
+  alertMsg,
+  linkSx,
+  isMobile = false,
+  disabled = false,
+  direction = 'row'
+}: ContactLinkProps) => {
+  const handleCopy = () => {
+    if (disabled) return;
+    navigator.clipboard.writeText(value);
+    if (alertMsg) alert(alertMsg);
+  };
+
+  const linkProps = getLinkProps(type, value, isMobile, handleCopy);
+
+  return (
+    <Box
+      sx={{
+        ...styles.wrapper,
+        flexDirection: direction,
+        alignItems: direction === 'column' ? 'flex-start' : 'center'
+      }}
+    >
+      {icon && (
+        <IconButton customStyles={styles.iconButton} disabled>
+          <Svg Component={icon} stroke={mainHexPallete.black} width="20px" height="20px" alt={`${type} icon`} />
+        </IconButton>
+      )}
+
+      {label && <Typography sx={styles.weakText}>{label}:</Typography>}
+
+      <Link
+        sx={[styles.link, ...sxToArray(linkSx)]}
+        {...linkProps}
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : 0}
+        onClick={disabled ? (e) => e.preventDefault() : linkProps.onClick}
+      >
+        {value}
+      </Link>
+    </Box>
+  );
+};


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this PR and what was changed -->
Replaced duplicated contact display code with a reusable ContactLink component.
The component supports both icon and label modes, depending on the design context

### Props

| Name | Type | Description |
|------|------|-------------|
| `type` | `'phone' \| 'email'` | Defines the contact type. |
| `value` | `string` | Phone number or email address. |
| `label` | `string` *(optional)* | Text label displayed before the value (used in label mode). |
| `icon` | `React.ComponentType` *(optional)* | SVG icon displayed before the value (used in icon mode). |
| `alertMsg` | `string` *(optional)* | Message shown after copying the value (temporary alert). |
| `isMobile` | `boolean` *(optional)* | Enables `tel:` behavior on mobile devices. |
| `disabled` | `boolean` *(optional)* | Disables interactions and applies a muted style. |
| `linkSx` | `SxProps<Theme>` *(optional)* | Additional styles for the link. |
| `direction` | `'row' \| 'column'` *(optional)* | Layout direction for label/icon and value. |

 
## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. **Navigate to a page that uses the new component**
   - For example: `SupportUs → FAQ` section.
   - The `ContactLink` component replaces the previous duplicated contact markup.

2. **Verify rendering**
   - Phone link displays an **icon** when `icon` is provided.  
   - Email link displays a **label** when `label` is provided.  
   - Layout direction changes correctly between `row` and `column`.

3. **Check interactions**
   - On **desktop**, clicking the phone number copies it to the clipboard and shows a temporary alert.  
   - On **mobile**, clicking the phone number opens the dialer (`tel:`).  
   - ⚠️ **Note:** I don’t have a mail client configured locally, so please pay special attention when testing that clicking an email address opens the default mail client (`mailto:`).  
   - When `disabled` is set to `true`, the link is non-clickable and styled as muted.

4. **Perform visual checks**
   - Verify spacing, alignment, and direction match the design.  
   - Check hover, active, and disabled states.  
   - Ensure icon and text colors follow the main palette (`mainHexPallete`).

5. **(Optional)**
   - Pass custom `linkSx` styles and confirm they merge correctly via `sxToArray`.  
   - Resize the viewport to ensure the component behaves as expected on mobile and desktop.



## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
