### PR TITLE
fix(header): correct horizontal paddings in navigation menu

### DIFF
--- a/app/shared/components/design-system/all-components/button-group/ButtonGroup.styles.ts
+++ b/app/shared/components/design-system/all-components/button-group/ButtonGroup.styles.ts
@@ -13,8 +13,8 @@ export const StyledIndicator = styled(Box, {
   const paletteValues = palette === 'primary' ? hexButtonGroupColors.primary : hexButtonGroupColors.secondary;
 
   return {
-    height: 'calc(100% - 4px)',
-    top: 2,
+    height: 'calc(100% - 8px)',
+    top: 4,
     position: 'absolute',
     borderRadius: '9999px',
     transition: 'all 0.3s ease',
@@ -36,7 +36,9 @@ export const StyledButtonItem = styled(Box, {
   const paletteValues = palette === 'primary' ? hexButtonGroupColors.primary : hexButtonGroupColors.secondary;
 
   return {
-    display: 'inline-block',
+    display: 'inline-flex',
+    alignItems: 'center',
+    height: '100%',
     borderRadius: '9999px',
     color: active ? paletteValues.selectedButtonTextColor : paletteValues.buttonTextColor,
     fontFamily: 'inherit',
@@ -73,7 +75,7 @@ export const StyledButtonItem = styled(Box, {
       border: 'none',
       padding: 0,
       margin: 0,
-      display: 'inline-block',
+      display: 'inline-flex',
       height: '100%',
       transition: 'none'
     }

--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.styles.ts
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.styles.ts
@@ -22,13 +22,12 @@ export const styles = {
     marginTop: '8px'
   },
   buttonGroup: {
-    maxHeight: '40px',
-    minWidth: '553px',
-    backgroundColor: backgroundColors.offWhite
+    height: '40px',
+    backgroundColor: backgroundColors.offWhite,
+    p: '4px'
   },
   buttonGroupBackground: {
     backgroundColor: backgroundColors.white,
-    padding: '6px',
     borderRadius: '999px',
     display: 'flex',
     alignItems: 'center',


### PR DESCRIPTION
## Description

Fixed the header nav's left/right padding mismatch that appeared after locale changes. Normalized the ButtonGroup padding to `4px` and removed the extra wrapper padding so both sides now match Figma exactly (previously `~2px`). Internal styles were adjusted so the active/hover capsule still fits within the same `4px` gutter.

## Type of change

- [x] Bug fix

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open the website on desktop view
2. Look at the header navigation (menu items: "Борис Лятошинський" i "Співпраця")
3. Compare header nav against Figma grid (below are screenshots)

## Screenshots

Now:
<img width="1115" height="99" alt="image" src="https://github.com/user-attachments/assets/ed0af63b-958a-4cce-8ab0-ae0b00f2271c" />

Figma:
<img width="1127" height="118" alt="image" src="https://github.com/user-attachments/assets/bca827ee-cfd3-4068-8064-a9d678de3378" />


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
