### PR TITLE
fix: correct broken chevron icon and update color + global icon cleanup

### DIFF
--- a/app/shared/components/design-system/all-components/arrow-carousel/ArrowCarousel.styles.ts
+++ b/app/shared/components/design-system/all-components/arrow-carousel/ArrowCarousel.styles.ts
@@ -10,6 +10,9 @@ export const styles = {
     },
     '&:active': {
       backgroundColor: 'rgba(25, 13, 3, 1)'
+    },
+    '& svg': {
+      viewBox: '0 0 15 27'
     }
   }
 };

--- a/app/shared/components/design-system/all-components/arrow-carousel/ArrowCarousel.test.tsx
+++ b/app/shared/components/design-system/all-components/arrow-carousel/ArrowCarousel.test.tsx
@@ -4,8 +4,6 @@ import React from 'react';
 
 import ArrowCarousel from './ArrowCarousel';
 
-jest.mock('next/image');
-
 jest.mock('~/ds-components/icon-button/IconButton', () => ({
   IconButton: ({
     children,
@@ -25,6 +23,16 @@ jest.mock('~/ds-components/icon-button/IconButton', () => ({
   )
 }));
 
+jest.mock('~/public/icons/chevron-left.svg', () => ({
+  __esModule: true,
+  default: () => <svg data-testid="mock-left-svg" />
+}));
+
+jest.mock('~/public/icons/chevron-right.svg', () => ({
+  __esModule: true,
+  default: () => <svg data-testid="mock-right-svg" />
+}));
+
 describe('ArrowCarousel', () => {
   const mockOnClick = jest.fn();
 
@@ -36,28 +44,29 @@ describe('ArrowCarousel', () => {
     render(<ArrowCarousel direction="left" onClick={mockOnClick} />);
 
     const button = screen.getByRole('button', { name: 'Previous slide' });
-    const image = screen.getByAltText('Previous');
+    const svgWrapper = screen.getByLabelText('Previous');
 
     expect(button).toBeInTheDocument();
-    expect(image).toBeInTheDocument();
-    expect(image).toHaveAttribute('src', '/icons/chevron-left.svg');
+    expect(svgWrapper).toBeInTheDocument();
+
+    expect(svgWrapper.querySelector('svg')).toBeInTheDocument();
   });
 
   it('should render right arrow correctly', () => {
     render(<ArrowCarousel direction="right" onClick={mockOnClick} />);
 
     const button = screen.getByRole('button', { name: 'Next slide' });
-    const image = screen.getByAltText('Next');
+    const svgWrapper = screen.getByLabelText('Next');
 
     expect(button).toBeInTheDocument();
-    expect(image).toBeInTheDocument();
-    expect(image).toHaveAttribute('src', '/icons/chevron-right.svg');
+    expect(svgWrapper).toBeInTheDocument();
+    expect(svgWrapper.querySelector('svg')).toBeInTheDocument();
   });
 
   it('should call onClick when button is clicked', () => {
     render(<ArrowCarousel direction="left" onClick={mockOnClick} />);
 
-    const button = screen.getByRole('button');
+    const button = screen.getByRole('button', { name: 'Previous slide' });
     fireEvent.click(button);
 
     expect(mockOnClick).toHaveBeenCalledTimes(1);
@@ -66,7 +75,8 @@ describe('ArrowCarousel', () => {
   it('should render disabled state correctly', () => {
     render(<ArrowCarousel direction="left" onClick={mockOnClick} disabled={true} />);
 
-    const button = screen.getByRole('button');
+    const button = screen.getByRole('button', { name: 'Previous slide' });
+
     expect(button).toBeDisabled();
   });
 });

--- a/app/shared/components/design-system/all-components/arrow-carousel/ArrowCarousel.tsx
+++ b/app/shared/components/design-system/all-components/arrow-carousel/ArrowCarousel.tsx
@@ -1,11 +1,15 @@
 'use client';
+
 import { Box } from '@mui/material';
-import Image from 'next/image';
 import React from 'react';
 
 import { IconButton } from '~/ds-components/icon-button/IconButton';
 
 import { styles } from './ArrowCarousel.styles';
+
+import ChevronLeft from '~/public/icons/chevron-left.svg';
+import ChevronRight from '~/public/icons/chevron-right.svg';
+import { Svg } from '~/shared/components/colored-svg/ColoredSvg';
 
 interface ArrowCarouselProps {
   direction: 'left' | 'right';
@@ -14,26 +18,27 @@ interface ArrowCarouselProps {
 }
 
 const ArrowCarousel: React.FC<ArrowCarouselProps> = ({ direction, onClick, disabled = false, ...props }) => {
-  const arrowLeft = '/icons/chevron-left.svg';
-  const arrowRight = '/icons/chevron-right.svg';
-  const Icon = (
-    <Image
-      src={direction === 'left' ? arrowLeft : arrowRight}
-      alt={direction === 'left' ? 'Previous' : 'Next'}
-      width={16}
-      height={32}
-    />
-  );
+  const Icon = direction === 'left' ? ChevronLeft : ChevronRight;
+
   return (
     <Box>
       <IconButton
         onClick={onClick}
         aria-label={`${direction === 'left' ? 'Previous' : 'Next'} slide`}
         disabled={disabled}
-        sx={{ ...styles.iconButton, ...(direction === 'left' ? { pr: '12px' } : { pl: '12px' }) }}
+        sx={{
+          ...styles.iconButton,
+          ...(direction === 'left' ? { pr: '12px' } : { pl: '12px' })
+        }}
         {...props}
       >
-        {Icon}
+        <Svg
+          Component={Icon}
+          alt={direction === 'left' ? 'Previous' : 'Next'}
+          stroke="rgba(252, 252, 252, 1)"
+          width="48px"
+          height="48px"
+        />
       </IconButton>
     </Box>
   );

--- a/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.styles.ts
+++ b/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.styles.ts
@@ -11,7 +11,7 @@ export const collapsibleRowStyles = {
     py: collapsed ? 'auto' : 0,
     overflow: 'hidden',
     transition: 'height 400ms ease',
-    backgroundColor: collapsed ? mainHexPallete.blue[50] : 'transparent'
+    backgroundColor: collapsed ? mainHexPallete.blue[75] : 'transparent'
   }),
 
   cell: {
@@ -20,7 +20,6 @@ export const collapsibleRowStyles = {
     borderLeft: 'none',
     borderRight: 'none',
     borderTop: 'none',
-    backgroundColor: mainHexPallete.blue[75],
     borderBottom: `2px solid ${borderWithOpacity}`,
     '& .MuiTableCell-root': {
       borderBottom: 'none',

--- a/public/icons/chevron-left.svg
+++ b/public/icons/chevron-left.svg
@@ -1,3 +1,13 @@
-<svg width="15" height="27" viewBox="0 0 15 27" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M13.25 25.25L1.25 13.25L13.25 1.25" stroke="#FCFCFC" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M15 18L9 12L15 6"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
 </svg>

--- a/public/icons/chevron-right.svg
+++ b/public/icons/chevron-right.svg
@@ -1,3 +1,13 @@
-<svg width="15" height="27" viewBox="0 0 15 27" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1.25 25.25L13.25 13.25L1.25 1.25" stroke="#FCFCFC" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M9 18L15 12L9 6"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
 </svg>


### PR DESCRIPTION
## Description

This PR fixes a visual inconsistency with chevron icons used in the Opus section and across the project.
The original issue was a distorted, incorrect-looking icon in the Opus carousel.
To resolve it, I refactored the icon implementation:

- Replaced hardcoded SVGs with clean, scalable chevrons (24×24, currentColor)
- Updated the ArrowCarousel component to use the new <Svg /> renderer
- Fixed icon rendering issues in the Opus view
- Corrected the Opus color to match the design system

## Type of change

- [ ] New feature
- [x] Refactoring / Tech debt
- [x] Bug fix (tests)
- [ ] Documentation update
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. See carousel and verify both arrows render with correct proportions
2. See opus in the table and confirm icon looks and works good, the color of the opus background matches the design.

## Additional

<img width="1896" height="327" alt="image" src="https://github.com/user-attachments/assets/9b018f74-15e5-4af4-96a4-9f2249b8f2c9" />