### PR TITLE
Chore/772/Defining identifiers for components on the "About Us" page

### DIFF
--- a/app/shared/components/Quote/Quote.tsx
+++ b/app/shared/components/Quote/Quote.tsx
@@ -13,12 +13,13 @@ const QuoteBlock = ({
   mainTextColor,
   alignRight,
   sx,
-  width
+  width,
+  dataTestId
 }: QuoteBlockProps) => {
   const alignKey = alignRight ? 'right' : 'left';
 
   return (
-    <Box sx={[styles.mainContainer(alignKey, width), ...sxToArray(sx)]}>
+    <Box sx={[styles.mainContainer(alignKey, width), ...sxToArray(sx)]} data-testid={dataTestId}>
       <Box sx={styles.image(quoteIconColor, alignKey)}>
         <QuoteImage />
       </Box>

--- a/app/shared/components/blocks/FoundationFounders/FoundationFounders.tsx
+++ b/app/shared/components/blocks/FoundationFounders/FoundationFounders.tsx
@@ -12,11 +12,11 @@ const FoundationFounders = ({ data }: { data: IFoundationFounders }) => {
   const { titleText, listTitle, members } = data;
 
   return (
-    <Box sx={styles.container}>
-      <ColumnGuides lineColor="rgba(252, 252, 252, 1)" />
-      <Box sx={styles.contentContainer}>
-        <FoundationWasCreated data={titleText} />
-        <FoundationTeam title={listTitle} team={members} />
+    <Box sx={styles.container} data-testid="FoundationFounders">
+      <ColumnGuides lineColor="rgba(252, 252, 252, 1)" dataTestId="FoundationFounders-guides" />
+      <Box sx={styles.contentContainer} data-testid="FoundationFounders-contentContainer">
+        <FoundationWasCreated data={titleText} dataTestId="FoundationFounders-titleText" />
+        <FoundationTeam title={listTitle} team={members} dataTestId="FoundationFounders-listTitle" />
       </Box>
     </Box>
   );

--- a/app/shared/components/blocks/FoundationFounders/FoundationTeam/FoundationTeam.tsx
+++ b/app/shared/components/blocks/FoundationFounders/FoundationTeam/FoundationTeam.tsx
@@ -10,6 +10,7 @@ import { IImageBlock } from '~/types/page/about-us.types';
 interface FoundationTeamProps {
   title: string;
   team: Teammate[];
+  dataTestId?: string;
 }
 
 interface Teammate {
@@ -18,7 +19,7 @@ interface Teammate {
   photo: IImageBlock;
 }
 
-const FoundationTeam: React.FC<FoundationTeamProps> = ({ title, team }) => {
+const FoundationTeam: React.FC<FoundationTeamProps> = ({ title, team, dataTestId }) => {
   const fallback = (
     <Box sx={styles.logo}>
       <SvgImage src="/images/light-logo.svg" width={210} height={78} alt="logo" />
@@ -26,7 +27,7 @@ const FoundationTeam: React.FC<FoundationTeamProps> = ({ title, team }) => {
   );
 
   return (
-    <Box sx={styles.container}>
+    <Box sx={styles.container} data-testid={dataTestId}>
       <Box sx={styles.titleWrapper}>
         <Typography sx={styles.title}>{title}</Typography>
       </Box>

--- a/app/shared/components/blocks/FoundationFounders/FoundationWasCreated/FoundationWasCreated.tsx
+++ b/app/shared/components/blocks/FoundationFounders/FoundationWasCreated/FoundationWasCreated.tsx
@@ -11,6 +11,7 @@ import { TextNode, TipTapDoc } from '~/types/types/common.types';
 
 interface FoundationWasCreatedProps {
   data: TipTapDoc;
+  dataTestId?: string;
 }
 
 const descriptionParagraph = (children: React.ReactNode) => <Typography sx={styles.description}>{children}</Typography>;
@@ -35,9 +36,9 @@ const boldTitleWrapper = (node: TextNode) => (
   </Typography>
 );
 
-const FoundationWasCreated: React.FC<FoundationWasCreatedProps> = ({ data }) => {
+const FoundationWasCreated: React.FC<FoundationWasCreatedProps> = ({ data, dataTestId }) => {
   return (
-    <Box sx={styles.container}>
+    <Box sx={styles.container} data-testid={dataTestId}>
       <Box sx={styles.ellipseWrapper}>
         <SvgImage src="/icons/ellipse.svg" alt="ellipse" width={22} height={20} />
       </Box>

--- a/app/shared/components/blocks/FoundationInfo/FoundationInfo.tsx
+++ b/app/shared/components/blocks/FoundationInfo/FoundationInfo.tsx
@@ -12,25 +12,35 @@ export default function FoundationInfo({ data }: { readonly data: IFoundationInf
   const { image, ourOrganisation, ourName, ourBelief } = data;
 
   const organisationParagraph = (children: React.ReactNode) => (
-    <Typography sx={styles.explanationText}>{children}</Typography>
+    <Typography sx={styles.explanationText} data-testid="FoundationInfo-explanationText">
+      {children}
+    </Typography>
   );
 
   const organisationBoldText = (children: React.ReactNode) => (
-    <Box component="strong" sx={styles.organisationText}>
+    <Box component="strong" sx={styles.organisationText} data-testid="FoundationInfo-organisationText">
       {children}
     </Box>
   );
 
-  const nameParagraph = (children: React.ReactNode) => <Typography sx={styles.textSection}>{children}</Typography>;
+  const nameParagraph = (children: React.ReactNode) => (
+    <Typography sx={styles.textSection} data-testid="FoundationInfo-textSection">
+      {children}
+    </Typography>
+  );
 
-  const beliefParagraph = (children: React.ReactNode) => <Typography sx={styles.textImage}>{children}</Typography>;
+  const beliefParagraph = (children: React.ReactNode) => (
+    <Typography sx={styles.textImage} data-testid="FoundationInfo-textImage">
+      {children}
+    </Typography>
+  );
 
   return (
-    <Box sx={styles.container}>
-      <Box sx={styles.firstBulletIcon}>
+    <Box sx={styles.container} data-testid="FoundationInfo">
+      <Box sx={styles.firstBulletIcon} data-testid="FoundationInfo-firstBulletIcon">
         <SvgImage src="/icons/ellipse.svg" alt="bullet point" width={22} height={20} />
       </Box>
-      <Box sx={styles.organisationSection}>
+      <Box sx={styles.organisationSection} data-testid="FoundationInfo-organisationSection">
         <TipTapContent
           data={ourOrganisation}
           markRenderers={{
@@ -42,7 +52,7 @@ export default function FoundationInfo({ data }: { readonly data: IFoundationInf
         />
       </Box>
 
-      <Box sx={styles.explanationSection}>
+      <Box sx={styles.explanationSection} data-testid="FoundationInfo-explanationSection">
         <TipTapContent
           data={ourName}
           nodeRenderers={{
@@ -51,7 +61,7 @@ export default function FoundationInfo({ data }: { readonly data: IFoundationInf
         />
       </Box>
 
-      <Box sx={styles.secondBulletIcon}>
+      <Box sx={styles.secondBulletIcon} data-testid="FoundationInfo-secondBulletIcon">
         <SvgImage src="/icons/ellipse.svg" alt="bullet point" width={22} height={20} />
       </Box>
 
@@ -62,7 +72,7 @@ export default function FoundationInfo({ data }: { readonly data: IFoundationInf
         }}
       />
 
-      <Box sx={styles.bodyImage}>
+      <Box sx={styles.bodyImage} data-testid="FoundationInfo-bodyImage">
         {image && (
           <Image
             src={image.src}

--- a/app/shared/components/blocks/IntroSection/IntroSection.tsx
+++ b/app/shared/components/blocks/IntroSection/IntroSection.tsx
@@ -11,9 +11,11 @@ export function IntroSection({ data }: { readonly data: IIntroSection }) {
   const { title, image, quote } = data;
 
   return (
-    <Box sx={styles.container}>
-      <Typography sx={styles.title}>{title}</Typography>
-      <Box sx={styles.photoContainer}>
+    <Box sx={styles.container} data-testid="IntroSection">
+      <Typography sx={styles.title} data-testid="IntroSection-title">
+        {title}
+      </Typography>
+      <Box sx={styles.photoContainer} data-testid="IntroSection-photoContainer">
         {image && (
           <ImageWithCaption
             src={image.src}
@@ -34,10 +36,11 @@ export function IntroSection({ data }: { readonly data: IIntroSection }) {
             containerSx={styles.imageContainer}
             captionSx={styles.imageCaption}
             imageSx={{ width: { xs: '80vw', sm: '60vw', xxl: '980px' } }}
+            dataTestId="IntroSection-imageCaption"
           />
         )}
       </Box>
-      <Box sx={styles.quote}>
+      <Box sx={styles.quote} data-testid="IntroSection-quote">
         {quote && (
           <QuoteBlock
             quoteText={quote.text}
@@ -46,6 +49,7 @@ export function IntroSection({ data }: { readonly data: IIntroSection }) {
             mainTextColor="burgundy"
             alignRight={false}
             sx={styles.quoteBlock}
+            dataTestId="IntroSection-quoteBlock"
           />
         )}
       </Box>

--- a/app/shared/components/blocks/Liatoshynsky-office/LiatoshynskyOffice.tsx
+++ b/app/shared/components/blocks/Liatoshynsky-office/LiatoshynskyOffice.tsx
@@ -15,10 +15,10 @@ const oswald = Oswald({ weight: '700', subsets: ['latin'], display: 'swap' });
 const LiatoshynskyOffice = ({ data, t }: { data: ILiatoshynskyOffice; t: ReturnType<typeof useTranslations> }) => {
   const { quote } = data;
   return (
-    <Box sx={styles.mainContainer}>
-      <Box sx={styles.trapezoid} />
-      <Box sx={styles.contentContainer}>
-        <Box sx={styles.quoteBlock}>
+    <Box sx={styles.mainContainer} data-testid="LiatoshynskyOffice">
+      <Box sx={styles.trapezoid} data-testid="LiatoshynskyOffice-trapezoid" />
+      <Box sx={styles.contentContainer} data-testid="LiatoshynskyOffice-contentContainer">
+        <Box sx={styles.quoteBlock} data-testid="LiatoshynskyOffice-quoteBlock">
           <Quote
             quoteText={quote?.text}
             sourceText={quote?.source}
@@ -26,16 +26,21 @@ const LiatoshynskyOffice = ({ data, t }: { data: ILiatoshynskyOffice; t: ReturnT
             mainTextColor="black"
             alignRight
             sx={styles.quoteSx}
+            dataTestId="LiatoshynskyOffice-quote"
           />
         </Box>
-        <Box sx={styles.textBlock} className={oswald.className}>
-          <Typography sx={styles.text}>{t('office')}</Typography>
-          <Typography sx={[styles.text, styles.indentedLine]}>{t('name')}</Typography>
+        <Box sx={styles.textBlock} className={oswald.className} data-testid="LiatoshynskyOffice-textBlock">
+          <Typography sx={styles.text} data-testid="LiatoshynskyOffice-textOffice">
+            {t('office')}
+          </Typography>
+          <Typography sx={[styles.text, styles.indentedLine]} data-testid="LiatoshynskyOffice-textName">
+            {t('name')}
+          </Typography>
         </Box>
-        <Box sx={styles.media}>
-          <OfficeMedia />
+        <Box sx={styles.media} data-testid="LiatoshynskyOffice-media">
+          <OfficeMedia dataTestId="LiatoshynskyOffice-officeMedia" />
         </Box>
-        <Box sx={styles.buttonBlock}>
+        <Box sx={styles.buttonBlock} data-testid="LiatoshynskyOffice-buttonBlock">
           <Button
             size="large"
             color="primary"
@@ -43,6 +48,7 @@ const LiatoshynskyOffice = ({ data, t }: { data: ILiatoshynskyOffice; t: ReturnT
             link="/office"
             label={t('goToOfficeButton')}
             sx={styles.button}
+            data-testid="LiatoshynskyOffice-goToOfficeButton"
           />
         </Box>
       </Box>

--- a/app/shared/components/blocks/Liatoshynsky-office/office-media/OfficeMedia.tsx
+++ b/app/shared/components/blocks/Liatoshynsky-office/office-media/OfficeMedia.tsx
@@ -5,7 +5,11 @@ import Logo from '~/ds-components/logo/Logo';
 
 import { ImageData } from '~/types/types/officeMedia';
 
-const OfficeMedia: React.FC = () => {
+interface OfficeMedia {
+  dataTestId?: string;
+}
+
+const OfficeMedia: React.FC<OfficeMedia> = ({ dataTestId }) => {
   const images: ImageData[] = [
     { src: '/images/office-media/lf-office1.png', alt: 'Фото 1', styleKey: 'photo1' },
     { src: '/images/office-media/lf-office2.png', alt: 'Фото 2', styleKey: 'photo2' },
@@ -13,7 +17,7 @@ const OfficeMedia: React.FC = () => {
   ];
 
   return (
-    <Box sx={styles.mainContainer}>
+    <Box sx={styles.mainContainer} data-testid={dataTestId}>
       <Box sx={styles.mediaContainer}>
         {images.map((img) => (
           <Box

--- a/app/shared/components/blocks/our-goals/OurGoals.tsx
+++ b/app/shared/components/blocks/our-goals/OurGoals.tsx
@@ -21,9 +21,9 @@ const OurGoals = ({ data }: { data: IOurGoals }) => {
   const sizesAttribute = generateSizesAttribute(iconSizes);
 
   return (
-    <Box sx={styles.mainContainer}>
-      <SectionTitle title={title} mb={0} />
-      <Box sx={styles.goalsGrid}>
+    <Box sx={styles.mainContainer} data-testid="OurGoals">
+      <SectionTitle title={title} mb={0} data-testid="OurGoals-title" />
+      <Box sx={styles.goalsGrid} data-testid="OurGoals-goalsGrid">
         {goals.map((goal, index) => (
           <Box sx={styles.cardWithIcon} key={`${goal.title + index}`}>
             <Box sx={styles.iconWrapper}>

--- a/app/shared/components/blocks/our-mission/OurMission.tsx
+++ b/app/shared/components/blocks/our-mission/OurMission.tsx
@@ -14,9 +14,9 @@ const OurMission = ({ data }: { data: IOurMission }) => {
   const { title, smallImage, bigImage, list } = data;
 
   return (
-    <Box sx={styles.mainContainer}>
-      <SectionTitle title={title} sx={styles.title} />
-      <Box sx={styles.list}>
+    <Box sx={styles.mainContainer} data-testid="OurMission">
+      <SectionTitle title={title} sx={styles.title} data-testid="OurMission-title" />
+      <Box sx={styles.list} data-testid="OurMission-list">
         {list.map((item, idx) => (
           <TipTapContent key={`${item.type}-${idx}`} data={item} nodeRenderers={{ paragraph: getListItem }} />
         ))}
@@ -34,6 +34,7 @@ const OurMission = ({ data }: { data: IOurMission }) => {
             height: { xs: 167, sm: 221, md: 319, lg: 400 }
           }}
           containerSx={styles.smallImg}
+          dataTestId="OurMission-smallImage"
         />
       )}
 
@@ -57,6 +58,7 @@ const OurMission = ({ data }: { data: IOurMission }) => {
           }}
           containerSx={styles.bigImg}
           imageSx={{ width: { xs: '80vw', sm: '60vw', xxl: '816px' } }}
+          dataTestId="OurMission-bigImage"
         />
       )}
     </Box>

--- a/app/shared/components/blocks/what-we-do/WhatWeDo.tsx
+++ b/app/shared/components/blocks/what-we-do/WhatWeDo.tsx
@@ -21,9 +21,9 @@ const WhatWeDo = ({ data }: { data: IWhatWeDo }) => {
   const sizesAttribute = generateSizesAttribute(iconSizes);
 
   return (
-    <Box sx={styles.mainContainer}>
-      <SectionTitle title={title} mb={0} />
-      <Box sx={styles.grid}>
+    <Box sx={styles.mainContainer} data-testid="WhatWeDo">
+      <SectionTitle title={title} mb={0} data-testid="WhatWeDo-title" />
+      <Box sx={styles.grid} data-testid="WhatWeDo-listContainer">
         {items.map((item, index) => (
           <Box sx={styles.item} key={item.title + index}>
             <Box sx={styles.icon}>

--- a/app/shared/components/blocks/what-we-do/WhatWeDo.tsx
+++ b/app/shared/components/blocks/what-we-do/WhatWeDo.tsx
@@ -22,7 +22,7 @@ const WhatWeDo = ({ data }: { data: IWhatWeDo }) => {
 
   return (
     <Box sx={styles.mainContainer} data-testid="WhatWeDo">
-      <SectionTitle title={title} mb={0} data-testid="WhatWeDo-title" />
+      <SectionTitle title={title} mb={0} dataTestId="WhatWeDo-title" />
       <Box sx={styles.grid} data-testid="WhatWeDo-listContainer">
         {items.map((item, index) => (
           <Box sx={styles.item} key={item.title + index}>

--- a/app/shared/components/column-guides/ColumnGuides.tsx
+++ b/app/shared/components/column-guides/ColumnGuides.tsx
@@ -6,6 +6,7 @@ import { styles } from './ColumnGuides.style';
 
 interface ColumnGuidesProps {
   lineColor?: string;
+  dataTestId?: string;
 }
 
 const columnsMap: Record<number, { col: number; align: 'start' | 'end' }[]> = {
@@ -33,7 +34,7 @@ const columnsMap: Record<number, { col: number; align: 'start' | 'end' }[]> = {
   ]
 };
 
-export const ColumnGuides = ({ lineColor = '#EFE9E0' }: ColumnGuidesProps) => {
+export const ColumnGuides = ({ lineColor = '#EFE9E0', dataTestId }: ColumnGuidesProps) => {
   const theme = useTheme();
   const isSm = useMediaQuery(theme.breakpoints.down('sm'));
   const isMd = useMediaQuery(theme.breakpoints.down('md'));
@@ -70,7 +71,7 @@ export const ColumnGuides = ({ lineColor = '#EFE9E0' }: ColumnGuidesProps) => {
   });
 
   return (
-    <Box sx={styles.containerStyle}>
+    <Box sx={styles.containerStyle} data-testid={dataTestId}>
       <Box aria-hidden sx={styles.gridContainerStyle(layout, gap, paddingX)}>
         {Object.entries(grouped).map(([colStr, aligns]) => {
           const col = Number(colStr);

--- a/app/shared/components/image-with-caption/ImageWithCaption.tsx
+++ b/app/shared/components/image-with-caption/ImageWithCaption.tsx
@@ -22,6 +22,7 @@ interface ImageWithCaptionProps {
   containerSx?: BoxProps['sx'];
   imageSx?: BoxProps['sx'];
   captionSx?: TypographyProps['sx'];
+  dataTestId?: string;
 }
 
 const ImageWithCaption: React.FC<ImageWithCaptionProps> = ({
@@ -33,12 +34,13 @@ const ImageWithCaption: React.FC<ImageWithCaptionProps> = ({
   align = 'right',
   containerSx = {},
   imageSx = {},
-  captionSx = {}
+  captionSx = {},
+  dataTestId
 }) => {
   const sizesAttribute = generateSizesAttribute(sizes);
 
   return (
-    <Box sx={{ ...styles.container, ...containerSx } as BoxProps['sx']}>
+    <Box sx={{ ...styles.container, ...containerSx } as BoxProps['sx']} data-testid={dataTestId}>
       <Box sx={{ ...styles.imageContainer(sizes), ...imageSx } as BoxProps['sx']}>
         {border && <Box sx={styles.border(border)} data-testid="img-border" />}
         <Image style={styles.image as React.CSSProperties} src={src} fill alt={alt} sizes={sizesAttribute} />

--- a/app/shared/components/section-title/SectionTitle.tsx
+++ b/app/shared/components/section-title/SectionTitle.tsx
@@ -12,13 +12,14 @@ interface SectionTitleProps {
   gridColumn?: object;
   title: string;
   sx?: SxProps<Theme>;
+  dataTestId?: string;
 }
 
-const SectionTitle: React.FC<SectionTitleProps> = ({ icon = true, mb, title, gridColumn, sx }) => {
+const SectionTitle: React.FC<SectionTitleProps> = ({ icon = true, mb, title, gridColumn, sx, dataTestId }) => {
   const sizesAttribute = generateSizesAttribute(imageSizes);
 
   return (
-    <Box sx={[styles.container(mb), ...sxToArray(sx)]}>
+    <Box sx={[styles.container(mb), ...sxToArray(sx)]} data-testid={dataTestId}>
       {icon && (
         <Box sx={styles.image} data-testid="title-icon">
           <Image src="/icons/ellipse.svg" alt="ellipse" fill sizes={sizesAttribute} />

--- a/app/shared/components/title-with-description/TitleWithDescription.tsx
+++ b/app/shared/components/title-with-description/TitleWithDescription.tsx
@@ -3,9 +3,9 @@ import { Box, Typography } from '@mui/material';
 import { styles } from './TitleWithDescription.styles';
 import { TitleWithDescriptionProps } from '~/types/types/titleWithDescriptionComponent';
 
-const TitleWithDescription = ({ variant, title, description }: TitleWithDescriptionProps) => {
+const TitleWithDescription = ({ variant, title, description, dataTestId }: TitleWithDescriptionProps) => {
   return (
-    <Box sx={styles.container(variant)}>
+    <Box sx={styles.container(variant)} data-testid={dataTestId}>
       <Typography sx={styles.blockTitle()}>{title}</Typography>
 
       {description && <Typography sx={styles.blockDescription()}>{description}</Typography>}

--- a/app/types/types/quoteComponent.ts
+++ b/app/types/types/quoteComponent.ts
@@ -11,4 +11,5 @@ export type QuoteBlockProps = {
   alignRight?: boolean;
   sx?: SxProps;
   width?: string | Record<string, string>;
+  dataTestId?: string;
 };

--- a/app/types/types/titleWithDescriptionComponent.ts
+++ b/app/types/types/titleWithDescriptionComponent.ts
@@ -4,4 +4,5 @@ export type TitleWithDescriptionProps = {
   variant: Variant;
   title: string;
   description?: string | React.ReactNode;
+  dataTestId?: string;
 };


### PR DESCRIPTION
## Description

Implement data-testid attributes for key elements on the target page.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Run the project
2. Navigate to the /en/about-us
3. Open browser DevTools
4. Inspect elements and make sure that they have their own data-testid attributes

## Affected areas

### Page sections: 

1. app/shared/components/blocks/**IntroSection/IntroSection.tsx**
2. app/shared/components/blocks/**FoundationInfo/FoundationInfo.tsx**
3. app/shared/components/blocks/**OurMission/OurMission.tsx**
4. app/shared/components/blocks/**OurGoals/OurGoals.tsx**
5. app/shared/components/blocks/**Liatoshynsky-office/LiatoshynskyOffice.tsx**
6. app/shared/components/blocks/**what-we-do/WhatWeDo.tsx**
7. app/shared/components/blocks/**FoundationFounders/FoundationFounders.tsx**

## Linked

#772  

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
