### PR TITLE
fix: Inconsistent shade between opus and works #827

### DIFF
--- a/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.styles.ts
+++ b/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.styles.ts
@@ -20,6 +20,7 @@ export const collapsibleRowStyles = {
     borderLeft: 'none',
     borderRight: 'none',
     borderTop: 'none',
+    backgroundColor: mainHexPallete.blue[75],
     borderBottom: `2px solid ${borderWithOpacity}`,
     '& .MuiTableCell-root': {
       borderBottom: 'none',


### PR DESCRIPTION
## Description

Shades now consistents

## Type of change

- [x] Bug fix

## How to test

1.Open the `/artistry`
2.Open any specific opus.
3.Blue background in the opus header/section are now identical to the blue used in the works list.

## Video / Screenshots

Before: 

<img width="1213" height="482" alt="image" src="https://github.com/user-attachments/assets/6e274890-d5a7-4c8b-ba6b-6688ce75081f" />


After:

<img width="1217" height="415" alt="image" src="https://github.com/user-attachments/assets/e02b590d-24b4-426c-a7f9-919b080ef2de" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
