### PR TITLE
test: add MusicTableCells unit tests

### DIFF
--- a/app/shared/components/tables/CompositionTable/MusicTableCells.test.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableCells.test.tsx
@@ -1,0 +1,212 @@
+import '@testing-library/jest-dom';
+import { CellContext, Row } from '@tanstack/react-table';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import {
+  RenderActionsCell,
+  RenderExpanderCell,
+  RenderGenreCell,
+  RenderGenreHeader,
+  renderGroupActions,
+  renderNameCell,
+  RenderNameHeader,
+  renderOpusGroupLabel,
+  RenderOpusHeader,
+  renderOpusTitleGroupLabel,
+  RenderPlayCell,
+  renderYearCell,
+  RenderYearHeader
+} from './MusicTableCells';
+import { Music } from '~/types/types/enhancedTable';
+
+import { useAudioPlayer } from '~/shared/context/AudioPlayerContext';
+import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key
+}));
+
+jest.mock('~/i18n/navigation', () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>
+}));
+
+jest.mock('~/shared/components/design-system/all-components/Ellipsis/Ellipsis', () => {
+  const Ellipsis = ({ text }: { text: string }) => {
+    return <div>{text}</div>;
+  };
+  return { __esModule: true, Ellipsis };
+});
+
+jest.mock('~/components/colored-svg/ColoredSvg', () => {
+  const Svg = () => <div data-testid="mock-svg" />;
+  return { __esModule: true, Svg };
+});
+
+jest.mock('~/shared/context/AudioPlayerContext', () => ({
+  useAudioPlayer: jest.fn()
+}));
+
+jest.mock('~/shared/hooks/use-breakpoints/useBreakpoints', () => jest.fn());
+
+const mockUseAudioPlayer = useAudioPlayer as jest.Mock;
+const mockUseBreakpoints = useBreakpoints as jest.Mock;
+
+const mockMusic: Music = {
+  id: '1',
+  name: 'Poem about the Forest',
+  year: 1918,
+  opus: 'op.50',
+  opusTitle: 'Symphony No. 3 in B minor',
+  audioAvailable: true,
+  sheetAvailable: true,
+  sheetMusic: [
+    {
+      url: '',
+      isFree: true,
+      dateUploaded: ''
+    }
+  ]
+};
+
+const mockRow = {
+  original: mockMusic,
+  getCanExpand: jest.fn(() => false)
+} as unknown as Row<Music>;
+
+const mockCellContext = {
+  row: mockRow
+} as CellContext<Music, unknown>;
+
+const useAudioPlayerMockReturn = {
+  playTrack: jest.fn(),
+  togglePlay: jest.fn(),
+  isPlaying: true,
+  src: `/api/blob-url?blobName=${encodeURIComponent(mockMusic.name)}&folderName=compositions`
+};
+
+describe('MusicTableCells', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Header renderers', () => {
+    it('renders all headers with correct translation keys', () => {
+      render(
+        <>
+          <RenderOpusHeader />
+          <RenderNameHeader />
+          <RenderYearHeader />
+          <RenderGenreHeader />
+        </>
+      );
+      expect(screen.getByText('opus')).toBeInTheDocument();
+      expect(screen.getByText('name')).toBeInTheDocument();
+      expect(screen.getByText('year')).toBeInTheDocument();
+      expect(screen.getByText('genre')).toBeInTheDocument();
+    });
+  });
+
+  describe('Basic cell renderers', () => {
+    it('renders name and year cells with values', () => {
+      const nameCell = renderNameCell({ getValue: () => 'Poem about the Forest' } as CellContext<Music, unknown>);
+      const yearCell = renderYearCell({ getValue: () => '1918' } as CellContext<Music, unknown>);
+      const { getByText } = render(
+        <>
+          {nameCell}
+          {yearCell}
+        </>
+      );
+      expect(getByText('Poem about the Forest')).toBeInTheDocument();
+      expect(getByText('1918')).toBeInTheDocument();
+    });
+
+    it('renders genre cell joined with commas', () => {
+      const genreCell = RenderGenreCell({ getValue: () => ['Classical', 'Romantic'] } as CellContext<Music, unknown>);
+      const { getByText } = render(<>{genreCell}</>);
+      expect(getByText('Classical, Romantic')).toBeInTheDocument();
+    });
+
+    it('renders nothing if no genres', () => {
+      const genreCell = RenderGenreCell({ getValue: () => [] } as CellContext<Music, unknown>);
+      const { container } = render(<>{genreCell}</>);
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('PlayCell', () => {
+    it('renders play icon', () => {
+      mockUseAudioPlayer.mockReturnValue(useAudioPlayerMockReturn);
+      const { getByTestId } = render(RenderPlayCell(mockCellContext));
+      expect(getByTestId('mock-svg')).toBeInTheDocument();
+    });
+
+    it('calls playTrack when clicked if different track', () => {
+      mockUseAudioPlayer.mockReturnValue({ ...useAudioPlayerMockReturn, src: 'different-src' });
+      const { getByRole } = render(RenderPlayCell(mockCellContext));
+      fireEvent.click(getByRole('button', { hidden: true }));
+      expect(useAudioPlayerMockReturn.playTrack).toHaveBeenCalledWith(
+        expect.stringContaining('compositions'),
+        mockMusic.name
+      );
+    });
+
+    it('calls togglePlay when same track is playing', () => {
+      mockUseAudioPlayer.mockReturnValue(useAudioPlayerMockReturn);
+      const { getByRole } = render(RenderPlayCell(mockCellContext));
+      fireEvent.click(getByRole('button', { hidden: true }));
+      expect(useAudioPlayerMockReturn.togglePlay).toHaveBeenCalled();
+    });
+  });
+
+  describe('ActionsCell', () => {
+    it('renders button when desktop', () => {
+      mockUseBreakpoints.mockReturnValue({
+        isDesktop: true
+      });
+      const onAction = jest.fn();
+      const { getByText } = render(RenderActionsCell(mockCellContext, onAction));
+      const desktopBtn = getByText('viewSheetMusic');
+      expect(desktopBtn).toBeInTheDocument();
+      fireEvent.click(desktopBtn);
+      expect(onAction).toHaveBeenCalled();
+    });
+
+    it('renders icon button on laptop', () => {
+      mockUseBreakpoints.mockReturnValue({
+        isLaptop: true
+      });
+      const onAction = jest.fn();
+      const { getByAltText } = render(RenderActionsCell(mockCellContext, onAction));
+      expect(getByAltText('viewSheetMusic')).toBeInTheDocument();
+    });
+  });
+
+  describe('Group renderers', () => {
+    it('renders opus label', () => {
+      const { getByText } = render(renderOpusGroupLabel([mockMusic]));
+      expect(getByText('op.50')).toBeInTheDocument();
+    });
+
+    it('renders opus title label', () => {
+      const { getByText } = render(renderOpusTitleGroupLabel([mockMusic]));
+      expect(getByText('Symphony No. 3 in B minor')).toBeInTheDocument();
+    });
+
+    it('renders group actions icon', () => {
+      const { getByAltText } = render(renderGroupActions());
+      expect(getByAltText('menu')).toBeInTheDocument();
+    });
+  });
+
+  describe('RenderExpanderCell', () => {
+    it('renders expander icon for group rows', () => {
+      mockUseBreakpoints.mockReturnValue({
+        isMobile: true
+      });
+      mockUseAudioPlayer.mockReturnValue(useAudioPlayerMockReturn);
+      const { getByTestId } = render(RenderExpanderCell(mockCellContext));
+      expect(getByTestId('mock-svg')).toBeInTheDocument();
+    });
+  });
+});

--- a/app/shared/components/tables/CompositionTable/MusicTableCells.test.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableCells.test.tsx
@@ -91,7 +91,7 @@ describe('MusicTableCells', () => {
   });
 
   describe('Header renderers', () => {
-    it('renders all headers with correct translation keys', () => {
+    it('should render all headers with correct translation keys', () => {
       render(
         <>
           <RenderOpusHeader />
@@ -108,7 +108,7 @@ describe('MusicTableCells', () => {
   });
 
   describe('Basic cell renderers', () => {
-    it('renders name and year cells with values', () => {
+    it('should render name and year cells with values', () => {
       const nameCell = renderNameCell({ getValue: () => 'Poem about the Forest' } as CellContext<Music, unknown>);
       const yearCell = renderYearCell({ getValue: () => '1918' } as CellContext<Music, unknown>);
       const { getByText } = render(
@@ -121,13 +121,13 @@ describe('MusicTableCells', () => {
       expect(getByText('1918')).toBeInTheDocument();
     });
 
-    it('renders genre cell joined with commas', () => {
+    it('should render genre cell joined with commas', () => {
       const genreCell = RenderGenreCell({ getValue: () => ['Classical', 'Romantic'] } as CellContext<Music, unknown>);
       const { getByText } = render(<>{genreCell}</>);
       expect(getByText('Classical, Romantic')).toBeInTheDocument();
     });
 
-    it('renders nothing if no genres', () => {
+    it('should render nothing if no genres', () => {
       const genreCell = RenderGenreCell({ getValue: () => [] } as CellContext<Music, unknown>);
       const { container } = render(<>{genreCell}</>);
       expect(container).toBeEmptyDOMElement();
@@ -135,13 +135,13 @@ describe('MusicTableCells', () => {
   });
 
   describe('PlayCell', () => {
-    it('renders play icon', () => {
+    it('should render play icon', () => {
       mockUseAudioPlayer.mockReturnValue(useAudioPlayerMockReturn);
       const { getByTestId } = render(RenderPlayCell(mockCellContext));
       expect(getByTestId('mock-svg')).toBeInTheDocument();
     });
 
-    it('calls playTrack when clicked if different track', () => {
+    it('should call playTrack when clicked if different track', () => {
       mockUseAudioPlayer.mockReturnValue({ ...useAudioPlayerMockReturn, src: 'different-src' });
       const { getByRole } = render(RenderPlayCell(mockCellContext));
       fireEvent.click(getByRole('button', { hidden: true }));
@@ -151,7 +151,7 @@ describe('MusicTableCells', () => {
       );
     });
 
-    it('calls togglePlay when same track is playing', () => {
+    it('should call togglePlay when same track is playing', () => {
       mockUseAudioPlayer.mockReturnValue(useAudioPlayerMockReturn);
       const { getByRole } = render(RenderPlayCell(mockCellContext));
       fireEvent.click(getByRole('button', { hidden: true }));
@@ -160,7 +160,7 @@ describe('MusicTableCells', () => {
   });
 
   describe('ActionsCell', () => {
-    it('renders button when desktop', () => {
+    it('should render button when desktop', () => {
       mockUseBreakpoints.mockReturnValue({
         isDesktop: true
       });
@@ -172,7 +172,7 @@ describe('MusicTableCells', () => {
       expect(onAction).toHaveBeenCalled();
     });
 
-    it('renders icon button on laptop', () => {
+    it('should render icon button on laptop', () => {
       mockUseBreakpoints.mockReturnValue({
         isLaptop: true
       });
@@ -183,24 +183,24 @@ describe('MusicTableCells', () => {
   });
 
   describe('Group renderers', () => {
-    it('renders opus label', () => {
+    it('should render opus label', () => {
       const { getByText } = render(renderOpusGroupLabel([mockMusic]));
       expect(getByText('op.50')).toBeInTheDocument();
     });
 
-    it('renders opus title label', () => {
+    it('should render opus title label', () => {
       const { getByText } = render(renderOpusTitleGroupLabel([mockMusic]));
       expect(getByText('Symphony No. 3 in B minor')).toBeInTheDocument();
     });
 
-    it('renders group actions icon', () => {
+    it('should render group actions icon', () => {
       const { getByAltText } = render(renderGroupActions());
       expect(getByAltText('menu')).toBeInTheDocument();
     });
   });
 
   describe('RenderExpanderCell', () => {
-    it('renders expander icon for group rows', () => {
+    it('should render expander icon for group rows', () => {
       mockUseBreakpoints.mockReturnValue({
         isMobile: true
       });


### PR DESCRIPTION
## Description

Implemented unit tests for `MusicTableCells` component

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:

## How to test

1. Open project and run `npm test -- MusicTableCells` command.
2. Navigate to \lf-client\coverage\shared\components\tables\CompositionTable and open `index.html` file.

## Video / Screenshots

<img width="733" height="72" alt="image" src="https://github.com/user-attachments/assets/7ab26389-cedd-4df5-b2ea-7fca47c03f55" />


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
