### PR TITLE
chore: add data-testid attributes to music table components

### DIFF
--- a/app/shared/components/design-system/all-components/pagination/Pagination.tsx
+++ b/app/shared/components/design-system/all-components/pagination/Pagination.tsx
@@ -32,6 +32,7 @@ const Pagination: React.FC<PaginationProps> = ({ visiblePages, renderItem, page,
           renderItem(item)
         ) : (
           <PaginationItem
+            data-testid={`Pagination-${item.type}-${item.page}`}
             {...item}
             selected={page != null && isSelectedPage(item, page, visiblePages)}
             sx={paginationStyles.item[item.type as PaginationItemType] ?? {}}

--- a/app/shared/components/enhanced-table/EnhancedTable.tsx
+++ b/app/shared/components/enhanced-table/EnhancedTable.tsx
@@ -209,7 +209,13 @@ export const EnhancedTable = <T extends RowData>({
 
           <Box sx={styles.paginationWrapper} data-testid="EnhancedTable-paginationWrapper">
             {hasMore && (
-              <Button variant="contained" size="large" onClick={handleLoadMore} sx={styles.loadMoreButton}>
+              <Button
+                data-testid="Pagination-loadMore"
+                variant="contained"
+                size="large"
+                onClick={handleLoadMore}
+                sx={styles.loadMoreButton}
+              >
                 {t('viewMore')}
               </Button>
             )}

--- a/app/shared/components/enhanced-table/collapsible-row/CollapsibleDataRow.tsx
+++ b/app/shared/components/enhanced-table/collapsible-row/CollapsibleDataRow.tsx
@@ -13,9 +13,13 @@ interface CollapsibleDataRowProps<T extends RowData> {
 
 function CollapsibleDataRowComponent<T extends RowData>({ row, collapsed }: Readonly<CollapsibleDataRowProps<T>>) {
   return (
-    <TableRow>
+    <TableRow data-testid={collapsed ? 'CollapsibleDataRow-expanded' : 'CollapsibleDataRow-expanded-empty'}>
       {row.getVisibleCells().map((cell) => (
-        <TableCell key={cell.id} sx={styles.collapsedCell(collapsed)}>
+        <TableCell
+          key={cell.id}
+          sx={styles.collapsedCell(collapsed)}
+          data-testid={`CollapsibleDataRow-expanded-${cell.id.split('_').at(1)}`}
+        >
           <Collapse in={collapsed} timeout={300} unmountOnExit>
             <Box>{flexRender(cell.column.columnDef.cell, cell.getContext())}</Box>
           </Collapse>

--- a/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.tsx
+++ b/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.tsx
@@ -49,10 +49,9 @@ export const CollapsibleRow = <T extends RowData>({
 
   const factoryIndexes = useMemo(() => getFactoryIndexes(columns), [columns]);
   let coveredUntil = -1;
-
   return (
     <>
-      <TableRow sx={styles.row(collapsed)}>
+      <TableRow sx={styles.row(collapsed)} data-testid="CollapsibleRow-mainOpus">
         {columns.map((col, idx) => {
           if (idx <= coveredUntil) return null;
 
@@ -71,6 +70,7 @@ export const CollapsibleRow = <T extends RowData>({
                     variant={IconButtonColorVariant.Secondary}
                     disableRipple
                     sx={{ bgcolor: 'none' }}
+                    data-testid="CollapsibleRow-mainOpus-toggle"
                   >
                     <Svg
                       Component={collapsed ? chevronDown : chevronRight}
@@ -97,12 +97,13 @@ export const CollapsibleRow = <T extends RowData>({
             return (
               <TableCell key={cellKey} colSpan={colSpan} sx={styles.cell}>
                 <Box sx={styles.cellInner}>
-                  <Box sx={{ width: '100%' }}>{normalized}</Box>
+                  <Box sx={{ width: '100%' }} data-testid={`CollapsibleRow-mainOpus-${cellKey}`}>
+                    {normalized}
+                  </Box>
                 </Box>
               </TableCell>
             );
           }
-
           return (
             <TableCell key={cellKey} sx={styles.cell}>
               <Box sx={styles.cellInner} />

--- a/app/shared/components/enhanced-table/enhanced-table-header/EnhancedTableHeader.tsx
+++ b/app/shared/components/enhanced-table/enhanced-table-header/EnhancedTableHeader.tsx
@@ -26,7 +26,7 @@ export default function EnhancedTableHeader<T>({ table, columnWidths = {} }: Rea
                 cursor: header.column.getCanSort() ? 'pointer' : 'default'
               }}
             >
-              <Box display="flex" alignItems="center" gap="2px">
+              <Box display="flex" alignItems="center" gap="2px" data-testid={`EnhancedTableHeader-${header.id}`}>
                 {flexRender(header.column.columnDef.header, header.getContext())}
                 {header.column.getCanSort() && (
                   <>

--- a/app/shared/components/enhanced-table/enhanced-table-row/EnhancedTableRow.tsx
+++ b/app/shared/components/enhanced-table/enhanced-table-row/EnhancedTableRow.tsx
@@ -16,9 +16,13 @@ export default function EnhancedTableRow<T extends { id: string }>({
   if (!row) return null;
 
   return (
-    <TableRow>
+    <TableRow data-testid="EnhancedTableRow-mainNoOpus">
       {row.getVisibleCells().map((cell) => (
-        <TableCell key={cell.id} sx={styles.cell}>
+        <TableCell
+          key={cell.id}
+          sx={styles.cell}
+          data-testid={`EnhancedTableRow-mainNoOpus-${cell.id.split('_').at(1)}`}
+        >
           {flexRender(cell.column.columnDef.cell, cell.getContext())}
         </TableCell>
       ))}


### PR DESCRIPTION
## Description
<!-- Briefly describe the purpose of this PR and what was changed -->
This PR adds data-testid attributes to the Music Table components located on the Artistry page to improve the reliability and stability of automated testing.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [x] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. run the project.
2. verify Headers: Inspect the table header and confirm the presence of data-testid starting with `EnhancedTableHeader`.
3. verify Main Rows (With Opus): Locate a row with an Opus number and confirm the tr has `data-testid="CollapsibleRow-mainOpus"` and the toggle button has `data-testid="CollapsibleRow-mainOpus-toggle"`.
4. verify Expanded Content: Click the toggle button to expand a row. Inspect the new row and confirm it has `data-testid="CollapsibleDataRow-expanded"`.
5. verify Standard Rows (No Opus): Locate a row without an Opus number and confirm the tr has `data-testid="EnhancedTableRow-mainNoOpus"`.
6. verify Pagination: Scroll to the bottom of the table and confirm the navigation elements (Previous, Next, Page numbers) contain data-testid attributes starting with `Pagination-`.

## Video / Screenshots

### Table header: 
<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->
<img width="841" height="455" alt="1" src="https://github.com/user-attachments/assets/18cab876-8957-406a-91a6-e5da6176570c" />

### Main Rows — WITH Opus (can be collapse):
<img width="1081" height="472" alt="2" src="https://github.com/user-attachments/assets/7c42806f-55ca-41cf-b9b7-ac6b0495e41b" />

###  Expanded Rows (content after clicking toggle):
<img width="1105" height="166" alt="3" src="https://github.com/user-attachments/assets/04da80fe-2292-422b-b2d3-59a4a68c008d" />

### Main Rows — WITHOUT Opus (regular rows):
<img width="1132" height="160" alt="4" src="https://github.com/user-attachments/assets/d8d40fd0-2900-4efa-acb6-88ec4108faf5" />

### Pagination:
<img width="1180" height="452" alt="5" src="https://github.com/user-attachments/assets/d4554666-b8f7-4fef-9cf2-227d32602764" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [x] Task moved to the review column on the board

---
