### PR TITLE
fix(payment-details): remove background fill from IBAN container

### DIFF
--- a/app/shared/components/blocks/payment-details/PaymentDetails.styles.ts
+++ b/app/shared/components/blocks/payment-details/PaymentDetails.styles.ts
@@ -59,10 +59,7 @@ export const styles = {
     display: 'flex',
     flexWrap: { xs: 'wrap', md: 'nowrap' },
     alignItems: 'center',
-    borderRadius: '40px',
-    p: '12px 15px 12px 24px',
-    backgroundColor: mainHexPallete.brown[100],
-    ml: '-24px',
+    pr: '16px',
     gap: '8px'
   },
 


### PR DESCRIPTION
## Description

Remove the filled background from the IBAN value on the Support Us page so it matches the design. Also, update paddings and margins accordingly.

## Type of change

- [x] Bug fix

## How to test

1. Open `/support-us`.
2. Verify the IBAN row: transparent background, correct spacings.
3. Shrink to mobile: the IBAN may wrap, layout stays readable.

## Screenshots

Before:
<img width="628" height="309" alt="before" src="https://github.com/user-attachments/assets/5fd8ce12-b955-42f1-a8b6-17db2db72b0f" />

Now:
<img width="596" height="289" alt="now" src="https://github.com/user-attachments/assets/ff0ceff2-4e7f-4cb0-8905-10a43d008b11" />

Design:
<img width="775" height="391" alt="design" src="https://github.com/user-attachments/assets/b93783dd-b9af-4b50-9425-0669634b0e4f" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
