### PR TITLE
chore: refactor component decor element color setting

### DIFF
--- a/app/shared/components/image-with-caption/ImageWithCaption.styles.ts
+++ b/app/shared/components/image-with-caption/ImageWithCaption.styles.ts
@@ -24,7 +24,7 @@ export const styles = {
       xxl: `translate(-${border.left.xxl}px, -${border.top.xxl}px)`,
       ultra: `translate(-${border.left.ultra}px, -${border.top.ultra}px)`
     },
-    backgroundColor: '#FFE099',
+    backgroundColor: border.color || '#FFE099',
     zIndex: 0
   }),
   imageContainer: (sizes: ElementSizes) => ({

--- a/app/shared/components/image-with-caption/ImageWithCaption.tsx
+++ b/app/shared/components/image-with-caption/ImageWithCaption.tsx
@@ -10,6 +10,7 @@ export interface BorderProps {
   sizes: ElementSizes;
   top: Partial<Record<Breakpoint, number>>;
   left: Partial<Record<Breakpoint, number>>;
+  color?: string;
 }
 
 interface ImageWithCaptionProps {


### PR DESCRIPTION
## Description

The component has a decorative rectangle element.
In the previous implementation the color of this rectangle is hardcoded, but the component is used in different sections and needs to have different colors depending on the context.
I made the possibility to set color if necessary.

## Type of change
- [X] Refactoring / Tech debt

## Screenshots
<img width="992" height="682" alt="border1" src="https://github.com/user-attachments/assets/d835edfa-fb93-4715-8977-3629ef9de605" />
<img width="989" height="659" alt="border2" src="https://github.com/user-attachments/assets/e0e3b2b2-45ca-4a85-94d8-aea4a4116223" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
