### PR TITLE
fix(ui): prevent hydration mismatches for Button label and ListItem bullets

### DIFF
--- a/app/shared/components/Footer/Footer.test.tsx
+++ b/app/shared/components/Footer/Footer.test.tsx
@@ -98,7 +98,7 @@ describe('Footer component', () => {
       'href',
       'https://facebook.com/foundation'
     );
-    expect(await screen.findByRole('button', { name: /contact us/i })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /contactusbutton/i })).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: /donate/i })).toHaveAttribute('href', '/donate');
   });
 });

--- a/app/shared/components/blocks/payment-details/PaymentDetails.tsx
+++ b/app/shared/components/blocks/payment-details/PaymentDetails.tsx
@@ -40,7 +40,7 @@ function PaymentDetails() {
             </Typography>
 
             {isIban ? (
-              <Typography variant="customSemiBold20" sx={styles.iban}>
+              <Typography component="div" variant="customSemiBold20" sx={styles.iban}>
                 <Typography component="span" variant="customSemiBold20" sx={styles.ibanText} ref={ibanRef}>
                   {selectedPaymentDetails[key]}
                 </Typography>

--- a/app/shared/components/design-system/all-components/button/Button.styles.ts
+++ b/app/shared/components/design-system/all-components/button/Button.styles.ts
@@ -1,0 +1,14 @@
+export const styles = {
+  short: {
+    display: {
+      xs: 'inline',
+      md: 'none'
+    }
+  },
+  full: {
+    display: {
+      xs: 'none',
+      md: 'inline'
+    }
+  }
+};

--- a/app/shared/components/design-system/all-components/button/Button.test.tsx
+++ b/app/shared/components/design-system/all-components/button/Button.test.tsx
@@ -7,14 +7,6 @@ jest.mock('~/i18n/navigation', () => ({
   Link: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>
 }));
 
-const mockedUseBreakpoints = jest.fn();
-
-mockedUseBreakpoints.mockReturnValue({
-  isMobile: false
-});
-
-jest.mock('~/shared/hooks/use-breakpoints/useBreakpoints', () => () => mockedUseBreakpoints());
-
 describe('Button Component', () => {
   const startIcon = <span data-testid="start-icon">start</span>;
   const endIcon = <span data-testid="end-icon">end</span>;
@@ -92,11 +84,10 @@ describe('Button Component', () => {
     expect(screen.getByTestId('child')).toBeInTheDocument();
   });
 
-  it('should use shortLabel on mobile', () => {
-    mockedUseBreakpoints.mockReturnValue({
-      isMobile: true
-    });
+  it('should render short and full labels when both provided and use the full label as the accessible name', () => {
     render(<Button label="Long Label" shortLabel="Short" />);
     expect(screen.getByText('Short')).toBeInTheDocument();
+    expect(screen.getByText('Long Label')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Long Label' })).toBeInTheDocument();
   });
 });

--- a/app/shared/components/design-system/all-components/button/Button.tsx
+++ b/app/shared/components/design-system/all-components/button/Button.tsx
@@ -4,8 +4,9 @@ import { Button as MuiButton, ButtonProps as MuiButtonProps, CircularProgress } 
 import { styled } from '@mui/material/styles';
 import { forwardRef, ReactNode } from 'react';
 
+import { ButtonLabel } from './ButtonLabel';
+
 import { Link } from '~/i18n/navigation';
-import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
 
 const CustomButton = styled(MuiButton)({});
 
@@ -37,9 +38,6 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ label, shortLabel, link, externalLink, disabled, loading, startIcon, endIcon, children, ...props }, ref) => {
     const isDisabled = disabled ?? loading;
 
-    const { isMobile } = useBreakpoints();
-    label = isMobile && shortLabel ? shortLabel : label;
-
     const content = (
       <CustomButton
         ref={ref}
@@ -48,7 +46,13 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         endIcon={!loading ? endIcon : undefined}
         {...props}
       >
-        {loading ? <CircularProgress color="inherit" size={25} data-testid="loader" /> : (label ?? children)}
+        {loading ? (
+          <CircularProgress color="inherit" size={25} data-testid="loader" />
+        ) : (
+          <ButtonLabel label={label} shortLabel={shortLabel}>
+            {children}
+          </ButtonLabel>
+        )}
       </CustomButton>
     );
 

--- a/app/shared/components/design-system/all-components/button/ButtonLabel.tsx
+++ b/app/shared/components/design-system/all-components/button/ButtonLabel.tsx
@@ -1,0 +1,29 @@
+import { Box } from '@mui/material';
+import { ReactNode } from 'react';
+
+import { styles as labelStyles } from './Button.styles';
+
+type ButtonLabelProps = {
+  label?: string;
+  shortLabel?: string;
+  children?: ReactNode;
+};
+
+export const ButtonLabel: React.FC<ButtonLabelProps> = ({ label, shortLabel, children }) => {
+  if (children) return <>{children}</>;
+
+  if (shortLabel && label) {
+    return (
+      <>
+        <Box component="span" sx={labelStyles.short}>
+          {shortLabel}
+        </Box>
+        <Box component="span" sx={labelStyles.full}>
+          {label}
+        </Box>
+      </>
+    );
+  }
+
+  return <>{label ?? shortLabel ?? null}</>;
+};

--- a/app/shared/components/design-system/all-components/button/ButtonLabel.tsx
+++ b/app/shared/components/design-system/all-components/button/ButtonLabel.tsx
@@ -15,7 +15,7 @@ export const ButtonLabel: React.FC<ButtonLabelProps> = ({ label, shortLabel, chi
   if (shortLabel && label) {
     return (
       <>
-        <Box component="span" sx={labelStyles.short}>
+        <Box component="span" sx={labelStyles.short} aria-hidden>
           {shortLabel}
         </Box>
         <Box component="span" sx={labelStyles.full}>

--- a/app/shared/components/list-item/ListItem.styles.ts
+++ b/app/shared/components/list-item/ListItem.styles.ts
@@ -20,6 +20,18 @@ export const styles = {
       md: '8px'
     }
   },
+  bulletMobile: {
+    display: {
+      xs: 'inline-flex',
+      md: 'none'
+    }
+  },
+  bulletDesktop: {
+    display: {
+      xs: 'none',
+      md: 'inline-flex'
+    }
+  },
   typography: {
     fontFamily: 'Mulish',
     fontSize: { xs: '16px', md: '20px' },

--- a/app/shared/components/list-item/ListItem.test.tsx
+++ b/app/shared/components/list-item/ListItem.test.tsx
@@ -14,11 +14,14 @@ describe('ListItem component', () => {
     render(<ListItem text={mockText} />);
   });
 
-  it('should render the bullet icon with correct alt text and src', () => {
-    const bullet = screen.getByTestId('svg-image');
-    expect(bullet).toBeInTheDocument();
-    expect(bullet).toHaveAttribute('alt', 'bullet');
-    expect(bullet).toHaveAttribute('src', '/icons/bullet-small.svg');
+  it('should render decorative bullet icon(s) with correct src', () => {
+    const bullets = screen.getAllByTestId('svg-image');
+    expect(bullets.length).toBeGreaterThan(0);
+
+    for (const img of bullets) {
+      expect(img).toHaveAttribute('src', expect.stringContaining('/icons/bullet-small.svg'));
+      expect(img).toHaveAttribute('alt', '');
+    }
   });
 
   it('should render the provided text', () => {

--- a/app/shared/components/list-item/ListItem.tsx
+++ b/app/shared/components/list-item/ListItem.tsx
@@ -2,8 +2,6 @@
 
 import { Box, Typography } from '@mui/material';
 
-import useBreakpoints from '~/hooks/use-breakpoints/useBreakpoints';
-
 import { SvgImage } from '../svg-image/SvgImage';
 import { styles } from './ListItem.styles';
 
@@ -13,17 +11,15 @@ interface ListItemProps {
 }
 
 const ListItem: React.FC<ListItemProps> = ({ text, sx }) => {
-  const { isLaptopAndAbove } = useBreakpoints();
-
   return (
     <Box sx={{ ...styles.listItem, ...sx }}>
       <Box sx={styles.bulletIcon}>
-        <SvgImage
-          src="/icons/bullet-small.svg"
-          alt="bullet"
-          width={isLaptopAndAbove ? 16 : 12}
-          height={isLaptopAndAbove ? 16 : 12}
-        />
+        <Box sx={styles.bulletMobile} aria-hidden={true}>
+          <SvgImage src="/icons/bullet-small.svg" alt="" width={12} height={12} />
+        </Box>
+        <Box sx={styles.bulletDesktop} aria-hidden={true}>
+          <SvgImage src="/icons/bullet-small.svg" alt="" width={16} height={16} />
+        </Box>
       </Box>
       <Typography sx={styles.typography} component="div">
         {text}


### PR DESCRIPTION
## Description

Fixes hydration warnings by removing runtime breakpoint swaps. Button now renders both labels and hides/shows them with CSS. ListItem renders two decorative bullets (12px/16px) and switches via CSS. PaymentDetails: set <Typography component="div"> for IBAN row to avoid div-in-p and hydration errors.

## Type of change

- [x] Bug fix

## How to test

1. Open any page with the footer donation button and list bullets and check console has no hydration warnings
2. Resize from mobile to desktop and verify the button label switches correctly and bullets change 12 -> 16 without warnings

## Video / Screenshots

Mobile:
<img width="356" height="285" alt="image" src="https://github.com/user-attachments/assets/32400f47-87b5-47b4-9fd2-d7e2571b9a0f" />
<img width="377" height="259" alt="image" src="https://github.com/user-attachments/assets/3628c766-ff39-4375-b241-32a3cac43ccf" />

Desktop:
<img width="363" height="256" alt="image" src="https://github.com/user-attachments/assets/f9190728-2146-4fa7-8663-e446d9e59a79" />
<img width="467" height="58" alt="image" src="https://github.com/user-attachments/assets/eec1834f-675b-45ad-87ee-09ad59242b70" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
