### PR TITLE
fix: adjust font styles and positioning in TableNoResultsFound component

### DIFF
--- a/app/shared/components/design-system/all-components/theme/Theme.ts
+++ b/app/shared/components/design-system/all-components/theme/Theme.ts
@@ -229,10 +229,10 @@ export const theme = createTheme({
     },
     h4: {
       fontFamily: oswald.style.fontFamily,
-      fontSize: '28px',
-      fontWeight: 700,
-      lineHeight: 'normal',
-      letterSpacing: '0px'
+      fontWeight: 600,
+      lineHeight: '120%',
+      marginRight: '5px',
+      letterSpacing: '0%'
     },
     h5: {
       fontSize: '24px',

--- a/app/shared/components/tables/CompositionTable/no-results-found/TableNoResultsFound.styles.ts
+++ b/app/shared/components/tables/CompositionTable/no-results-found/TableNoResultsFound.styles.ts
@@ -1,3 +1,5 @@
+import { colors } from '@mui/material';
+
 const styles = {
   container: {
     display: 'flex',
@@ -13,15 +15,26 @@ const styles = {
   },
   image: {
     position: 'relative',
-    width: { xs: 169, md: 248 },
-    height: { xs: 112, md: 165 },
-    mt: '30px'
+    width: { xs: 171, sm: 171, md: 248, lg: 248, xl: 248 },
+    height: { xs: 114, sm: 114, md: 180, lg: 180, xl: 180 },
+    mt: { md: '55px', lg: '80px', xl: '70px' },
+    mr: { xl: '20px' },
+    ml: { sm: '10px', md: '75px', lg: '140px', xl: '0px' }
   },
   description: {
     mt: 2,
     width: { xs: 272, sm: 350, md: 460 },
     height: { xs: 72, sm: 48 },
-    fontSize: '18px'
+    ml: { sm: '10px', md: '90px', lg: '140px', xl: '0px' },
+    lineHeight: '150%',
+    color: colors.brown[800],
+    letterSpacing: '0%',
+    fontWeight: 500,
+    fontSize: '16px'
+  },
+  h4: {
+    fontSize: { xs: 40, sm: 40, md: 48, lg: 48, xl: 48 },
+    ml: { sm: '40px', md: '90px', lg: '160px', xl: '0px' }
   }
 };
 

--- a/app/shared/components/tables/CompositionTable/no-results-found/TableNoResultsFound.tsx
+++ b/app/shared/components/tables/CompositionTable/no-results-found/TableNoResultsFound.tsx
@@ -13,7 +13,7 @@ export default function TableNoResultsFound() {
           <Box sx={styles.image} data-testid="TableNoResultsFound-image">
             <Image src="/images/cat-no-results-found.svg" alt="No results found" fill />
           </Box>
-          <Typography variant="h4" fontWeight="bold" data-testid="TableNoResultsFound-title">
+          <Typography variant="h4" sx={styles.h4} fontWeight="bold" data-testid="TableNoResultsFound-title">
             {t('title')}
           </Typography>
           <Typography


### PR DESCRIPTION
## Description

Component TableNoResultsFound  are now responsive to every screen size

## Type of change

- [x] Bug fix


## How to test

1.Open the Artistry page.
2.In the search bar, type any query that does not match existing compositions.
3.Observe the displayed “empty state” section.

Fonts and positioning of the “Ой! ПоРожньо” block match the Figma design.
The layout and typography of the “No results” message, description, and illustration are consistent with design specifications.

## Video / Screenshots

1920:
<img width="615" height="358" alt="image" src="https://github.com/user-attachments/assets/c03cc981-56fe-45e4-b599-174c21855a33" />

1280:
<img width="591" height="355" alt="image" src="https://github.com/user-attachments/assets/f9711b16-8324-4ac9-a63b-9055ab078473" />

1024:
<img width="519" height="355" alt="image" src="https://github.com/user-attachments/assets/a584c807-d8df-4d6c-a22a-efd10bd6ec88" />


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
