### PR TITLE
fix(ContactForm): update privacy policy link to correct URL

### DIFF
--- a/app/shared/components/forms/contact-form/ContactForm.test.tsx
+++ b/app/shared/components/forms/contact-form/ContactForm.test.tsx
@@ -77,7 +77,7 @@ describe('ContactForm', () => {
     if (!link) {
       throw new Error('Expected a privacy policy link to be present.');
     }
-    expect(link).toHaveAttribute('href', '#');
+    expect(link).toHaveAttribute('href', '/privacy-policy');
   });
 
   it('should render a submit button', () => {

--- a/app/shared/components/forms/contact-form/ContactForm.tsx
+++ b/app/shared/components/forms/contact-form/ContactForm.tsx
@@ -119,7 +119,7 @@ function ContactForm({ onSubmit }: Readonly<ContactFormProps>) {
             label={
               <Box>
                 <Typography variant="customItalic14" sx={styles.confidentialPolicyText}>
-                  {t('policyText')} <Link href="#">{t('policyLink')}</Link>
+                  {t('policyText')} <Link href="/privacy-policy">{t('policyLink')}</Link>
                 </Typography>
                 {errors.policy && (
                   <FormHelperText sx={styles.checkboxError}>


### PR DESCRIPTION
## Description

On the Contacts page, a link now routs to the "Політика конфіденційності" (`/privacy-policy`) page.

## Type of change

- [x] Bug fix

## How to test

1.Open the Contacts page.
2.Scroll to the contact form section.
3.Locate the text containing the link “Політика конфіденційності”.
4.Click the link - privacy-policy page will open

## Video / Screenshots

<img width="1902" height="962" alt="image" src="https://github.com/user-attachments/assets/2282b408-0408-4f5a-8cfc-a0029aae0f47" />

<img width="1763" height="794" alt="image" src="https://github.com/user-attachments/assets/5c7f6f99-e73a-4d13-95bb-66d4305b2898" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
