### PR TITLE
fix(404-page): add horizontal padding on mobile

### DIFF
--- a/app/[lang]/[...unknown-route]/page-not-found/pageNotFound.styles.ts
+++ b/app/[lang]/[...unknown-route]/page-not-found/pageNotFound.styles.ts
@@ -9,7 +9,8 @@ export const styles = {
     alignItems: 'center',
     height: '100vh',
     gridColumn: '1 / -1',
-    my: { xs: '50px', sm: '100px' }
+    my: { xs: '50px', sm: '100px' },
+    px: { xs: '16px', sm: '24px' }
   },
   titleText: {
     lineHeight: '120%',


### PR DESCRIPTION
## Description

Add horizontal padding (16px on mobile, 24px on small tablets) to the 404 page to prevent content from touching the screen edges.

## Type of change

- [x] Bug fix

## How to test

1. Go to any invalid route (e.g., /this-route-does-not-exist).
2. Switch to a mobile viewport (<550 px).
3. Content should not touch edges.

## Video

https://github.com/user-attachments/assets/e4bc34da-fa51-4384-98c8-4e2a192feef7

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
