### PR TITLE
feat: add data-testid attributes to Privacy Policy page components

### DIFF
--- a/app/[lang]/privacy-policy/page.tsx
+++ b/app/[lang]/privacy-policy/page.tsx
@@ -42,6 +42,7 @@ export default async function PrivacyPolicy({ params }: Readonly<Language>) {
           title={page.title}
           trustAndSecurity={blocks.IntroSection.trustAndSecurity}
           agreement={blocks.IntroSection.agreement}
+          dataTestId="PrivacyPolicy-intro"
         />
       )}
 
@@ -51,6 +52,7 @@ export default async function PrivacyPolicy({ params }: Readonly<Language>) {
           description={blocks.DataWeCollect.description}
           sections={blocks.DataWeCollect.sections}
           note={blocks.DataWeCollect.note}
+          dataTestId="PrivacyPolicy-dataWeCollect"
         />
       )}
 
@@ -59,6 +61,7 @@ export default async function PrivacyPolicy({ params }: Readonly<Language>) {
           title={blocks.DataUsage.title}
           description={blocks.DataUsage.description}
           list={blocks.DataUsage.list}
+          dataTestId="PrivacyPolicy-dataUsage"
         />
       )}
 
@@ -68,6 +71,7 @@ export default async function PrivacyPolicy({ params }: Readonly<Language>) {
           description={blocks.Cookies.description}
           list={blocks.Cookies.list}
           note={blocks.Cookies.note}
+          dataTestId="PrivacyPolicy-cookies"
         />
       )}
 
@@ -77,21 +81,40 @@ export default async function PrivacyPolicy({ params }: Readonly<Language>) {
           description={blocks.GoogleAuth.description}
           list={blocks.GoogleAuth.list}
           note={blocks.GoogleAuth.note}
+          dataTestId="PrivacyPolicy-googleAuth"
         />
       )}
 
       {blocks.SocialNetworks && (
-        <PolicySection title={blocks.SocialNetworks.title} note={blocks.SocialNetworks.description} />
+        <PolicySection
+          title={blocks.SocialNetworks.title}
+          note={blocks.SocialNetworks.description}
+          dataTestId="PrivacyPolicy-socialNetworks"
+        />
       )}
 
-      {blocks.TargetedAds && <PolicySection title={blocks.TargetedAds.title} note={blocks.TargetedAds.description} />}
+      {blocks.TargetedAds && (
+        <PolicySection
+          title={blocks.TargetedAds.title}
+          note={blocks.TargetedAds.description}
+          dataTestId="PrivacyPolicy-targetedAds"
+        />
+      )}
 
       {blocks.NewsletterSubscription && (
-        <PolicySection title={blocks.NewsletterSubscription.title} note={blocks.NewsletterSubscription.description} />
+        <PolicySection
+          title={blocks.NewsletterSubscription.title}
+          note={blocks.NewsletterSubscription.description}
+          dataTestId="PrivacyPolicy-newsletter"
+        />
       )}
 
       {blocks.DataRetention && (
-        <PolicySection title={blocks.DataRetention.title} note={blocks.DataRetention.description} />
+        <PolicySection
+          title={blocks.DataRetention.title}
+          note={blocks.DataRetention.description}
+          dataTestId="PrivacyPolicy-dataRetention"
+        />
       )}
 
       {blocks.UserRights && (
@@ -100,10 +123,17 @@ export default async function PrivacyPolicy({ params }: Readonly<Language>) {
           description={blocks.UserRights.description}
           list={blocks.UserRights.list}
           note={blocks.UserRights.note}
+          dataTestId="PrivacyPolicy-userRights"
         />
       )}
 
-      {blocks.ContactUs && <PolicySection title={blocks.ContactUs.title} description={blocks.ContactUs.description} />}
+      {blocks.ContactUs && (
+        <PolicySection
+          title={blocks.ContactUs.title}
+          description={blocks.ContactUs.description}
+          dataTestId="PrivacyPolicy-contactUs"
+        />
+      )}
     </MainLayout>
   );
 }

