### PR TITLE
Fix(ui): unify clear filter button styles and extract into reusable component

### DIFF
--- a/app/shared/components/design-system/all-components/clear-filter-button/ClearFilterButton.styles.ts
+++ b/app/shared/components/design-system/all-components/clear-filter-button/ClearFilterButton.styles.ts
@@ -1,0 +1,28 @@
+import { mainHexPallete, rgbaClearFilterButton } from '~/ds-components/theme/colors';
+
+export const styles = {
+  button: {
+    lineHeight: '140%',
+    width: '100%',
+    borderRadius: '8px',
+    display: 'flex',
+    justifyContent: 'flex-start',
+    color: rgbaClearFilterButton.defaultTextColor,
+
+    '& svg path, & svg circle, & svg line, & svg rect': {
+      stroke: 'currentColor'
+    },
+
+    '&:hover': {
+      backgroundColor: mainHexPallete.red[50]
+    },
+
+    '&:focus-visible': {
+      color: mainHexPallete.red[700]
+    },
+
+    '&:active': {
+      color: mainHexPallete.red[700]
+    }
+  }
+};

--- a/app/shared/components/design-system/all-components/clear-filter-button/ClearFilterButton.test.tsx
+++ b/app/shared/components/design-system/all-components/clear-filter-button/ClearFilterButton.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import ClearFilterButton from './ClearFilterButton';
+
+jest.mock('~/i18n/navigation', () => ({
+  Link: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>
+}));
+
+jest.mock('~/components/colored-svg/ColoredSvg', () => ({
+  Svg: ({ alt }: any) => <svg data-testid="svg-icon" aria-label={alt} />
+}));
+
+jest.mock('~/public/icons/trash-2.svg', () => {
+  const MockTrashIcon = () => <svg data-testid="trash-icon" />;
+  MockTrashIcon.displayName = 'TrashIcon';
+  return MockTrashIcon;
+});
+
+describe('ClearFilterButton', () => {
+  it('should render with text', () => {
+    render(<ClearFilterButton onClick={() => {}}>Clear</ClearFilterButton>);
+    expect(screen.getByText('Clear')).toBeInTheDocument();
+  });
+
+  it('should call onClick when clicked', () => {
+    const onClick = jest.fn();
+    render(<ClearFilterButton onClick={onClick}>Clear</ClearFilterButton>);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render start icon', () => {
+    render(<ClearFilterButton onClick={() => {}}>Clear</ClearFilterButton>);
+    const svg = screen.getByRole('button').querySelector('svg');
+    expect(svg).not.toBeNull();
+  });
+});

--- a/app/shared/components/design-system/all-components/clear-filter-button/ClearFilterButton.tsx
+++ b/app/shared/components/design-system/all-components/clear-filter-button/ClearFilterButton.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Svg } from '~/components/colored-svg/ColoredSvg';
 import Button from '~/ds-components/button/Button';
 import { rgbaClearFilterButton } from '~/ds-components/theme/colors';
