### PR TITLE
fix: add scroll to table top on pagination change

### DIFF
--- a/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.styles.ts
+++ b/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.styles.ts
@@ -1,20 +1,21 @@
 import { mainHexPallete } from '../theme/colors';
 
 export const styles = {
-  container: (width: number, height: number) => ({
+  container: (width?: number, height?: number) => ({
     position: 'relative',
-    width: width,
-    height: height,
-    gridColumn: '1 / -1'
+    width: width ?? '100%',
+    height: height ?? '100%',
+    gridColumn: '1 / -1',
+    ...(height ? {} : { minHeight: 100 })
   }),
-  border: (borderWidth: number, height: number) => ({
+  border: (borderWidth: number, height?: number) => ({
     display: 'block',
     position: 'absolute',
     width: borderWidth,
-    height: height,
+    height: height ?? '100%',
     top: 0,
     left: 0,
     backgroundColor: mainHexPallete.yellow[300],
-    zIndex: 0
+    zIndex: 1
   })
 };

--- a/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.tsx
+++ b/app/shared/components/design-system/all-components/image-with-border/ImageWithBorder.tsx
@@ -5,8 +5,8 @@ import { styles } from './ImageWithBorder.styles';
 
 interface ImageWithBorderProps {
   image: string;
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
   borderWidth?: number;
   alt: string;
 }
@@ -18,10 +18,16 @@ export default function ImageWithBorder({
   borderWidth = 8,
   alt
 }: Readonly<ImageWithBorderProps>) {
+  const useFillMode = !width || !height;
+
   return (
     <Box sx={styles.container(width, height)}>
       <Box sx={styles.border(borderWidth, height)} />
-      <Image width={width} height={height} alt={alt} src={image} />
+      {useFillMode ? (
+        <Image alt={alt} src={image} fill style={{ objectFit: 'cover' }} />
+      ) : (
+        <Image width={width} height={height} alt={alt} src={image} />
+      )}
     </Box>
   );
 }

--- a/app/shared/components/enhanced-table/EnhancedTable.test.tsx
+++ b/app/shared/components/enhanced-table/EnhancedTable.test.tsx
@@ -72,7 +72,7 @@ const mockSetSearch = jest.fn();
 const mockSetFilterParams = jest.fn();
 
 beforeEach(() => {
-  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  globalThis.HTMLElement.prototype.scrollIntoView = jest.fn();
 });
 
 describe('EnhancedTable', () => {

--- a/app/shared/components/enhanced-table/EnhancedTable.test.tsx
+++ b/app/shared/components/enhanced-table/EnhancedTable.test.tsx
@@ -3,7 +3,8 @@ import { ColumnDef } from '@tanstack/react-table';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 
-import { FilterSelect } from '../design-system/all-components/selector/FilterSelect';
+import { FilterSelect } from '~/ds-components/selector/FilterSelect';
+
 import { Search } from '../search/Search';
 
 import { EnhancedTable } from '~/shared/components/enhanced-table/EnhancedTable';
@@ -67,9 +68,15 @@ const columns: ColumnDef<TestRow>[] = [
   }
 ];
 
+const mockSetSearch = jest.fn();
+const mockSetFilterParams = jest.fn();
+
+beforeEach(() => {
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+});
+
 describe('EnhancedTable', () => {
   it('renders control panel title, search and filters', () => {
-    const mockSetSearch = jest.fn();
     render(
       <EnhancedTable
         data={mockData}
@@ -77,8 +84,8 @@ describe('EnhancedTable', () => {
         tableName="Test Table"
         groupByKey="group"
         itemsPerPage={2}
-        Search={<Search setSearch={mockSetSearch} search={''} options={[]} />}
-        Filters={<FilterSelect label={''} options={[]} />}
+        Search={<Search setSearch={mockSetSearch} setFilterParams={mockSetFilterParams} search="" options={[]} />}
+        Filters={<FilterSelect label="" options={[]} />}
       />
     );
 
@@ -109,7 +116,6 @@ describe('EnhancedTable', () => {
     fireEvent.click(screen.getByText('Переглянути більше'));
 
     const afterRows = screen.getAllByRole('row').length;
-
     expect(afterRows).toBeGreaterThan(beforeRows);
   });
 

--- a/app/shared/components/enhanced-table/EnhancedTable.tsx
+++ b/app/shared/components/enhanced-table/EnhancedTable.tsx
@@ -12,7 +12,7 @@ import {
   useReactTable
 } from '@tanstack/react-table';
 import { useTranslations } from 'next-intl';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import Button from '~/ds-components/button/Button';
 import Pagination from '~/ds-components/pagination/Pagination';
@@ -70,6 +70,12 @@ export const EnhancedTable = <T extends RowData>({
   const t = useTranslations('common');
 
   const breakpoint = useBreakpoints();
+
+  const tableRef = useRef<HTMLDivElement | null>(null);
+
+  const scrollToTableTop = useCallback(() => {
+    tableRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, []);
 
   const toggleGroupCollapse = (groupLabel: string) => {
     setCollapsedGroups((prev) => ({
@@ -154,7 +160,7 @@ export const EnhancedTable = <T extends RowData>({
   });
 
   return (
-    <Box sx={styles.root} data-testid="EnhancedTable">
+    <Box ref={tableRef} sx={styles.root} data-testid="EnhancedTable">
       <ControlPanel
         Search={Search}
         tableName={tableName}
@@ -201,7 +207,10 @@ export const EnhancedTable = <T extends RowData>({
                 siblingCount={breakpoint.isMobile || breakpoint.isTablet ? 0 : 1}
                 page={currentPage}
                 visiblePages={visiblePages}
-                onChange={(_, page) => handlePageChange(page)}
+                onChange={(_, page) => {
+                  handlePageChange(page);
+                  scrollToTableTop();
+                }}
               />
             )}
           </Box>

--- a/app/shared/components/enhanced-table/EnhancedTable.tsx
+++ b/app/shared/components/enhanced-table/EnhancedTable.tsx
@@ -12,7 +12,7 @@ import {
   useReactTable
 } from '@tanstack/react-table';
 import { useTranslations } from 'next-intl';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import Button from '~/ds-components/button/Button';
 import Pagination from '~/ds-components/pagination/Pagination';
@@ -70,12 +70,6 @@ export const EnhancedTable = <T extends RowData>({
   const t = useTranslations('common');
 
   const breakpoint = useBreakpoints();
-
-  const tableRef = useRef<HTMLDivElement | null>(null);
-
-  const scrollToTableTop = useCallback(() => {
-    tableRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }, []);
 
   const toggleGroupCollapse = (groupLabel: string) => {
     setCollapsedGroups((prev) => ({
@@ -159,6 +153,24 @@ export const EnhancedTable = <T extends RowData>({
     itemsPerPage
   });
 
+  const tableRef = useRef<HTMLDivElement | null>(null);
+  const shouldScrollRef = useRef(false);
+
+  useLayoutEffect(() => {
+    if (!shouldScrollRef.current) return;
+    shouldScrollRef.current = false;
+
+    const el = tableRef.current;
+    if (el && typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [currentPage]);
+
+  const handlePageChangeWithScroll = (page: number) => {
+    shouldScrollRef.current = true;
+    handlePageChange(page);
+  };
+
   return (
     <Box ref={tableRef} sx={styles.root} data-testid="EnhancedTable">
       <ControlPanel
@@ -207,10 +219,7 @@ export const EnhancedTable = <T extends RowData>({
                 siblingCount={breakpoint.isMobile || breakpoint.isTablet ? 0 : 1}
                 page={currentPage}
                 visiblePages={visiblePages}
-                onChange={(_, page) => {
-                  handlePageChange(page);
-                  scrollToTableTop();
-                }}
+                onChange={(_, page) => handlePageChangeWithScroll(page)}
               />
             )}
           </Box>


### PR DESCRIPTION
## Description

Fixed table pagination behavior — when navigating between pages, the view no longer jumps to the footer.
Implemented smooth scrolling to the top of the table container after page change to improve user experience.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the Artistry page.
2. Scroll down and use the pagination controls to navigate to another page.
3. Verify that after switching pages, the viewport automatically scrolls smoothly to the top of the table.
4. Confirm that no layout shifts or flickering occur.

## Video / Screenshots


https://github.com/user-attachments/assets/572a3fe5-37b3-4281-8fd8-4033634161c1


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
