### PR TITLE
feat(archive): add backend skeleton for case details

### DIFF
--- a/app/di/modules/composedServices.module.ts
+++ b/app/di/modules/composedServices.module.ts
@@ -1,5 +1,6 @@
 import { asFunction } from 'awilix';
 
+import { createArchiveService } from '~/services/composed/archive-service/archiveService';
 import { createArtistryService } from '~/services/composed/artistry-service/artistryService';
 import { createFooterService } from '~/services/composed/footer-service/footerService';
 import { createHeaderService } from '~/services/composed/header-service/headerService';
@@ -29,5 +30,7 @@ export const registerComposedServices = () => ({
 
   pagesDataService: asFunction(({ pagesService }) => createPagesDataService(pagesService)).scoped(),
 
-  draftPagesDataService: asFunction(({ draftPagesService }) => createDraftPagesDataService(draftPagesService)).scoped()
+  draftPagesDataService: asFunction(({ draftPagesService }) => createDraftPagesDataService(draftPagesService)).scoped(),
+
+  archiveCaseService: asFunction(({ archiveService }) => createArchiveService({ archiveService })).scoped()
 });

--- a/app/di/modules/coreService.module.ts
+++ b/app/di/modules/coreService.module.ts
@@ -1,5 +1,6 @@
 import { asFunction } from 'awilix';
 
+import { createArchiveService } from '~/services/core/archiveService';
 import { createCompositionService } from '~/services/core/compositionService';
 import { createFoundationInfoService } from '~/services/core/foundationInfoService';
 import { createNavigationService } from '~/services/core/navigationService';
@@ -23,5 +24,7 @@ export const registerCoreServices = () => ({
 
   pagesService: asFunction(({ pagesDataRepository }) => createPagesService(pagesDataRepository)).scoped(),
 
-  draftPagesService: asFunction(({ pagesDataRepository }) => createDraftPagesService(pagesDataRepository)).scoped()
+  draftPagesService: asFunction(({ pagesDataRepository }) => createDraftPagesService(pagesDataRepository)).scoped(),
+
+  archiveService: asFunction(({ archiveRepository }) => createArchiveService(archiveRepository)).scoped()
 });

--- a/app/di/modules/repositories.module.ts
+++ b/app/di/modules/repositories.module.ts
@@ -1,5 +1,6 @@
 import { asFunction } from 'awilix';
 
+import { archiveRepository } from '~/infrastructure/repositories/archive/archive.repository';
 import { compositionsRepository } from '~/infrastructure/repositories/artistry/сompositions.repository';
 import { foundationInfoRepository } from '~/infrastructure/repositories/foundation-info/foundationInfo.repository';
 import { navigationRepository } from '~/infrastructure/repositories/navigation/navigation.repository';
@@ -11,5 +12,6 @@ export const registerRepositories = () => ({
   navigationRepository: asFunction(() => navigationRepository).scoped(),
   compositionsRepository: asFunction(() => compositionsRepository).scoped(),
   pagesDataRepository: asFunction(() => pagesDataRepository).scoped(),
-  scientificWorksRepository: asFunction(() => scientificWorksRepository).scoped()
+  scientificWorksRepository: asFunction(() => scientificWorksRepository).scoped(),
+  archiveRepository: asFunction(() => archiveRepository).scoped()
 });

--- a/app/domain/repositories/archive.repository.ts
+++ b/app/domain/repositories/archive.repository.ts
@@ -1,0 +1,3 @@
+export type ArchiveRepository = {
+  getCaseDetail(fund: string, caseSlug: string): Promise<unknown>;
+};

--- a/app/domain/services/archive.type.ts
+++ b/app/domain/services/archive.type.ts
@@ -1,0 +1,5 @@
+import type { ArchiveService } from '~/services/core/archiveService';
+
+export type ArchiveServiceDeps = {
+  archiveService: ArchiveService;
+};

--- a/app/infrastructure/repositories/archive/archive.repository.ts
+++ b/app/infrastructure/repositories/archive/archive.repository.ts
@@ -1,0 +1,10 @@
+import type { ArchiveRepository } from '~/domain/repositories/archive.repository';
+import dbConnect from '~/infrastructure/db/connect';
+
+export const archiveRepository: ArchiveRepository = {
+  async getCaseDetail(_fund, _caseSlug) {
+    await dbConnect();
+
+    return null;
+  }
+};

