### PR TITLE
fix(works-table): update sorting configuration for sortableYear column

### DIFF
--- a/app/shared/components/tables/WorksTable/WorkTableSelection.tsx
+++ b/app/shared/components/tables/WorksTable/WorkTableSelection.tsx
@@ -179,7 +179,8 @@ export const WorkTableSection = ({ lang }: Readonly<Props>) => {
         accessorKey: 'sortableYear',
         header: RenderYearHeader,
         cell: (info) => renderYearCell(info.row.original.year),
-        sortingFn: 'basic'
+        sortingFn: 'basic',
+        sortDescFirst: false
       },
       {
         id: 'actions',


### PR DESCRIPTION
## Description

The “Year” sort button does follow the expected state cycle when clicked repeatedly.
the button cycles through Default -> Ascending -> Descending -> Default,

## Type of change

- [x] Bug fix

## How to test

Steps to reproduce the behavior:

Navigate to the Research and Academic Works Page (/research).
Locate the Year sorting button in the works table header.
Verify the initial state is Default (no arrows active).
Click the Year sort button once -> observe the first active state.
Click the button again -> observe the second active state.
Click a third time -> observe it returning to the default state.

## Video / Screenshots

<img width="1271" height="243" alt="image" src="https://github.com/user-attachments/assets/e79fefd4-1a4e-4e47-9649-c4e1ace97739" />

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
