### PR TITLE
fix: mobile layout and icon alignment in bullettextwithlinks component

### DIFF
--- a/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.styles.ts
+++ b/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.styles.ts
@@ -17,12 +17,14 @@ export const styles = {
     gridArea: 'buttons',
     display: 'flex',
     flexDirection: 'column',
-    gap: 2,
+    gap: { xs: '8px', sm: '16px' },
     justifySelf: 'end',
     gridColumn: { xs: '1/ -1', sm: '1/4', md: '1 / 6' },
     justifyContent: 'space-between',
     width: '100%',
-    height: '100%'
+    height: '100%',
+    marginBottom: { xs: '10px', sm: 0 },
+    marginTop: { xs: '4px', sm: 0 }
   },
 
   button: {
@@ -59,6 +61,6 @@ export const styles = {
     display: 'flex',
     flexWrap: 'wrap',
     justifyContent: 'flex-start',
-    gap: 2
+    gap: { xs: '8px', md: '16px' }
   }
 };

--- a/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.tsx
+++ b/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.tsx
@@ -76,17 +76,25 @@ export default function BulletTextWithLinks({
       </Box>
       <Box sx={styles.buttonsBox} data-testid="BulletTextWithLinks-buttonsBox">
         {buttons.map((button) => (
-          <Button key={button.shortText} link={button.link} externalLink={true} variant="outlined" size="medium">
+          <Button
+            key={button.shortText}
+            link={button.link}
+            externalLink={true}
+            variant="outlined"
+            size="medium"
+            startIcon={
+              <Svg
+                Component={FacebookIcon}
+                fill="none"
+                alt="icon"
+                color="#000"
+                width="24px"
+                height="24px"
+                sx={styles.icon}
+              />
+            }
+          >
             {isMobile ? button.shortText : button.fullText}
-            <Svg
-              Component={FacebookIcon}
-              fill="none"
-              alt="icon"
-              color="#000"
-              width="20px"
-              height="20px"
-              sx={styles.icon}
-            />
           </Button>
         ))}
       </Box>


### PR DESCRIPTION
## Description

This PR fixes layout and icon alignment issues in the `BulletTextWithLinks` component on mobile devices.

The update includes:
- Corrected mobile positioning of the link buttons.
- Proper visual alignment of the Facebook icon inside outlined buttons.
- Updated spacing and structure according to the Figma mobile design.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the /war-in-ukraine page.
2. Switch to mobile viewport.
3. Scroll to the BulletTextWithLinks section.
4. Verify:
   - Buttons match the Figma mobile layout.
   - Facebook icon is properly centered.
   - Spacing between elements matches design.
5. Compare with the Figma mobile reference.

## Video / Screenshots


https://github.com/user-attachments/assets/200f6f6e-472c-43a4-9ecc-f79594a1d0c0


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
