### PR TITLE
fix(layouts): add white guiding lines on Contacts via ColoredLayout

### DIFF
--- a/app/[lang]/contacts/page.tsx
+++ b/app/[lang]/contacts/page.tsx
@@ -29,7 +29,7 @@ export default async function Contacts({ params }: Readonly<Language>) {
   }
 
   return (
-    <ColoredLayout>
+    <ColoredLayout withLines>
       <ContactsInfo contacts={contacts} socialLinks={socialLinks} />
     </ColoredLayout>
   );

--- a/app/shared/layouts/colored-layout/ColoredLayout.tsx
+++ b/app/shared/layouts/colored-layout/ColoredLayout.tsx
@@ -1,6 +1,8 @@
 import { Box, SxProps, Theme } from '@mui/material';
 import React from 'react';
 
+import { mainHexPallete } from '~/ds-components/theme/colors';
+
 import { styles } from '~/layouts/colored-layout/ColoredLayout.styles';
 import MainLayout, { MainLayoutProps } from '~/layouts/main-layout/MainLayout';
 
@@ -10,12 +12,16 @@ export interface ColoredLayoutProps extends MainLayoutProps {
 }
 
 const ColoredLayout: React.FC<ColoredLayoutProps> = ({ color = '#F2EEE8', wrapperSx = {}, children, ...props }) => {
+  const DEFAULT_LINE_COLOR = mainHexPallete.white;
+
   return (
     <Box
       sx={[styles.container(color), ...(Array.isArray(wrapperSx) ? wrapperSx : [wrapperSx])]}
       data-testid="colored-layout"
     >
-      <MainLayout {...props}>{children}</MainLayout>
+      <MainLayout lineColor={DEFAULT_LINE_COLOR} {...props}>
+        {children}
+      </MainLayout>
     </Box>
   );
 };


### PR DESCRIPTION
## Description

Set `ColoredLayout` to pass `mainHexPallete.white` as the default `lineColor` into `MainLayout`, so guide lines render white on colored backgrounds. The color remains overrideable by passing `lineColor` from the caller.
On the Contacts page, turn on `withLines` to display the grid lines.

## Type of change

- [x] Bug fix

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open Contacts (/{lang}/contacts): verify thin white lines appear over the colored background.
2. (Override check) Temporarily set <ColoredLayout withLines lineColor="#FF00FF" /> on Contacts: verify lines use the override.

## Screenshots

<img width="1651" height="93" alt="now" src="https://github.com/user-attachments/assets/2e4b29c8-8a10-4bbe-bc4e-3ebbebc7c099" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
