### PR TITLE
test: fix ts errors in footer and blocks tests

### DIFF
--- a/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.test.tsx
+++ b/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.test.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { useIsMobile } from '~/hooks/is-mobile/useIsMobile';
@@ -18,7 +19,7 @@ const labels = {
 
 const alertMsg = 'Copied';
 
-jest.mock('~/shared/hooks/is-mobile/useIsMobile', () => ({
+jest.mock('~/hooks/is-mobile/useIsMobile', () => ({
   useIsMobile: jest.fn()
 }));
 
@@ -26,15 +27,6 @@ describe('Contact information block inside of the Footer', () => {
   describe('Contact information on desktop', () => {
     beforeAll(() => {
       (useIsMobile as jest.Mock).mockReturnValue(false);
-
-      Object.defineProperties(navigator, {
-        clipboard: {
-          value: {
-            writeText: jest.fn()
-          }
-        }
-      });
-
       jest.spyOn(window, 'alert').mockImplementation(() => {});
     });
 
@@ -64,16 +56,22 @@ describe('Contact information block inside of the Footer', () => {
     });
 
     it('renders tel phone link with CopyButton', async () => {
-      const phoneSection = screen.getByText(contacts.phone).closest('div');
-      expect(phoneSection).not.toBeNull();
+      const user = userEvent.setup();
 
-      const copyButton = within(phoneSection).getByRole('button', { name: /copy content/i });
+      const writeSpy = jest.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(void 0);
 
-      await act(async () => {
-        fireEvent.click(copyButton);
-      });
+      const phoneLink = screen.getByRole('link', { name: contacts.phone });
+      expect(phoneLink).toBeInTheDocument();
 
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(contacts.phone);
+      const phoneContainer = phoneLink.parentElement as HTMLElement;
+      const copyButton = within(phoneContainer).getByRole('button', { name: /copy content/i });
+
+      await user.click(copyButton);
+
+      expect(writeSpy).toHaveBeenCalledTimes(1);
+      expect(writeSpy).toHaveBeenCalledWith(contacts.phone);
+
+      writeSpy.mockRestore();
     });
   });
 

--- a/app/shared/components/Footer/footer-social-media/FooterSocialMedia.test.tsx
+++ b/app/shared/components/Footer/footer-social-media/FooterSocialMedia.test.tsx
@@ -11,7 +11,7 @@ describe('Social media icon buttons', () => {
   const mockData = [
     {
       icon: SocialMediaTypes.Instagram,
-      href: 'https://www.instagram.com/'
+      link: 'https://www.instagram.com/'
     }
   ];
   it('should render an image based on the type', () => {

--- a/app/shared/components/blocks/FoundationFounders/FoundationTeam/FoundationTeam.test.tsx
+++ b/app/shared/components/blocks/FoundationFounders/FoundationTeam/FoundationTeam.test.tsx
@@ -6,17 +6,26 @@ const teamData = [
   {
     name: 'Тетяна Гомон',
     description: 'Спадкоємиця композитора',
-    photo: '/images/foundation/team/tetyana-gomon.jpg'
+    photo: {
+      src: '/images/foundation/team/tetyana-gomon.jpg',
+      alt: 'Tetyana Homon'
+    }
   },
   {
     name: 'Іван Коваленко',
     description: 'Дослідник творчості Лятошинського',
-    photo: '/images/foundation/team/ivan-kovalenko.jpg'
+    photo: {
+      src: '/images/foundation/team/ivan-kovalenko.jpg',
+      alt: 'Tetyana Homon'
+    }
   },
   {
     name: 'Марія Петрівна',
     description: 'Куратор проектів фонду',
-    photo: '/images/foundation/team/maria-petryvna.jpg'
+    photo: {
+      src: '/images/foundation/team/maria-petryvna.jpg',
+      alt: 'Tetyana Homon'
+    }
   }
 ];
 

--- a/app/shared/components/blocks/IntroSection/IntroSection.test.tsx
+++ b/app/shared/components/blocks/IntroSection/IntroSection.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 
 import { IntroSection } from '~/components/blocks/IntroSection/IntroSection';
 
+import type { IIntroSection } from '~/types/page/about-us.types';
+
 jest.mock('~/components/image-with-caption/ImageWithCaption', () => ({
   __esModule: true,
   default: ({ src, alt, caption }: { src: string; alt: string; caption: string }) => (
@@ -12,17 +14,17 @@ jest.mock('~/components/image-with-caption/ImageWithCaption', () => ({
   )
 }));
 
-jest.mock('~/shared/components/Quote/Quote', () => {
+jest.mock('~/components/Quote/Quote', () => {
   const AboutFoundationMockQuote = () => <div data-testid="quote" />;
   AboutFoundationMockQuote.displayName = 'AboutFoundationMockQuote';
   return AboutFoundationMockQuote;
 });
 
-const mockData = {
+const mockData: IIntroSection = {
   title: 'Welcome to the Lyatoshynsky Foundation',
   quote: {
-    mainText: 'Preserving the legacy of a musical genius',
-    sourceTitle: 'Boris Lyatoshynsky'
+    text: 'Preserving the legacy of a musical genius',
+    source: 'Boris Lyatoshynsky'
   },
   image: {
     src: '/images/intro-section.jpg',
@@ -33,7 +35,7 @@ const mockData = {
 
 describe('IntroSection', () => {
   it('should render the IntroSection with text', () => {
-    render(IntroSection({ data: mockData }));
+    render(<IntroSection data={mockData} />);
     expect(screen.getByText('Welcome to the Lyatoshynsky Foundation')).toBeInTheDocument();
   });
 });

--- a/app/shared/components/blocks/Liatoshynsky-office/LiatoshynskyOffice.test.tsx
+++ b/app/shared/components/blocks/Liatoshynsky-office/LiatoshynskyOffice.test.tsx
@@ -35,7 +35,8 @@ const mockT = mockTWithTranslations as ReturnType<typeof useTranslations>;
 const mockData = {
   quote: {
     text: 'Текст моєї тестової цитати',
-    author: 'Тестовий Автор'
+    author: 'Тестовий Автор',
+    source: 'Тестове Джерело'
   }
 };
 

--- a/app/shared/components/blocks/collaboration/collaboration-intro/CollaborationIntro.test.tsx
+++ b/app/shared/components/blocks/collaboration/collaboration-intro/CollaborationIntro.test.tsx
@@ -33,8 +33,14 @@ describe('CollaborationIntro', () => {
   };
 
   it('should render title, subtitle and content', () => {
-    render(<CollaborationIntro title={mockedData.title} subtitle={mockedData.subtitle} content={mockedData.content} />);
-
+    render(
+      <CollaborationIntro
+        title={mockedData.title}
+        subtitle={mockedData.subtitle}
+        content={mockedData.content}
+        contentAbove={{ type: TipTapNodeTypes.doc, content: [] }}
+      />
+    );
     const title = screen.getByText(mockedData.title);
     const subtitle = screen.getByText(mockedData.subtitle);
     const paragraph1 = screen.getByText(mockedData.content.content[0].content[0].text);

--- a/app/shared/components/cookie-modal/CookieModalWrapper.test.tsx
+++ b/app/shared/components/cookie-modal/CookieModalWrapper.test.tsx
@@ -5,9 +5,7 @@ import { CookieModalProps } from './modal/CookieModal';
 import { CookiePreferencesModalProps } from './preferances/CookiePreferencesModal';
 
 declare global {
-  interface Window {
-    gtag: (...args: any[]) => void;
-  }
+  var gtag: (...args: unknown[]) => void;
 }
 
 jest.mock('./modal/CookieModal', () => ({
@@ -52,7 +50,7 @@ const expectCookieSet = (expected: 'granted' | 'denied') => {
 describe('CookieModalWrapper', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    window.gtag = jest.fn();
+    globalThis.gtag = jest.fn();
     document.cookie = '';
   });
 


### PR DESCRIPTION
## Description

- FooterSocialMedia: align test data to `link` prop (was `href`);
- FooterContactInfo: use userEvent; query CopyButton by *scoped* role to the phone section (email also has a CopyButton);
- useIsMobile: correct mock path and typing;
- IntroSection: type with IIntroSection, correct quote shape, render via JSX;
- FoundationTeam: pass photo as {src, alt} to match component contract;
- LiatoshynskyOffice: include quote.source in mock;
- CookieModalWrapper: type-safe gtag mock via globalThis, drop Parameters<Window['gtag']>

## Type of change

- [x] Refactoring / Tech debt
- [x] Other: tests/typing fixes

## How to test

Type-check the project:
```bash
npx tsc -p tsconfig.json --noEmit
```

## Screenshots

The reported errors are from unrelated files.
The seven files in this issue compile with zero TypeScript errors:
<img width="1015" height="241" alt="image" src="https://github.com/user-attachments/assets/7c963c16-df58-40f8-ace7-b5b53a7a2011" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