--- a/app/services/composed/archive-service/archiveService.test.ts
+++ b/app/services/composed/archive-service/archiveService.test.ts
@@ -1,0 +1,86 @@
+import type { ArchiveServiceDeps } from '~/domain/services/archive.type';
+import { createArchiveService } from '~/services/composed/archive-service/archiveService';
+
+const uk = 'uk' as const;
+const en = 'en' as const;
+
+const raw = {
+  fund: '2',
+  caseSlug: 'op1-spr3',
+  title: { uk: 'Трудова діяльність', en: 'Work activity' },
+  code: 'Ф. 2, оп. 1, спр. 3',
+  dates: '1895–1955',
+  sheetsCount: 26,
+  items: [
+    { order: 2, text: { uk: 'Документ Б', en: 'Document B' } },
+    { order: 1, text: { uk: 'Документ А', en: 'Document A' } }
+  ],
+  pdfUrl: 'https://example.com/f2-op1-spr3.pdf',
+  prev: { href: '/uk/archive/fund/2/case/op1-spr2', title: { uk: 'Попередня назва', en: 'Previous title' } },
+  next: null
+};
+
+describe('archiveService', () => {
+  let deps: ArchiveServiceDeps;
+
+  beforeEach(() => {
+    deps = {
+      archiveService: {
+        getCaseDetail: jest.fn()
+      }
+    };
+  });
+
+  it('returns localized, validated data (uk) and sorts items by order', async () => {
+    (deps.archiveService.getCaseDetail as jest.Mock).mockResolvedValue(raw);
+    const service = createArchiveService(deps);
+
+    const res = await service.getCase(uk, '2', 'op1-spr3');
+
+    expect(res).toEqual({
+      id: '2-op1-spr3',
+      fund: '2',
+      caseSlug: 'op1-spr3',
+      title: 'Трудова діяльність',
+      code: 'Ф. 2, оп. 1, спр. 3',
+      dates: '1895–1955',
+      sheetsCount: 26,
+      items: [
+        { order: 1, text: 'Документ А' },
+        { order: 2, text: 'Документ Б' }
+      ],
+      pdfUrl: 'https://example.com/f2-op1-spr3.pdf',
+      prev: { href: '/uk/archive/fund/2/case/op1-spr2', title: 'Попередня назва' },
+      next: null
+    });
+
+    expect(deps.archiveService.getCaseDetail).toHaveBeenCalledWith('2', 'op1-spr3');
+  });
+
+  it('localizes to EN', async () => {
+    (deps.archiveService.getCaseDetail as jest.Mock).mockResolvedValue(raw);
+    const service = createArchiveService(deps);
+
+    const res = await service.getCase(en, '2', 'op1-spr3');
+
+    expect(res?.title).toBe('Work activity');
+    expect(res?.items[0].text).toBe('Document A');
+    expect(res?.prev?.title).toBe('Previous title');
+  });
+
+  it('returns null when not found', async () => {
+    (deps.archiveService.getCaseDetail as jest.Mock).mockResolvedValue(null);
+    const service = createArchiveService(deps);
+
+    const res = await service.getCase(uk, '2', 'op1-spr3');
+
+    expect(res).toBeNull();
+  });
+
+  it('throws on invalid shape', async () => {
+    (deps.archiveService.getCaseDetail as jest.Mock).mockResolvedValue({ ...raw, code: undefined });
+    const service = createArchiveService(deps);
+
+    await expect(service.getCase(uk, '2', 'op1-spr3')).rejects.toThrow();
+  });
+});

--- a/app/services/composed/archive-service/archiveService.ts
+++ b/app/services/composed/archive-service/archiveService.ts
@@ -1,0 +1,14 @@
+import { Locale } from 'next-intl';
+
+import type { ArchiveCaseDetail } from '~/types/page/archive.types';
+
+import type { ArchiveServiceDeps } from '~/domain/services/archive.type';
+import { createLocalizedArchiveCaseSchema } from '~/validators/pagesSchemas/pages/archive.schema';
+
+export const createArchiveService = ({ archiveService }: ArchiveServiceDeps) => ({
+  async getCase(locale: Locale, fund: string, caseSlug: string): Promise<ArchiveCaseDetail | null> {
+    const raw = await archiveService.getCaseDetail(fund, caseSlug);
+    if (!raw) return null;
+    return createLocalizedArchiveCaseSchema(locale).parse(raw);
+  }
+});