--- a/app/shared/components/blocks/privacy-policy/intro-section/IntroSection.tsx
+++ b/app/shared/components/blocks/privacy-policy/intro-section/IntroSection.tsx
@@ -11,17 +11,20 @@ type IntroSectionProps = {
   title: string;
   trustAndSecurity?: TipTapDoc;
   agreement?: TipTapDoc;
+  dataTestId?: string;
 };
 
-export default function IntroSection({ title, trustAndSecurity, agreement }: Readonly<IntroSectionProps>) {
+export default function IntroSection({ title, trustAndSecurity, agreement, dataTestId }: Readonly<IntroSectionProps>) {
   return (
     <>
-      <Box sx={styles(theme).titleWrapper}>
-        <Typography sx={styles(theme).title}>{title}</Typography>
+      <Box sx={styles(theme).titleWrapper} data-testid={dataTestId}>
+        <Typography sx={styles(theme).title} data-testid={`${dataTestId}-title`}>
+          {title}
+        </Typography>
       </Box>
 
       {(trustAndSecurity || agreement) && (
-        <Box sx={styles(theme).introGrid}>
+        <Box sx={styles(theme).introGrid} data-testid={`${dataTestId}-content`}>
           {trustAndSecurity && (
             <PolicyContent doc={trustAndSecurity} paragraphSx={styles(theme).trustAndSecurityParagraph} />
           )}

--- a/app/shared/components/blocks/privacy-policy/policy-section/PolicySection.tsx
+++ b/app/shared/components/blocks/privacy-policy/policy-section/PolicySection.tsx
@@ -26,6 +26,7 @@ type PolicySectionProps = {
   sx?: object;
   contentGridColumn?: { xs: string; sm: string; md: string } & Record<string, string>;
   listGridColumn?: { xs: string; sm: string; md: string } & Record<string, string>;
+  dataTestId?: string;
 };
 
 export default function PolicySection({
@@ -36,13 +37,14 @@ export default function PolicySection({
   sections,
   sx,
   contentGridColumn = { xs: '2 / 5', sm: '4 / 9', md: '6 / 13' },
-  listGridColumn = { xs: '2 / 5', sm: '4 / 9', md: '6 / 13' }
+  listGridColumn = { xs: '2 / 5', sm: '4 / 9', md: '6 / 13' },
+  dataTestId
 }: Readonly<PolicySectionProps>) {
   const hasList = Array.isArray(list) && list.length > 0;
   const hasSections = Array.isArray(sections) && sections.length > 0;
 
   return (
-    <Box sx={{ ...styles(theme).root, ...sx }}>
+    <Box sx={{ ...styles(theme).root, ...sx }} data-testid={dataTestId}>
       {title && <SectionTitle title={title} mb={16} />}
 
       {description && (


### PR DESCRIPTION
## Description

Adds `dataTestId` attributes to components on the Privacy Policy page to enable automated testing. All identifiers follow the SUIT CSS naming convention for consistency and predictability.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x]  Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

**Changes:**
- Added `dataTestId` prop support to IntroSection component (root, title, content)
- Added `dataTestId` prop support to PolicySection component
- Added `dataTestId` to all Privacy Policy page sections:
  - Intro section
  - Data we collect
  - Data usage
  - Cookies
  - Google authentication
  - Social networks
  - Targeted ads
  - Newsletter subscription
  - Data retention
  - User rights
  - Contact us
- All naming follows `PrivacyPolicy-sectionName` pattern

## How to test

1. Run the project
2. Navigate to the Privacy Policy page (`/privacy-policy` or `/en/privacy-policy`)
3. Open browser DevTools
4. Inspect elements on the page
5. Verify that key elements have `data-testid` attributes:
   - Intro section: `PrivacyPolicy-intro`, `PrivacyPolicy-intro-title`, `PrivacyPolicy-intro-content`
   - All policy sections: `PrivacyPolicy-dataWeCollect`, `PrivacyPolicy-dataUsage`, etc.
6. Run tests: `npm run test` - all tests should pass

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
