### PR TITLE
fix(donation-form): highlight invalid donation amount in input

### DIFF
--- a/app/shared/components/forms/donation-form/DonationForm.styles.ts
+++ b/app/shared/components/forms/donation-form/DonationForm.styles.ts
@@ -73,7 +73,11 @@ export const style = {
     }
   },
   moneyInputError: {
-    color: rgbaTextFieldColors.errorBorderBottom
+    color: rgbaTextFieldColors.errorBorderBottom,
+    '& input::placeholder': {
+      color: rgbaTextFieldColors.errorBorderBottom,
+      opacity: 1
+    }
   },
   currencyInput: {
     minWidth: '90px',

--- a/app/shared/components/forms/donation-form/DonationForm.test.tsx
+++ b/app/shared/components/forms/donation-form/DonationForm.test.tsx
@@ -3,15 +3,23 @@ import React from 'react';
 
 import DonationForm from './DonationForm';
 
-jest.mock('../../design-system/all-components/button/Button', () => {
-  const MockButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({ children, ...props }) => (
-    <button {...props}>{children}</button>
-  );
+jest.mock('~/ds-components/button/Button', () => {
+  const MockButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & { fullWidth?: boolean }> = ({
+    children,
+    fullWidth: _fullWidth,
+    ...props
+  }) => <button {...props}>{children}</button>;
+
   return {
     __esModule: true,
     default: MockButton
   };
 });
+
+jest.mock('~/components/turnstileWidget/TurnstileWidget', () => ({
+  __esModule: true,
+  default: () => <div data-testid="TurnstileWidget-mock" />
+}));
 
 const mockDonate = jest.fn();
 jest.mock('~/hooks/use-donation/useDonation', () => ({
@@ -82,8 +90,10 @@ describe('DonationForm', () => {
     const input = screen.getByRole('spinbutton');
     const button = screen.getByText('Зробити внесок');
 
-    fireEvent.change(input, { target: { value: '0' } });
+    fireEvent.change(input, { target: { value: '100' } });
     fireEvent.click(button);
+
+    fireEvent.change(input, { target: { value: '0' } });
     expect(input).toHaveAttribute('aria-invalid', 'true');
 
     fireEvent.change(input, { target: { value: '100' } });

--- a/app/shared/components/forms/donation-form/DonationForm.test.tsx
+++ b/app/shared/components/forms/donation-form/DonationForm.test.tsx
@@ -86,14 +86,12 @@ describe('DonationForm', () => {
     expect(screen.getByDisplayValue('')).toBeInTheDocument();
   });
 
-  it('should remove error after entering valid value', () => {
+  it('should show error after submitting invalid amount and clear it after changing value', () => {
     const input = screen.getByRole('spinbutton');
     const button = screen.getByText('Зробити внесок');
 
-    fireEvent.change(input, { target: { value: '100' } });
-    fireEvent.click(button);
-
     fireEvent.change(input, { target: { value: '0' } });
+    fireEvent.click(button);
     expect(input).toHaveAttribute('aria-invalid', 'true');
 
     fireEvent.change(input, { target: { value: '100' } });

--- a/app/shared/components/forms/donation-form/DonationForm.tsx
+++ b/app/shared/components/forms/donation-form/DonationForm.tsx
@@ -21,6 +21,9 @@ const proposedSum: Record<Currency, number[]> = {
   GBP: [10, 20, 40]
 };
 
+const MIN_DONATION_AMOUNT = 0;
+const isValidDonationAmount = (value: number | ''): boolean => typeof value === 'number' && value > MIN_DONATION_AMOUNT;
+
 function DonationForm() {
   const t = useTranslations('donationForm');
   const lang = useLocale();
@@ -63,7 +66,7 @@ function DonationForm() {
   const handleDonateClick = (amount: number) => {
     setTouched(true);
     const currentAmount = Number(amount);
-    const isInvalid = currentAmount <= 0;
+    const isInvalid = !isValidDonationAmount(currentAmount);
     setHasError(isInvalid);
     if (isInvalid) {
       return;
@@ -102,7 +105,9 @@ function DonationForm() {
       size={isMobile ? 'small' : 'medium'}
       onClick={() => {
         setDonationSum(item);
-        if (touched) setHasError(donationSum === 0);
+        if (touched) {
+          setHasError(!isValidDonationAmount(item));
+        }
       }}
       data-testid={`DonationForm-suggestButton-${item}`}
     >
@@ -122,7 +127,7 @@ function DonationForm() {
     const val = e.target.value === '' || +e.target.value < 0 ? '' : Number(e.target.value);
     setDonationSum(val);
     if (touched) {
-      setHasError(val === '' || val === 0);
+      setHasError(!isValidDonationAmount(val));
     }
   };
 
@@ -178,6 +183,7 @@ function DonationForm() {
           variant="contained"
           size={isMobile ? 'medium' : 'large'}
           fullWidth
+          disabled={!isValidDonationAmount(donationSum)}
           onClick={() => handleDonateClick(donationSum as number)}
           data-testid="DonationForm-donateButton"
         >

--- a/app/shared/components/forms/donation-form/DonationForm.tsx
+++ b/app/shared/components/forms/donation-form/DonationForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { Box, FormControl, Input, MenuItem, Select, Typography } from '@mui/material';
 import { useLocale, useTranslations } from 'next-intl';
-import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 import PaperComponent from '~/components/paper-component/PaperComponent';
 import TurnstileWidget from '~/components/turnstileWidget/TurnstileWidget';
@@ -32,16 +32,15 @@ function DonationForm() {
   const [currency, setCurrency] = useState<Currency>('UAH');
   const [openDropdown, setOpenDropdown] = useState(false);
   const [hasError, setHasError] = useState(false);
-  const [touched, setTouched] = useState(false);
   const [showCaptcha, setShowCaptcha] = useState(false);
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null);
+  const amountInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleCurrencySwitch = (event: { target: { value: string } }) => {
     setCurrency(event.target.value as Currency);
     setDonationSum('');
     setHasError(false);
-    setTouched(false);
   };
 
   const onVerificationFailure = useCallback(() => {
@@ -64,11 +63,11 @@ function DonationForm() {
   }, []);
 
   const handleDonateClick = (amount: number) => {
-    setTouched(true);
     const currentAmount = Number(amount);
     const isInvalid = !isValidDonationAmount(currentAmount);
     setHasError(isInvalid);
     if (isInvalid) {
+      amountInputRef.current?.focus();
       return;
     }
     setSelectedAmount(currentAmount);
@@ -105,8 +104,8 @@ function DonationForm() {
       size={isMobile ? 'small' : 'medium'}
       onClick={() => {
         setDonationSum(item);
-        if (touched) {
-          setHasError(!isValidDonationAmount(item));
+        if (hasError) {
+          setHasError(false);
         }
       }}
       data-testid={`DonationForm-suggestButton-${item}`}
@@ -126,8 +125,8 @@ function DonationForm() {
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value === '' || +e.target.value < 0 ? '' : Number(e.target.value);
     setDonationSum(val);
-    if (touched) {
-      setHasError(!isValidDonationAmount(val));
+    if (hasError) {
+      setHasError(false);
     }
   };
 
@@ -147,11 +146,15 @@ function DonationForm() {
             <Input
               disableUnderline
               type="number"
+              inputRef={amountInputRef}
               inputProps={{ 'aria-invalid': hasError }}
               value={donationSum}
               onChange={handleInputChange}
               placeholder="0"
-              sx={{ ...style.moneyInput, ...(hasError && style.moneyInputError) }}
+              sx={{
+                ...style.moneyInput,
+                ...(hasError && style.moneyInputError)
+              }}
               data-testid="DonationForm-moneyInput"
             />
             <FormControl variant="standard" sx={style.currencyInput}>
@@ -183,7 +186,6 @@ function DonationForm() {
           variant="contained"
           size={isMobile ? 'medium' : 'large'}
           fullWidth
-          disabled={!isValidDonationAmount(donationSum)}
           onClick={() => handleDonateClick(donationSum as number)}
           data-testid="DonationForm-donateButton"
         >


### PR DESCRIPTION
## Description

The designer confirmed that the primary "Make a donation" button should **not** be disabled, so users are not discouraged by a greyed-out main action. Instead, the amount field itself should indicate an error - red - when the donation amount is invalid.

Add `MIN_DONATION_AMOUNT` and `isValidDonationAmount` helper to centralize donation amount validation.
Per designer, keep the "Make a donation" button always enabled and show validation via the amount field:

-   invalid submit (empty or `0`) sets `hasError` and focuses the input;
-   any change in the input or via a suggested amount button clears the error.

Update `moneyInputError` styles so both value and placeholder `0` are red in error state.
Adjust unit test to reflect the new behavior

Note: fix mocks for Button and TurnstileWidget (DonationForm.test.tsx).

## Type of change

- [x] Bug fix

## How to test

1. Open `/support-us` and scroll to **QUICK DONATION**.
2. Click **"Зробити внесок"** with empty or `0` amount -> input border + `0` become red, input is focused.
3. Change the amount (type or use a suggested button) -> red error state disappears.
4. Enter a positive amount (e.g. `100`) and click **"Зробити внесок"** -> no error, donation flow works as before.

## Video / Screenshots

https://github.com/user-attachments/assets/26faf473-cec7-425f-839f-c200cb78f50b

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [ ] Task moved to the review column on the board

---