--- a/app/services/core/archiveService.ts
+++ b/app/services/core/archiveService.ts
@@ -1,0 +1,7 @@
+import type { ArchiveRepository } from '~/domain/repositories/archive.repository';
+
+export const createArchiveService = (repo: ArchiveRepository) => ({
+  getCaseDetail: (fund: string, caseSlug: string) => repo.getCaseDetail(fund, caseSlug)
+});
+
+export type ArchiveService = ReturnType<typeof createArchiveService>;

--- a/app/types/page/archive.types.ts
+++ b/app/types/page/archive.types.ts
@@ -1,0 +1,19 @@
+export type ArchiveCaseItem = {
+  order: number;
+  text: string;
+};
+
+export interface ArchiveCaseDetail {
+  id: string;
+  fund: string;
+  caseSlug: string;
+  title: string;
+  code: string;
+  dates: string;
+  sheetsCount: number;
+  items: ArchiveCaseItem[];
+  pdfUrl?: string;
+
+  prev?: { title: string; href: string } | null;
+  next?: { title: string; href: string } | null;
+}

--- a/app/validators/pagesSchemas/pages/archive.schema.ts
+++ b/app/validators/pagesSchemas/pages/archive.schema.ts
@@ -1,0 +1,50 @@
+import { Locale } from 'next-intl';
+import { z } from 'zod';
+
+import type { ArchiveCaseDetail } from '~/types/page/archive.types';
+
+import { translatedFieldSchema } from '~/validators/constants';
+
+const ArchiveCaseItemRaw = z.object({
+  order: z.number().int().positive(),
+  text: translatedFieldSchema
+});
+
+export const ArchiveCaseRaw = z.object({
+  fund: z.string().min(1),
+  caseSlug: z.string().min(1),
+  title: translatedFieldSchema,
+  code: z.string().min(1),
+  dates: z.string().min(1),
+  sheetsCount: z.number().int().nonnegative(),
+  items: z.array(ArchiveCaseItemRaw),
+  pdfUrl: z.string().url().optional(),
+  prev: z
+    .object({ title: translatedFieldSchema, href: z.string().min(1) })
+    .nullable()
+    .optional(),
+  next: z
+    .object({ title: translatedFieldSchema, href: z.string().min(1) })
+    .nullable()
+    .optional()
+});
+
+export const createLocalizedArchiveCaseSchema = (locale: Locale) =>
+  ArchiveCaseRaw.transform(
+    (raw): ArchiveCaseDetail => ({
+      id: `${raw.fund}-${raw.caseSlug}`,
+      fund: raw.fund,
+      caseSlug: raw.caseSlug,
+      title: raw.title[locale],
+      code: raw.code,
+      dates: raw.dates,
+      sheetsCount: raw.sheetsCount,
+      items: raw.items
+        .slice()
+        .sort((a, b) => a.order - b.order)
+        .map((i) => ({ order: i.order, text: i.text[locale] })),
+      pdfUrl: raw.pdfUrl,
+      prev: raw.prev ? { title: raw.prev.title[locale], href: raw.prev.href } : null,
+      next: raw.next ? { title: raw.next.title[locale], href: raw.next.href } : null
+    })
+  );


### PR DESCRIPTION
## Description

Prepare a backend skeleton for loading a single archive case by fund + caseSlug.
This adds types, Zod schema, repository, core + composed services, DI wiring, and unit tests.
The repository still returns null – real DB logic will be added later in archive-specific tasks.

1. Domain + types:

- add ArchiveCaseItem and ArchiveCaseDetail view types;
- add Zod schema for raw DB shape and localization transform;
- ArchiveCaseRaw – raw record from repository (fund, caseSlug, translated title, dates, sheetsCount, items, optional pdfUrl, prev/next);
- createLocalizedArchiveCaseSchema(locale) – converts ArchiveCaseRaw -> ArchiveCaseDetail, localizes title, items.text, prev/next.title and sorts items by order.

2. Repository + core service:

- define archive repository contract;
- add infrastructure repository stub;
- add core service that wraps the repository;
- add core service type for composed layer.

3. Composed service

- add composed archive service;
- unit tests for composed service.

4. DI wiring

- register repository;
- register core service;
- register composed service.

## Type of change

- [x] New feature

## How to test

There are no route or UI changes in this PR.
The /[lang]/archive/[fund]/[case] page will be implemented in the Case Details ticket.

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [ ] Task moved to the review column on the board

---
