### PR TITLE
fix(cooperation): remove absolute from OfferCollaboration and render outside MainLayout

### DIFF
--- a/app/[lang]/cooperation/page.test.tsx
+++ b/app/[lang]/cooperation/page.test.tsx
@@ -12,6 +12,12 @@ jest.mock('~/shared/components/blocks/collaboration/collaboration-intro/Collabor
   return MockCollaborationIntro;
 });
 
+jest.mock('~/shared/components/blocks/collaboration/offer-collaboration/OfferCollaboration', () => {
+  const MockOfferCollaboration = () => <div>Offer Collaboration</div>;
+  MockOfferCollaboration.displayName = 'MockOfferCollaboration';
+  return MockOfferCollaboration;
+});
+
 describe('Collaboration component', () => {
   it('should render CollaborationIntro component correctly', async () => {
     render(await Collaboration({ params: Promise.resolve({ lang: 'en' }) }));

--- a/app/[lang]/cooperation/page.tsx
+++ b/app/[lang]/cooperation/page.tsx
@@ -9,6 +9,7 @@ import { isProductionMode } from '~/utils/isProductionMode';
 import MainLayout from '~/layouts/main-layout/MainLayout';
 import CollaborationIntro from '~/shared/components/blocks/collaboration/collaboration-intro/CollaborationIntro';
 import { collaborationIntroPageData } from '~/shared/components/blocks/collaboration/collaboration-intro/CollaborationIntro.consts';
+import OfferCollaboration from '~/shared/components/blocks/collaboration/offer-collaboration/OfferCollaboration';
 
 export default async function CollaborationPage({ params }: Readonly<Language>) {
   const { lang } = await params;
@@ -18,13 +19,16 @@ export default async function CollaborationPage({ params }: Readonly<Language>) 
     return <UnderDevelopment />;
   }
   return (
-    <MainLayout withLines>
-      <CollaborationIntro
-        title={collaborationIntroPageData[lang].title}
-        subtitle={collaborationIntroPageData[lang].subtitle}
-        contentAbove={collaborationIntroPageData[lang].contentAbove}
-        content={collaborationIntroPageData[lang].content}
-      />
-    </MainLayout>
+    <>
+      <MainLayout withLines>
+        <CollaborationIntro
+          title={collaborationIntroPageData[lang].title}
+          subtitle={collaborationIntroPageData[lang].subtitle}
+          contentAbove={collaborationIntroPageData[lang].contentAbove}
+          content={collaborationIntroPageData[lang].content}
+        />
+      </MainLayout>
+      <OfferCollaboration />
+    </>
   );
 }

--- a/app/shared/components/blocks/collaboration/offer-collaboration/OfferCollaboration.styles.ts
+++ b/app/shared/components/blocks/collaboration/offer-collaboration/OfferCollaboration.styles.ts
@@ -2,9 +2,7 @@ import { mainHexPallete } from '~/ds-components/theme/colors';
 
 export const styles = {
   mainContainer: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
+    position: 'relative',
     width: '100%',
     height: { sm: '889px', md: '939px', lg: '921px' }
   },


### PR DESCRIPTION
## Description

Remove position: absolute from `OfferCollaboration` wrapper (`mainContainer -> position: relative`) so the block stays in normal flow and no longer overlaps neighbors.
On `/cooperation`, added `<OfferCollaboration />` outside `<MainLayout>` to keep its background from being cut by the grid wrapper.

If you prefer to keep `<OfferCollaboration />` inside `<MainLayout withLines>`, say so and we'll think on diff solution (grid + calculate?).

## Type of change

- [x] Refactoring / Tech debt

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open /cooperation.
2. Verify no overlap with the section above or the footer.
3. Resize through breakpoints - background aligns like the design.

## Screenshots

<img width="788" height="586" alt="now" src="https://github.com/user-attachments/assets/1268ddaa-a0e9-4360-bbcd-b394ab143978" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