@@ -9,8 +7,8 @@ import { styles } from './ClearFilterButton.styles';
 import TrashIcon from '~/public/icons/trash-2.svg';
 
 interface ClearFilterButtonProps {
-  onClick: () => void;
-  children: React.ReactNode;
+  readonly onClick: () => void;
+  readonly children: React.ReactNode;
 }
 
 export default function ClearFilterButton({ onClick, children }: ClearFilterButtonProps) {

--- a/app/shared/components/design-system/all-components/clear-filter-button/ClearFilterButton.tsx
+++ b/app/shared/components/design-system/all-components/clear-filter-button/ClearFilterButton.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Svg } from '~/components/colored-svg/ColoredSvg';
+import Button from '~/ds-components/button/Button';
+import { rgbaClearFilterButton } from '~/ds-components/theme/colors';
+
+import { styles } from './ClearFilterButton.styles';
+
+import TrashIcon from '~/public/icons/trash-2.svg';
+
+interface ClearFilterButtonProps {
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+export default function ClearFilterButton({ onClick, children }: ClearFilterButtonProps) {
+  return (
+    <Button
+      variant="text"
+      startIcon={<Svg Component={TrashIcon} alt="clear" stroke={rgbaClearFilterButton.defaultTextColor} />}
+      onClick={onClick}
+      sx={styles.button}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/app/shared/components/design-system/all-components/filtering/numeric/NumericFiltering.tsx
+++ b/app/shared/components/design-system/all-components/filtering/numeric/NumericFiltering.tsx
@@ -1,18 +1,15 @@
 'use client';
 
-import { Box, Divider, styled } from '@mui/material';
+import { Box, Divider } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { Svg } from '~/components/colored-svg/ColoredSvg';
-import Button from '~/ds-components/button/Button';
 import { DesignSystemSlider } from '~/ds-components/slider/Slider';
 import TextField from '~/ds-components/text-field/TextField';
-import { mainHexPallete, rgbaClearFilterButton } from '~/ds-components/theme/colors';
 
+import ClearFilterButton from '../../clear-filter-button/ClearFilterButton';
 import { styles } from './NumericFiltering.styles';
 
-import TrashIcon from '~/public/icons/trash-2.svg';
 import { getFilteringSchema } from '~/validators/filtering.schema';
 
 interface NumericFilteringProps {
@@ -22,39 +19,6 @@ interface NumericFilteringProps {
   minNumber?: number;
   maxNumber?: number;
 }
-
-const CustomButton = styled(Button)(() => ({
-  lineHeight: '140%',
-  color: rgbaClearFilterButton.defaultTextColor,
-  width: '100%',
-  display: 'flex',
-  justifyContent: 'flex-start',
-  borderRadius: '8px',
-
-  '&:hover': {
-    backgroundColor: mainHexPallete.red[50],
-    color: rgbaClearFilterButton.defaultTextColor
-  },
-  '&:focus-visible': {
-    color: mainHexPallete.red[700]
-  },
-  '&:active': {
-    color: mainHexPallete.red[700]
-  },
-
-  '& svg': {
-    color: rgbaClearFilterButton.defaultTextColor
-  },
-  '&:hover svg': {
-    color: rgbaClearFilterButton.defaultTextColor
-  },
-  '&:focus-visible svg': {
-    color: mainHexPallete.red[700]
-  },
-  '&:active svg': {
-    color: mainHexPallete.red[700]
-  }
-}));
 
 const minDistance = 1;
 
@@ -166,21 +130,7 @@ const NumericFiltering: React.FC<NumericFilteringProps> = ({
       <Box>
         <Divider sx={styles.divider} />
         <Box sx={styles.footer}>
-          <CustomButton
-            startIcon={
-              <Svg
-                Component={TrashIcon}
-                alt="trash"
-                stroke={rgbaClearFilterButton.defaultTextColor}
-                width="20px"
-                height="22px"
-              />
-            }
-            onClick={handleClearFilter}
-            variant="text"
-          >
-            {t('clear')}
-          </CustomButton>
+          <ClearFilterButton onClick={handleClearFilter}>{t('clear')}</ClearFilterButton>
         </Box>
       </Box>
     </Box>

--- a/app/shared/components/design-system/all-components/filtering/numeric/NumericFiltering.tsx
+++ b/app/shared/components/design-system/all-components/filtering/numeric/NumericFiltering.tsx
@@ -4,10 +4,10 @@ import { Box, Divider } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import ClearFilterButton from '~/ds-components/clear-filter-button/ClearFilterButton';
 import { DesignSystemSlider } from '~/ds-components/slider/Slider';
 import TextField from '~/ds-components/text-field/TextField';
 
-import ClearFilterButton from '../../clear-filter-button/ClearFilterButton';
 import { styles } from './NumericFiltering.styles';
 
 import { getFilteringSchema } from '~/validators/filtering.schema';

--- a/app/shared/components/design-system/all-components/selector/FilterSelect.test.tsx
+++ b/app/shared/components/design-system/all-components/selector/FilterSelect.test.tsx
@@ -31,6 +31,9 @@ jest.mock('~/components/colored-svg/ColoredSvg', () => ({
     </div>
   )
 }));
+jest.mock('~/i18n/navigation', () => ({
+  Link: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>
+}));
 
 describe('FilterSelect', () => {
   it('should render the label', () => {

--- a/app/shared/components/design-system/all-components/selector/FilterSelect.tsx
+++ b/app/shared/components/design-system/all-components/selector/FilterSelect.tsx
@@ -5,16 +5,13 @@ import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import React, { useEffect, useRef, useState } from 'react';
 
-import { Svg } from '~/components/colored-svg/ColoredSvg';
 import { Chip } from '~/ds-components/chip/Chip';
 import DropdownMenu from '~/ds-components/dropdown-menu/DropdownMenu';
 import FilterSelectItem from '~/ds-components/selector/FilterSelectItem/FilterSelectItem';
-import { mainHexPallete } from '~/ds-components/theme/colors';
 
+import ClearFilterButton from '../clear-filter-button/ClearFilterButton';
 import { filterSelectStyles } from './FilterSelect.styles';
 import { PositionEnum } from '~/types/enums/common.enums';
-
-import Trash from '~/public/icons/trash-2.svg';
 
 interface FilterOption {
   value: string;
@@ -107,12 +104,7 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
         })}
       </Box>
       <Divider sx={{ my: 1 }} />
-      <Box sx={filterSelectStyles.clearAllContainer} onClick={handleChipDelete}>
-        <Svg Component={Trash} alt="clear" stroke={mainHexPallete.red[600]} />
-        <Typography variant="customSemiBold16" sx={{ color: mainHexPallete.red[600], whiteSpace: 'nowrap' }}>
-          {t('clear')}
-        </Typography>
-      </Box>
+      <ClearFilterButton onClick={handleChipDelete}>{t('clear')}</ClearFilterButton>
     </Box>
   );
 


### PR DESCRIPTION
## Description

Unified the Clear button styling across filter components and extracted it into a reusable ClearFilterButton component.  

## Type of change

- [x] Bug fix

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open any table with filters (e.g., composition table).
2. Open genre / category filter dropdown and verify clear button matches design system and numeric clear button.
3. Open numeric filter and verify clear button matches design system.

## Video / Screenshots

https://github.com/user-attachments/assets/7d925b1b-778d-40fb-ac10-40959bc9398b

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
