### PR TITLE
fix: prevent active state from switching when opening dropdown menu

### DIFF
--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
@@ -50,7 +50,6 @@ const DesktopNav = ({
   const pathname = usePathname();
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  const [temporaryActiveIndex, setTemporaryActiveIndex] = useState<number | null>(null);
   const [openDropdownState, setOpenDropdownState] = useState<{ label: string; items: DropdownItem[] } | null>(null);
   const [activeButton, setActiveButton] = useState<number | undefined>();
 
@@ -61,10 +60,6 @@ const DesktopNav = ({
       handleDropdownClose();
     }
   }, [scrollDirection, anchorEl]);
-
-  useEffect(() => {
-    setTemporaryActiveIndex(null);
-  }, [pathname]);
 
   useEffect(() => {
     if (pathname === specialNav?.links[0].href) {
@@ -85,17 +80,9 @@ const DesktopNav = ({
     }
   }, [pathname, NAV_ITEMS, specialNav?.links]);
 
-  const effectiveActiveIndex = temporaryActiveIndex ?? activeButton;
-
-  const handleDropdownOpen = (
-    event: React.MouseEvent<HTMLElement>,
-    label: string,
-    items: DropdownItem[],
-    index: number
-  ) => {
+  const handleDropdownOpen = (event: React.MouseEvent<HTMLElement>, label: string, items: DropdownItem[]) => {
     setAnchorEl(event.currentTarget);
     setOpenDropdownState({ label, items });
-    setTemporaryActiveIndex(index);
   };
 
   const handleDropdownClose = () => {
@@ -105,7 +92,7 @@ const DesktopNav = ({
 
   const renderedNavButtons = NAV_ITEMS.map((item, index) => {
     const isOpen = openDropdownState?.label === item.label && Boolean(anchorEl);
-    const isActive = index === effectiveActiveIndex;
+    const isActive = index === activeButton;
 
     const ChevronIcon = isOpen ? ChevronUp : ChevronDown;
     const iconColor = isActive ? mainHexPallete.white : mainHexPallete.black;
@@ -117,7 +104,7 @@ const DesktopNav = ({
         <IconButton
           disableRipple
           key={`${item.label}-${index}`}
-          onClick={(e) => handleDropdownOpen(e, item.label, dropdownItems, index)}
+          onClick={(e) => handleDropdownOpen(e, item.label, dropdownItems)}
           sx={styles.iconButtonSx}
           style={styles.iconButtonInline}
         >
@@ -158,7 +145,7 @@ const DesktopNav = ({
       <Box sx={styles.buttonGroupBackground}>
         <ButtonGroup
           sx={styles.buttonGroup}
-          activeButton={effectiveActiveIndex}
+          activeButton={activeButton !== undefined ? activeButton : -1}
           buttons={renderedNavButtons}
           size="big"
         />


### PR DESCRIPTION
## Description

Fix bug where the active navigation button state incorrectly switched to the dropdown button when opening a dropdown menu. Now the active state remains on the current page's button and only changes when the user actually navigates to a different page.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to any page in the navigation (e.g., "Співпраця")
2. Click on a dropdown button (e.g., "Борис Лятошинський" or "Фундація")
3. Verify the active state (black background) remains on "Співпраця" while the dropdown is open
4. Click on a dropdown item to navigate to that page
5. Verify the active state switches to the dropdown button (e.g., "Фундація" becomes active)
6. Navigate to "Війна в Україні" page
7. Verify no navigation buttons are active (no black background on any button)
8. Click on any dropdown button and verify it doesn't become active, only opens the menu

## Video / Screenshots

https://github.com/user-attachments/assets/4c0d86f1-0e16-4f0b-b40b-3c232ca60240

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
