### PR TITLE
fix(header): show nav indicator in place on first render then keep slide on normal navigation

### DIFF
--- a/app/shared/components/design-system/all-components/button-group/ButtonGroup.styles.ts
+++ b/app/shared/components/design-system/all-components/button-group/ButtonGroup.styles.ts
@@ -4,12 +4,13 @@ import { styled } from '@mui/material/styles';
 import { hexButtonGroupColors } from '~/ds-components/theme/colors';
 
 export const StyledIndicator = styled(Box, {
-  shouldForwardProp: (prop) => prop !== 'left' && prop !== 'width' && prop !== 'palette'
+  shouldForwardProp: (prop) => prop !== 'left' && prop !== 'width' && prop !== 'palette' && prop !== 'animate'
 })<{
   left: number;
   width: number;
   palette: 'primary' | 'secondary' | 'tertiary';
-}>(({ left, width, palette }) => {
+  animate?: boolean;
+}>(({ left, width, palette, animate = true }) => {
   const paletteValues = palette === 'primary' ? hexButtonGroupColors.primary : hexButtonGroupColors.secondary;
 
   return {
@@ -17,7 +18,7 @@ export const StyledIndicator = styled(Box, {
     top: 2,
     position: 'absolute',
     borderRadius: '9999px',
-    transition: 'all 0.3s ease',
+    transition: animate ? 'all 0.3s ease' : 'none',
     zIndex: 0,
     backgroundColor: paletteValues.selectedButtonColor,
     color: paletteValues.selectedButtonTextColor,

--- a/app/shared/components/design-system/all-components/button-group/ButtonGroup.tsx
+++ b/app/shared/components/design-system/all-components/button-group/ButtonGroup.tsx
@@ -11,6 +11,7 @@ interface ButtonGroupProps extends Omit<BoxProps, 'color' | 'size'> {
   activeButton?: number;
   size?: ButtonGroupSizeOptions;
   palette?: ButtonGroupPaletteOptions;
+  animateIndicator?: boolean;
 }
 
 const ButtonGroup = ({
@@ -19,6 +20,7 @@ const ButtonGroup = ({
   activeButton: controlledActiveButton,
   size = 'small',
   palette = 'primary',
+  animateIndicator = true,
   sx,
   ...props
 }: ButtonGroupProps) => {
@@ -72,6 +74,7 @@ const ButtonGroup = ({
         palette={palette}
         left={indicatorStyle.left}
         width={indicatorStyle.width}
+        animate={animateIndicator}
         aria-label="indicator"
         aria-hidden="true"
       />

--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mui/material';
 import Link from 'next/link';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import Button from '~/ds-components/button/Button';
 import ButtonGroup from '~/ds-components/button-group/ButtonGroup';
@@ -52,7 +52,9 @@ const DesktopNav = ({
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [openDropdownState, setOpenDropdownState] = useState<{ label: string; items: DropdownItem[] } | null>(null);
   const [activeButton, setActiveButton] = useState<number | undefined>();
+  const [animateIndicator, setAnimateIndicator] = useState(true);
 
+  const prevActiveButtonRef = useRef<number | undefined>(undefined);
   const isSpecialActive = pathname === specialNav?.links[0].href;
 
   useEffect(() => {
@@ -79,6 +81,19 @@ const DesktopNav = ({
       setActiveButton(undefined);
     }
   }, [pathname, NAV_ITEMS, specialNav?.links]);
+
+  useEffect(() => {
+    const becameDefined = prevActiveButtonRef.current === undefined && activeButton !== undefined;
+    if (becameDefined) {
+      setAnimateIndicator(false);
+      const id = requestAnimationFrame(() => {
+        setAnimateIndicator(true);
+      });
+      prevActiveButtonRef.current = activeButton;
+      return () => cancelAnimationFrame(id);
+    }
+    prevActiveButtonRef.current = activeButton;
+  }, [activeButton]);
 
   const handleDropdownOpen = (event: React.MouseEvent<HTMLElement>, label: string, items: DropdownItem[]) => {
     setAnchorEl(event.currentTarget);
@@ -148,6 +163,7 @@ const DesktopNav = ({
           activeButton={activeButton !== undefined ? activeButton : -1}
           buttons={renderedNavButtons}
           size="big"
+          animateIndicator={animateIndicator}
         />
         {specialNav && specialNav.links.length > 0 && specialNav.links[0].visibility && (
           <Button


### PR DESCRIPTION
## Description

Now the active indicator shows on the correct item without sliding on the first render after navigation or locale change. On user clicks it still slides smoothly. I added an `animate` style flag to `StyledIndicator` and prevented it from forwarding via `shouldForwardProp`. `ButtonGroup` accepts a new `animateIndicator` prop and passes it to the indicator. In `DesktopNav` I detect when `activeButton` becomes defined for the first time, set `animateIndicator` to false so transitions are off, then in the next animation frame turn it back on so subsequent clicks animate as before.

## Type of change

- [x] Bug fix

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Switch language or navigate to a page and see the indicator show on the correct item with no slide. 
2. Click between header items and see the indicator slide as before.

## Video

https://github.com/user-attachments/assets/d54cefeb-a14f-4431-b96d-0fbf49948d4c

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
