### PR TITLE
fix(tests): add scrollDirection prop to render methods in multiple te…

### DIFF
--- a/app/shared/components/Header/RightActionsPanel/RightActionsPanel.test.tsx
+++ b/app/shared/components/Header/RightActionsPanel/RightActionsPanel.test.tsx
@@ -25,7 +25,7 @@ const mockedSupportButtonData = {
 
 describe('RightActionsPanel', () => {
   it('should render all components with correct data', () => {
-    render(<RightActionsPanel supportButtonData={mockedSupportButtonData} />);
+    render(<RightActionsPanel supportButtonData={mockedSupportButtonData} scrollDirection="up" />);
 
     const player = screen.getByTestId('audio-player');
     const switcher = screen.getByTestId('language-switcher');

--- a/app/shared/components/blocks/FoundationFounders/FoundationTeam/FoundationTeam.test.tsx
+++ b/app/shared/components/blocks/FoundationFounders/FoundationTeam/FoundationTeam.test.tsx
@@ -8,7 +8,8 @@ const teamData = [
     description: 'Спадкоємиця композитора',
     photo: {
       src: '/images/foundation/team/tetyana-gomon.jpg',
-      alt: 'Tetyana Homon'
+      alt: 'Tetyana Homon',
+      generatedSrc: 'test-image'
     }
   },
   {
@@ -16,7 +17,8 @@ const teamData = [
     description: 'Дослідник творчості Лятошинського',
     photo: {
       src: '/images/foundation/team/ivan-kovalenko.jpg',
-      alt: 'Tetyana Homon'
+      alt: 'Tetyana Homon',
+      generatedSrc: 'test-image'
     }
   },
   {
@@ -24,7 +26,8 @@ const teamData = [
     description: 'Куратор проектів фонду',
     photo: {
       src: '/images/foundation/team/maria-petryvna.jpg',
-      alt: 'Tetyana Homon'
+      alt: 'Tetyana Homon',
+      generatedSrc: 'test-image'
     }
   }
 ];

--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.test.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.test.tsx
@@ -67,7 +67,7 @@ describe('DesktopNav', () => {
   });
 
   it('should render all top-level navigation labels', () => {
-    render(<DesktopNav navLabels={navLabels} specialNav={specialNav} />);
+    render(<DesktopNav navLabels={navLabels} specialNav={specialNav} scrollDirection="up" />);
 
     expect(screen.getByText('Фундація')).toBeInTheDocument();
     expect(screen.getByText('Архів')).toBeInTheDocument();
@@ -76,7 +76,7 @@ describe('DesktopNav', () => {
   });
 
   it('should open dropdown when clicking on a group with multiple links', () => {
-    render(<DesktopNav navLabels={navLabels} specialNav={specialNav} />);
+    render(<DesktopNav navLabels={navLabels} specialNav={specialNav} scrollDirection="up" />);
 
     fireEvent.click(screen.getByText('Фундація'));
 
@@ -86,7 +86,7 @@ describe('DesktopNav', () => {
   });
 
   it('should close dropdown when clicking on a dropdown item', async () => {
-    render(<DesktopNav navLabels={navLabels} specialNav={specialNav} />);
+    render(<DesktopNav navLabels={navLabels} specialNav={specialNav} scrollDirection="up" />);
     fireEvent.click(screen.getByText('Фундація'));
 
     fireEvent.click(screen.getByText('Про Фундацію'));
@@ -97,7 +97,7 @@ describe('DesktopNav', () => {
   });
 
   it('should assign correct href to single-link navigation items', () => {
-    render(<DesktopNav navLabels={navLabels} specialNav={specialNav} />);
+    render(<DesktopNav navLabels={navLabels} specialNav={specialNav} scrollDirection="up" />);
 
     const archiveLink = screen.getByText('Архів').closest('a');
     const collabLink = screen.getByText('Співпраця').closest('a');
@@ -107,7 +107,7 @@ describe('DesktopNav', () => {
   });
 
   it('dropdown items have correct hrefs', () => {
-    render(<DesktopNav navLabels={navLabels} specialNav={specialNav} />);
+    render(<DesktopNav navLabels={navLabels} specialNav={specialNav} scrollDirection="up" />);
     fireEvent.click(screen.getByText('Фундація'));
 
     expect(screen.getByText('Новини').closest('a')).toHaveAttribute('href', '/news');
@@ -115,7 +115,7 @@ describe('DesktopNav', () => {
   });
 
   it('should not show special navigation if specialNav is null', () => {
-    render(<DesktopNav navLabels={navLabels} specialNav={null} />);
+    render(<DesktopNav navLabels={navLabels} specialNav={null} scrollDirection="up" />);
 
     expect(screen.queryByText('Спеціальна')).not.toBeInTheDocument();
   });


### PR DESCRIPTION

## Description

Updated all affected test files to include the required `scrollDirection` prop.

Used a default value (`'up'`) to keep the tests simple and consistent.

Ensured all tests properly render components without breaking TypeScript contracts.

All TypeScript errors related to `scrollDirection` are resolved.

Test suite compiles and runs successfully.

## Type of change

- [x] Tests fix
- [x] Refactoring / Tech debt

## How to test

Launch as
`npx tsc -p tsconfig.json --noEmit`

## Video / Screenshots

Before:
<img width="961" height="188" alt="image" src="https://github.com/user-attachments/assets/208b634b-dbbe-4764-b710-d73b0dbf9602" />

After:
<img width="360" height="64" alt="image" src="https://github.com/user-attachments/assets/c1520c45-246c-4c98-a811-f1e84d399545" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
