### PR TITLE
fix(header): chevron nav buttons use 16/12 padding + 2px icon offset

### DIFF
--- a/app/shared/components/design-system/all-components/button-group/ButtonGroup.styles.ts
+++ b/app/shared/components/design-system/all-components/button-group/ButtonGroup.styles.ts
@@ -45,6 +45,12 @@ export const StyledButtonItem = styled(Box, {
     zIndex: 1,
     marginRight: '4px',
     padding: size === 'big' ? '5px 16px' : '2px 16px',
+    '&:has(svg)': {
+      paddingRight: '12px'
+    },
+    '& svg': {
+      transform: 'translateY(2px)'
+    },
     textTransform: 'none',
     lineHeight: '150%',
     border: 'none',


### PR DESCRIPTION
## Description

Update the StyledButtonItem (the wrapper that already sets nav button padding) to keep `16px` left padding and reduce right padding to `12px` only for items that contain an SVG (chevron). Also lower the chevron by `2px` for optical baseline alignment. Non-chevron buttons are unchanged.

## Type of change

- [x] Bug fix

## How to test

Open the site header on desktop.

1. Inspect a chevron item (e.g., “Борис Лятошинський / Borys Liatoshynskyi”, “Фундація / Foundation”).
2. Verify:
- left padding = 16px; right padding = 12px (via DevTools);
- chevron SVG sits ~2px lower vs the text baseline;
- compare with a non-chevron button - text should remain visually centered.

## Screenshots

Now:
<img width="568" height="60" alt="now" src="https://github.com/user-attachments/assets/fcda171c-c8bc-4096-9537-e6385b94393e" />

Figma:
<img width="751" height="67" alt="design" src="https://github.com/user-attachments/assets/d327ba99-51ef-4ef0-b1e4-44356dc297a9" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
