### PR TITLE
feat(CustomLink): support sx and labelSx overrides

### DIFF
--- a/app/shared/components/design-system/all-components/link/CustomLink.tsx
+++ b/app/shared/components/design-system/all-components/link/CustomLink.tsx
@@ -1,25 +1,36 @@
-import { Button, ButtonProps, Typography } from '@mui/material';
+import { Button, Typography } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
 
 import { linkStyles } from './CustomLink.styles';
 import { NextLinkComposed } from './NextLink';
 
-export interface CustomLinkProps extends ButtonProps {
+import { sxToArray } from '~/lib/utils/sxToArray';
+
+export interface CustomLinkProps {
   children: React.ReactNode;
   path: string;
+  startIcon?: React.ReactNode;
+  endIcon?: React.ReactNode;
+  sx?: SxProps<Theme>;
+  labelSx?: SxProps<Theme>;
 }
-const CustomLink = ({ path, children, startIcon, endIcon }: CustomLinkProps) => {
+
+const CustomLink: React.FC<CustomLinkProps> = ({ path, children, startIcon, endIcon, sx, labelSx }) => {
+  const buttonSx = [linkStyles.button, ...sxToArray(sx)];
+  const typoSx = [linkStyles.typography, ...sxToArray(labelSx)];
+
   return (
     <Button
       startIcon={startIcon}
       endIcon={endIcon}
       size="small"
-      sx={linkStyles.button}
+      sx={buttonSx}
       component={NextLinkComposed}
       disableElevation
       disableRipple
       to={{ pathname: path }}
     >
-      <Typography sx={linkStyles.typography}>{children}</Typography>
+      <Typography sx={typoSx}>{children}</Typography>
     </Button>
   );
 };


### PR DESCRIPTION
## Description

The CustomLink component in the design system was using hard-coded styles (linkStyles.button and linkStyles.typography) and exposed an implicit API via ButtonProps, even though we only used a small subset of those props.

This became an issue when implementing the "<-Повернутись" (Return) button for the #899" task, which required different styling.

- add an explicit CustomLinkProps interface (no ButtonProps inheritance);
- add sx for the root button styles;
- add labelSx for the inner Typography styles;
- keep the existing behavior (still renders Button with NextLinkComposed under the hood).

## Type of change

- [x] New feature
- [x] Refactoring / Tech debt

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Run the app
```bash
npm install
npm run dev
```
2. Verify sx and labelSx overrides
Temporarily render CustomLink in a test component or page:
```ts
<CustomLink
  path="/test"
  startIcon={<SvgImage src="/icons/arrow-left.svg" height={12} width={12} alt="" />}
  sx={{ color: 'red', textTransform: 'none' }}
  labelSx={{
    fontSize: 18,
    fontWeight: 700,
    '&:hover': {
      borderBottom: 'none'
    }
  }}
>
  Test CustomLink
</CustomLink>
```
3. Confirm that:
- the root button picks up color: 'red' and other sx styles;
- the text uses the overridden font size / weight;
- the hover underline is removed thanks to labelSx overrides.

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
