### PR TITLE
fix(support-us): fix currency button height missmatch

### DIFF
--- a/app/shared/components/blocks/payment-details/PaymentDetails.styles.ts
+++ b/app/shared/components/blocks/payment-details/PaymentDetails.styles.ts
@@ -15,18 +15,19 @@ export const styles = {
     },
 
     '& [aria-label="indicator"]': {
-      width: '66px'
+      width: '66px',
+      height: 'calc(100% - 8px)',
+      top: 4
     }
   },
 
   currencyBtn: {
-    width: '68px',
-    height: '28px',
     border: 'none',
     display: 'flex',
     alignItems: 'center',
 
     '&, &:hover': {
+      background: 'transparent',
       borderRadius: '28px'
     }
   },


### PR DESCRIPTION
## Description

Decrease height of currency button on active state with formula `calc(100% - 8px)` to match currency button on hover state.
<!-- Briefly describe the purpose of this PR and what was changed -->

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Go to `support-us` page;
2. Check default (inactive) state;
3. Check hover state.
4. Check active state.

## Video / Screenshots
<img width="537" height="77" alt="screenshot" src="https://github.com/user-attachments/assets/3f1cadef-2289-41c9-9693-866e6b4a9083" />

<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
