### PR TITLE
fix(archive-case-details): make contentGrid grid to scope sticky pdf button

### DIFF
--- a/app/shared/components/blocks/archive-case-details/ArchiveCaseDetails.styles.ts
+++ b/app/shared/components/blocks/archive-case-details/ArchiveCaseDetails.styles.ts
@@ -12,15 +12,15 @@ export const styles: Record<string, SxProps<Theme>> = {
     gridColumn: '1 / -1',
     mt: {
       xs: '32px',
-      md: '88px'
+      sm: '88px'
     },
     mb: {
       xs: '96px',
-      md: '104px'
+      sm: '104px'
     },
     rowGap: {
       xs: '16px',
-      md: '24px'
+      sm: '24px'
     }
   },
 
@@ -37,15 +37,16 @@ export const styles: Record<string, SxProps<Theme>> = {
     },
     textTransform: 'uppercase',
     mb: {
-      sm: '8px',
+      xs: '0',
       md: '32px'
     },
     gridColumn: '1 / -1'
   },
 
   contentGrid: {
+    display: 'grid',
     gridColumn: '1 / -1',
-    display: 'contents'
+    gridTemplateColumns: 'subgrid'
   },
 
   pdfButtonWrapper: {
@@ -55,17 +56,13 @@ export const styles: Record<string, SxProps<Theme>> = {
       md: '2 / 4',
       lg: '2 / 5'
     },
-    gridRow: '4',
+    gridRow: '2',
     position: 'sticky',
     top: {
       xs: '24px',
       sm: '48px'
     },
-    mt: {
-      xs: '8px',
-      md: 0
-    },
-    mb: '40px',
+    mt: '24px',
     alignSelf: 'flex-start',
     zIndex: 1
   }

--- a/app/shared/components/blocks/archive-case-details/back-link/BackLink.styles.ts
+++ b/app/shared/components/blocks/archive-case-details/back-link/BackLink.styles.ts
@@ -11,14 +11,14 @@ export const styles: Record<string, SxProps<Theme>> = {
       sm: '1 / 3',
       md: '1 / 4'
     },
-    marginBottom: {
+    mb: {
       xs: '8px',
-      md: '0px'
+      sm: '0px'
     }
   },
 
   link: {
-    padding: '0px',
+    p: '0px',
     gap: '0px',
     transition: 'border-bottom 0.3s ease-in-out',
     borderBottom: '1px solid transparent',

--- a/app/shared/components/blocks/archive-case-details/documents/Documents.styles.ts
+++ b/app/shared/components/blocks/archive-case-details/documents/Documents.styles.ts
@@ -11,13 +11,15 @@ export const styles: Record<string, SxProps<Theme>> = {
     },
     gridRow: {
       xs: 'auto',
-      sm: '3 / 6'
+      sm: '1 / 4'
     }
   },
 
   list: {
-    margin: 0,
-    padding: 0,
+    mt: {
+      xs: '40px',
+      sm: '0'
+    },
     listStyle: 'none',
     counterReset: 'docs-counter',
     display: 'flex',

--- a/app/shared/components/blocks/archive-case-details/meta/Meta.styles.ts
+++ b/app/shared/components/blocks/archive-case-details/meta/Meta.styles.ts
@@ -10,11 +10,11 @@ export const styles: Record<string, SxProps<Theme>> = {
       md: '2 / 4',
       lg: '2 / 5'
     },
-    gridRow: '3',
+    gridRow: '1',
     display: 'flex',
     flexDirection: 'column',
     '& > * + *': {
-      marginTop: {
+      mt: {
         xs: '24px',
         md: '32px'
       }

--- a/app/shared/components/blocks/archive-case-details/navigation/Navigation.styles.ts
+++ b/app/shared/components/blocks/archive-case-details/navigation/Navigation.styles.ts
@@ -5,7 +5,7 @@ import { mainHexPallete } from '~/ds-components/theme/colors';
 export const styles: Record<string, SxProps<Theme>> = {
   root: {
     gridColumn: '1 / -1',
-    marginTop: {
+    mt: {
       xs: '32px',
       md: '40px'
     },
@@ -25,18 +25,12 @@ export const styles: Record<string, SxProps<Theme>> = {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'flex-end',
-    textAlign: {
-      xs: 'left',
-      sm: 'right'
-    },
+    textAlign: 'right',
     marginLeft: 'auto'
   },
 
   navButton: {
-    minWidth: {
-      xs: '40px',
-      sm: '100%'
-    },
+    minWidth: '40px',
     justifyContent: {
       xs: 'center',
       sm: 'space-between'
@@ -81,8 +75,8 @@ export const styles: Record<string, SxProps<Theme>> = {
   },
 
   navMetaLeft: {
-    marginTop: '8px',
-    marginLeft: {
+    mt: '8px',
+    ml: {
       xs: '0px',
       sm: '46px'
     },
@@ -90,8 +84,8 @@ export const styles: Record<string, SxProps<Theme>> = {
   },
 
   navMetaRight: {
-    marginTop: '8px',
-    marginRight: {
+    mt: '8px',
+    mr: {
       xs: '0px',
       sm: '46px'
     },


### PR DESCRIPTION
## Description

Make contentGrid a real grid (instead of display: contents) so the sticky "View PDF" button is scoped to the docs column and doesn't overlap navigation. Align grid rows for Meta / Documents / PDF button and update margins/paddings in related styles to use mt / ml / mr to match the latest design.

## Type of change

- [x] Bug fix
- [x] Refactoring / Tech debt

## How to test

1. Open any archive case details page.
2. Scroll the documents column:
- the "View PDF" button should stick while docs are visible;
- it should stop sticking and not overlap the bottom navigation.
3. Check layout and spacing: Back link, Meta, Documents, sticky button and Navigation should match the design and align correctly.

## Video / Screenshots

<img width="672" height="159" alt="image" src="https://github.com/user-attachments/assets/d01595cb-7848-42d1-96d2-cd5e72751126" />

<img width="350" height="148" alt="image" src="https://github.com/user-attachments/assets/4b20ed6e-6c69-407f-870c-903858d6b75d" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
