### PR TITLE
chore: сhanged the link to plain text for payment methods

### DIFF
--- a/app/shared/components/blocks/volunteer-donation/PaymentMethodItem.tsx
+++ b/app/shared/components/blocks/volunteer-donation/PaymentMethodItem.tsx
@@ -1,0 +1,32 @@
+import { Box, Typography } from '@mui/material';
+import React, { useRef } from 'react';
+
+import { CopyButton } from '~/components/copy-button/CopyButton';
+
+import { PaymentMethod } from './VolunteerDonation';
+import { styles } from './VolunteerDonation.styles';
+
+interface PaymentMethodItemProps {
+  method: PaymentMethod;
+  hint: string;
+}
+
+export const PaymentMethodItem: React.FC<PaymentMethodItemProps> = ({ method, hint }) => {
+  const textRef = useRef<HTMLSpanElement>(null);
+
+  return (
+    <Box sx={styles.card}>
+      <Box sx={styles.paymentMethodContainer}>
+        {method.label && <Typography sx={styles.label}>{method.label}:</Typography>}
+
+        <Box sx={styles.valueContainer}>
+          <Typography component="span" ref={textRef} sx={styles.value}>
+            {method.value}
+          </Typography>
+
+          <CopyButton targetRef={textRef} hint={hint} iconSize="medium" />
+        </Box>
+      </Box>
+    </Box>
+  );
+};

--- a/app/shared/components/blocks/volunteer-donation/VolunteerDonation.styles.ts
+++ b/app/shared/components/blocks/volunteer-donation/VolunteerDonation.styles.ts
@@ -37,6 +37,38 @@ export const styles = {
       md: '24px'
     }
   },
