### PR TITLE
WayForPay callback

### DIFF
--- a/app/api/callback/route.ts
+++ b/app/api/callback/route.ts
@@ -5,7 +5,9 @@ import crypto from 'node:crypto';
 
 import { WayForPay } from '~/config';
 import dbConnect from '~/infrastructure/db/connect';
+import type { IDonationOrder, TDonationOrderStatus } from '~/infrastructure/models/way-for-pay/DonationOrder';
 import { DonationOrder } from '~/infrastructure/models/way-for-pay/DonationOrder';
+import type { IWayforPayCallbackPayload } from '~/infrastructure/models/way-for-pay/PaymentEvent';
 import { PaymentEvent } from '~/infrastructure/models/way-for-pay/PaymentEvent';
 
 export const runtime = 'nodejs';
@@ -14,29 +16,29 @@ function hmacMd5(base: string, key: string) {
   return crypto.createHmac('md5', key).update(base, 'utf8').digest('hex');
 }
 
-type WayforPayCallback = {
-  merchantAccount: string;
-  orderReference: string;
-  merchantSignature: string;
-  amount: number | string;
-  currency: string;
-  authCode?: string;
-  cardPan?: string;
-  transactionStatus: string;
-  reasonCode: string | number;
-  reason?: string;
-  [k: string]: any;
-};
+type MongoErrorWithCode = { code: number };
+
+function isDuplicateKeyError(error: unknown): error is MongoErrorWithCode {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'number' &&
+    (error as { code: number }).code === 11000
+  );
+}
 
 export async function POST(req: NextRequest) {
   if (!req.headers.get('content-type')?.includes('application/json')) {
     return NextResponse.json({ error: 'unsupported media type' }, { status: 415 });
   }
+
   if (!WayForPay.MERCHANT_SECRET_KEY) {
     return NextResponse.json({ error: 'server misconfigured' }, { status: 500 });
   }
 
-  const body = (await req.json()) as WayforPayCallback;
+  const body = (await req.json()) as IWayforPayCallbackPayload;
+
   const {
     merchantAccount,
     orderReference,
@@ -79,7 +81,9 @@ export async function POST(req: NextRequest) {
   }
 
   await dbConnect();
-  const order = await DonationOrder.findOne({ orderReference }).lean();
+
+  const order = await DonationOrder.findOne({ orderReference }).lean<IDonationOrder>();
+
   if (!order) {
     return NextResponse.json({ error: 'order not found' }, { status: 500 });
   }
@@ -89,9 +93,11 @@ export async function POST(req: NextRequest) {
   }
 
   const session = await startSession();
+
   try {
     await session.withTransaction(async () => {
       let isNewEvent = true;
+
       try {
         await PaymentEvent.create(
           [
@@ -105,36 +111,37 @@ export async function POST(req: NextRequest) {
           ],
           { session }
         );
-      } catch (e: any) {
-        if (e?.code === 11000) {
+      } catch (error: unknown) {
+        if (isDuplicateKeyError(error)) {
           isNewEvent = false;
         } else {
-          throw e;
+          throw error;
         }
       }
 
       if (isNewEvent) {
-        const map: Record<string, 'Paid' | 'Declined' | 'Expired' | 'InProcessing' | 'Pending'> = {
+        const map: Record<string, TDonationOrderStatus> = {
           Approved: 'Paid',
           Declined: 'Declined',
           Expired: 'Expired',
           InProcessing: 'InProcessing'
         };
-        const nextStatus = map[String(transactionStatus)] ?? 'Pending';
 
-        const update: any = {
+        const nextStatus: TDonationOrderStatus = map[String(transactionStatus)] ?? 'Pending';
+
+        const update: Partial<IDonationOrder> & { status: TDonationOrderStatus } = {
           status: nextStatus,
           reasonCode: reasonCode ?? null,
           reason: reason ?? null
         };
+
         if (nextStatus === 'Paid') {
           update.paidAt = new Date();
           update.paymentProvider = 'WayForPay';
           update.providerTxnId = authCode ?? null;
         }
 
-        const res = await DonationOrder.updateOne({ orderReference }, { $set: update }, { session });
-        updated = res.modifiedCount > 0;
+        await DonationOrder.updateOne({ orderReference }, { $set: update }, { session });
       }
     });
   } finally {

--- a/app/api/callback/route.ts
+++ b/app/api/callback/route.ts
@@ -75,8 +75,8 @@ export async function POST(req: NextRequest) {
     String(reasonCode)
   ].join(';');
 
-  const localSig = hmacMd5(baseIncoming, WayForPay.MERCHANT_SECRET_KEY);
-  if (localSig !== merchantSignature) {
+  const localSignature = hmacMd5(baseIncoming, WayForPay.MERCHANT_SECRET_KEY);
+  if (localSignature !== merchantSignature) {
     return NextResponse.json({ error: 'invalid signature' }, { status: 403 });
   }
 

--- a/app/api/callback/route.ts
+++ b/app/api/callback/route.ts
@@ -1,0 +1,150 @@
+import { startSession } from 'mongoose';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import crypto from 'node:crypto';
+
+import { WayForPay } from '~/config';
+import dbConnect from '~/infrastructure/db/connect';
+import { DonationOrder } from '~/infrastructure/models/way-for-pay/DonationOrder';
+import { PaymentEvent } from '~/infrastructure/models/way-for-pay/PaymentEvent';
+
+export const runtime = 'nodejs';
+
+function hmacMd5(base: string, key: string) {
+  return crypto.createHmac('md5', key).update(base, 'utf8').digest('hex');
+}
+
+type WayforPayCallback = {
+  merchantAccount: string;
+  orderReference: string;
+  merchantSignature: string;
+  amount: number | string;
+  currency: string;
+  authCode?: string;
+  cardPan?: string;
+  transactionStatus: string;
+  reasonCode: string | number;
+  reason?: string;
+  [k: string]: any;
+};
+
+export async function POST(req: NextRequest) {
+  if (!req.headers.get('content-type')?.includes('application/json')) {
+    return NextResponse.json({ error: 'unsupported media type' }, { status: 415 });
+  }
+  if (!WayForPay.MERCHANT_SECRET_KEY) {
+    return NextResponse.json({ error: 'server misconfigured' }, { status: 500 });
+  }
+
+  const body = (await req.json()) as WayforPayCallback;
+  const {
+    merchantAccount,
+    orderReference,
+    amount,
+    currency,
+    authCode,
+    cardPan,
+    transactionStatus,
+    reasonCode,
+    merchantSignature,
+    reason
+  } = body ?? {};
+
+  if (
+    !merchantAccount ||
+    !orderReference ||
+    amount === undefined ||
+    !currency ||
+    !transactionStatus ||
+    reasonCode === undefined ||
+    !merchantSignature
+  ) {
+    return NextResponse.json({ error: 'bad payload' }, { status: 400 });
+  }
+
+  const baseIncoming = [
+    merchantAccount,
+    String(orderReference),
+    String(amount),
+    String(currency),
+    authCode ?? '',
+    cardPan ?? '',
+    String(transactionStatus),
+    String(reasonCode)
+  ].join(';');
+
+  const localSig = hmacMd5(baseIncoming, WayForPay.MERCHANT_SECRET_KEY);
+  if (localSig !== merchantSignature) {
+    return NextResponse.json({ error: 'invalid signature' }, { status: 403 });
+  }
+
+  await dbConnect();
+  const order = await DonationOrder.findOne({ orderReference }).lean();
+  if (!order) {
+    return NextResponse.json({ error: 'order not found' }, { status: 500 });
+  }
+
+  if (Number(order.amount) !== Number(amount) || order.currency !== String(currency)) {
+    return NextResponse.json({ error: 'amount/currency mismatch' }, { status: 422 });
+  }
+
+  const session = await startSession();
+  try {
+    await session.withTransaction(async () => {
+      let isNewEvent = true;
+      try {
+        await PaymentEvent.create(
+          [
+            {
+              orderReference,
+              transactionStatus: String(transactionStatus),
+              authCode: authCode ?? '',
+              reasonCode: reasonCode ?? null,
+              payload: body
+            }
+          ],
+          { session }
+        );
+      } catch (e: any) {
+        if (e?.code === 11000) {
+          isNewEvent = false;
+        } else {
+          throw e;
+        }
+      }
+
+      if (isNewEvent) {
+        const map: Record<string, 'Paid' | 'Declined' | 'Expired' | 'InProcessing' | 'Pending'> = {
+          Approved: 'Paid',
+          Declined: 'Declined',
+          Expired: 'Expired',
+          InProcessing: 'InProcessing'
+        };
+        const nextStatus = map[String(transactionStatus)] ?? 'Pending';
+
+        const update: any = {
+          status: nextStatus,
+          reasonCode: reasonCode ?? null,
+          reason: reason ?? null
+        };
+        if (nextStatus === 'Paid') {
+          update.paidAt = new Date();
+          update.paymentProvider = 'WayForPay';
+          update.providerTxnId = authCode ?? null;
+        }
+
+        const res = await DonationOrder.updateOne({ orderReference }, { $set: update }, { session });
+        updated = res.modifiedCount > 0;
+      }
+    });
+  } finally {
+    await session.endSession();
+  }
+
+  const time = Math.floor(Date.now() / 1000);
+  const status = 'accept' as const;
+  const ackBase = [String(orderReference), status, String(time)].join(';');
+  const signature = hmacMd5(ackBase, WayForPay.MERCHANT_SECRET_KEY);
+
+  return NextResponse.json({ orderReference, status, time, signature }, { status: 200 });
+}

--- a/app/infrastructure/models/way-for-pay/DonationOrder.ts
+++ b/app/infrastructure/models/way-for-pay/DonationOrder.ts
@@ -23,7 +23,11 @@ const schema = new Schema<IDonationOrder>(
     orderReference: { type: String, required: true, unique: true, index: true },
     amount: { type: Number, required: true, min: 1 },
     currency: { type: String, required: true },
-    status: { type: String, enum: ['Pending', 'Paid', 'Declined', 'Expired', 'InProcessing'], default: 'Pending' },
+    status: {
+      type: String,
+      enum: ['Pending', 'Paid', 'Declined', 'Expired', 'InProcessing'],
+      default: 'Pending'
+    },
     language: { type: String, enum: ['UA', 'EN'], required: true },
     paidAt: { type: Date, default: null },
     paymentProvider: { type: String, default: 'WayForPay' },

--- a/app/infrastructure/models/way-for-pay/DonationOrder.ts
+++ b/app/infrastructure/models/way-for-pay/DonationOrder.ts
@@ -10,7 +10,7 @@ export interface IDonationOrder {
   language: 'UA' | 'EN';
   paidAt?: Date | null;
   paymentProvider?: 'WayForPay';
-  providerTxnId?: string | null; // authCode
+  providerTxnId?: string | null;
   reasonCode?: string | number | null;
   reason?: string | null;
   productName: string[];

--- a/app/infrastructure/models/way-for-pay/DonationOrder.ts
+++ b/app/infrastructure/models/way-for-pay/DonationOrder.ts
@@ -1,0 +1,40 @@
+import { model, models, Schema } from 'mongoose';
+
+export type TDonationOrderStatus = 'Pending' | 'Paid' | 'Declined' | 'Expired' | 'InProcessing';
+
+export interface IDonationOrder {
+  orderReference: string;
+  amount: number;
+  currency: string;
+  status: TDonationOrderStatus;
+  language: 'UA' | 'EN';
+  paidAt?: Date | null;
+  paymentProvider?: 'WayForPay';
+  providerTxnId?: string | null; // authCode
+  reasonCode?: string | number | null;
+  reason?: string | null;
+  productName: string[];
+  productCount: number[];
+  productPrice: number[];
+}
+
+const schema = new Schema<IDonationOrder>(
+  {
+    orderReference: { type: String, required: true, unique: true, index: true },
+    amount: { type: Number, required: true, min: 1 },
+    currency: { type: String, required: true },
+    status: { type: String, enum: ['Pending', 'Paid', 'Declined', 'Expired', 'InProcessing'], default: 'Pending' },
+    language: { type: String, enum: ['UA', 'EN'], required: true },
+    paidAt: { type: Date, default: null },
+    paymentProvider: { type: String, default: 'WayForPay' },
+    providerTxnId: { type: String, default: null },
+    reasonCode: { type: Schema.Types.Mixed, default: null },
+    reason: { type: String, default: null },
+    productName: { type: [String], required: true },
+    productCount: { type: [Number], required: true },
+    productPrice: { type: [Number], required: true }
+  },
+  { timestamps: true }
+);
+
+export const DonationOrder = models.DonationOrder || model<IDonationOrder>('DonationOrder', schema);

--- a/app/infrastructure/models/way-for-pay/PaymentEvent.ts
+++ b/app/infrastructure/models/way-for-pay/PaymentEvent.ts
@@ -1,0 +1,24 @@
+import { model, models, Schema } from 'mongoose';
+
+export interface IPaymentEvent {
+  orderReference: string;
+  transactionStatus: string;
+  authCode: string;
+  reasonCode: string | number | null;
+  payload: any;
+}
+
+const schema = new Schema<IPaymentEvent>(
+  {
+    orderReference: { type: String, required: true, index: true },
+    transactionStatus: { type: String, required: true },
+    authCode: { type: String, required: true, default: '' },
+    reasonCode: { type: Schema.Types.Mixed, default: null },
+    payload: { type: Schema.Types.Mixed, required: true }
+  },
+  { timestamps: { createdAt: true, updatedAt: false } }
+);
+
+schema.index({ orderReference: 1, transactionStatus: 1, authCode: 1 }, { unique: true, name: 'uniq_orderStatusAuth' });
+
+export const PaymentEvent = models.PaymentEvent || model<IPaymentEvent>('PaymentEvent', schema);

--- a/app/infrastructure/models/way-for-pay/PaymentEvent.ts
+++ b/app/infrastructure/models/way-for-pay/PaymentEvent.ts
@@ -1,11 +1,37 @@
 import { model, models, Schema } from 'mongoose';
 
+export interface IWayforPayCallbackPayload {
+  merchantAccount: string;
+  orderReference: string;
+  merchantSignature: string;
+  amount: number | string;
+  currency: string;
+  transactionStatus: string;
+  reasonCode: string | number;
+  reason?: string;
+
+  authCode?: string;
+  cardPan?: string;
+  email?: string;
+  phone?: string;
+  createdDate?: number;
+  processingDate?: number;
+  cardType?: string;
+  issuerBankCountry?: string;
+  issuerBankName?: string;
+  recToken?: string;
+  fee?: number;
+  paymentSystem?: string;
+  repayUrl?: string;
+  [key: string]: unknown;
+}
+
 export interface IPaymentEvent {
   orderReference: string;
   transactionStatus: string;
   authCode: string;
   reasonCode: string | number | null;
-  payload: any;
+  payload: IWayforPayCallbackPayload;
 }
 
 const schema = new Schema<IPaymentEvent>(


### PR DESCRIPTION
## Description

Implements server-to-server WayForPay payment callback in Next.js with HMAC-MD5 signature verification, payload validation, and idempotent processing.

### Key Features
- JSON-only POST callback endpoint (`415` for invalid content-type)
- HMAC-MD5 signature validation using `MERCHANT_SECRET_KEY`
- MongoDB transaction with `PaymentEvent` deduplication (unique index)
- Donation order validation (amount & currency)
- Status mapping: `Approved → Paid`, `Declined → Declined`, `Expired → Expired`, `InProcessing → InProcessing`
- Automatic order update with `paidAt`, `providerTxnId`, and failure reasons
- Signed acknowledgement response to WayForPay

### Models
- `DonationOrder` – stores order state and payment metadata
- `PaymentEvent` – stores raw callbacks and ensures idempotency

## Type of change

- [X] New feature



## Checklist

- [ ] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [X] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [X] Branch is up to date with the target branch
- [X] Linked issue/task included
- [X] Task moved to the review column on the board

---