+  paymentMethodContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px'
+  },
+  label: {
+    fontFamily: 'Mulish, Sans-serif',
+    color: mainHexPallete.brown[700],
+    letterSpacing: '0px',
+    whiteSpace: 'pre-line',
+    fontSize: { xs: '16px', sm: '16px' }
+  },
+  valueContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px'
+  },
+  value: {
+    fontFamily: 'Mulish, Sans-serif',
+    fontSize: '16px',
+    fontWeight: 600,
+    lineHeight: '110%',
+    color: mainHexPallete.black,
+    transition: 'color 0.2s ease',
+    '&:hover': {
+      color: mainHexPallete.burgundy[800],
+      cursor: 'pointer'
+    },
+    '&:active': {
+      color: mainHexPallete.black
+    }
+  },
   img: {
     gridColumn: {
       xs: '2 / -1',

--- a/app/shared/components/blocks/volunteer-donation/VolunteerDonation.test.tsx
+++ b/app/shared/components/blocks/volunteer-donation/VolunteerDonation.test.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 
 import VolunteerDonation from './VolunteerDonation';
 
-jest.mock('~/components/contact-link/ContactLink', () => ({
-  ContactLink: ({ label, value, type }: { label: string; value: string; type: string }) => (
-    <div data-testid={`contact-link-${type}`}>
-      {label}: {value}
-    </div>
-  )
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key
+}));
+
+jest.mock('~/components/copy-button/CopyButton', () => ({
+  CopyButton: ({ hint }: { hint: string }) => <button aria-label="Copy content">{hint}</button>
 }));
 
 jest.mock('~/components/image-with-caption/ImageWithCaption', () => ({
@@ -55,17 +55,26 @@ describe('VolunteerDonation', () => {
   it('should render all payment methods', () => {
     render(<VolunteerDonation {...mockProps} />);
 
-    const contactLinks = screen.getAllByTestId(/contact-link-/);
-    expect(contactLinks).toHaveLength(2);
-    expect(screen.getByText(/PayPal: paypal@example.com/)).toBeInTheDocument();
-    expect(screen.getByText(/Bank Transfer: bank@example.com/)).toBeInTheDocument();
+    expect(screen.getByText('PayPal:')).toBeInTheDocument();
+    expect(screen.getByText('paypal@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Bank Transfer:')).toBeInTheDocument();
+    expect(screen.getByText('bank@example.com')).toBeInTheDocument();
   });
 
   it('should render payment methods with correct data', () => {
     render(<VolunteerDonation {...mockProps} />);
 
-    expect(screen.getByText(/paypal@example.com/)).toBeInTheDocument();
-    expect(screen.getByText(/bank@example.com/)).toBeInTheDocument();
+    expect(screen.getByText('paypal@example.com')).toBeInTheDocument();
+    expect(screen.getByText('bank@example.com')).toBeInTheDocument();
+  });
+
+  it('should render copy buttons for each payment method', () => {
+    render(<VolunteerDonation {...mockProps} />);
+
+    const copyButtons = screen.getAllByRole('button', { name: /copy content/i });
+    expect(copyButtons).toHaveLength(2);
+    expect(copyButtons[0]).toHaveTextContent('copied');
+    expect(copyButtons[1]).toHaveTextContent('copied');
   });
 
   it('should render image with caption', () => {
@@ -90,8 +99,8 @@ describe('VolunteerDonation', () => {
     const propsWithNoMethods = { ...mockProps, paymentMethods: [] };
     render(<VolunteerDonation {...propsWithNoMethods} />);
 
-    const contactLinks = screen.queryAllByTestId(/contact-link-/);
-    expect(contactLinks).toHaveLength(0);
+    const copyButtons = screen.queryAllByRole('button', { name: /copy content/i });
+    expect(copyButtons).toHaveLength(0);
   });
 
   it('should render single payment method', () => {
@@ -101,9 +110,10 @@ describe('VolunteerDonation', () => {
     };
     render(<VolunteerDonation {...propsWithOneMethod} />);
 
-    const contactLinks = screen.getAllByTestId(/contact-link-/);
-    expect(contactLinks).toHaveLength(1);
-    expect(screen.getByText(/PayPal: paypal@example.com/)).toBeInTheDocument();
+    expect(screen.getByText('PayPal:')).toBeInTheDocument();
+    expect(screen.getByText('paypal@example.com')).toBeInTheDocument();
+    const copyButtons = screen.getAllByRole('button', { name: /copy content/i });
+    expect(copyButtons).toHaveLength(1);
   });
 
   it('should use title as image alt text', () => {

--- a/app/shared/components/blocks/volunteer-donation/VolunteerDonation.tsx
+++ b/app/shared/components/blocks/volunteer-donation/VolunteerDonation.tsx
@@ -1,13 +1,16 @@
+'use client';
+
 import { Box } from '@mui/material';
+import { useTranslations } from 'next-intl';
 import React from 'react';
 
-import { ContactLink } from '~/components/contact-link/ContactLink';
 import ImageWithCaption from '~/components/image-with-caption/ImageWithCaption';
 import SectionTitle from '~/components/section-title/SectionTitle';
 
+import { PaymentMethodItem } from './PaymentMethodItem';
 import { imageSizes, styles } from './VolunteerDonation.styles';
 
-interface PaymentMethod {
+export interface PaymentMethod {
   label: string;
   value: string;
 }
@@ -20,6 +23,8 @@ interface Props {
 }
 
 const VolunteerDonation: React.FC<Props> = ({ title, paymentMethods, imageSrc, caption }) => {
+  const t = useTranslations('common');
+
   return (
     <Box sx={styles.mainContainer}>
       <SectionTitle
@@ -31,9 +36,7 @@ const VolunteerDonation: React.FC<Props> = ({ title, paymentMethods, imageSrc, c
 
       <Box sx={styles.contentWrapper}>
         {paymentMethods.map((method, idx) => (
-          <Box key={`${method.label}-${idx}`} sx={styles.card}>
-            <ContactLink type="phone" value={method.value} label={method.label} />
-          </Box>
+          <PaymentMethodItem key={`${method.label}-${idx}`} method={method} hint={t('copied')} />
         ))}
       </Box>
 


### PR DESCRIPTION
## Description

Fix block to use his own component to show payment methods, instead ContactLink

## Type of change

- [x] Refactoring / Tech debt

