### PR TITLE
feat(archive-case-details): align pdf stickiness with design

### DIFF
--- a/app/shared/components/blocks/archive-case-details/ArchiveCaseDetails.styles.ts
+++ b/app/shared/components/blocks/archive-case-details/ArchiveCaseDetails.styles.ts
@@ -57,13 +57,21 @@ export const styles: Record<string, SxProps<Theme>> = {
       lg: '2 / 5'
     },
     gridRow: '2',
-    position: 'sticky',
+
+    position: {
+      xs: 'static',
+      sm: 'sticky'
+    },
+
     top: {
-      xs: '24px',
       sm: '48px'
     },
+
     mt: '24px',
     alignSelf: 'flex-start',
-    zIndex: 1
+
+    zIndex: {
+      sm: 1
+    }
   }
 };

--- a/app/shared/components/blocks/archive-case-details/navigation/Navigation.styles.ts
+++ b/app/shared/components/blocks/archive-case-details/navigation/Navigation.styles.ts
@@ -53,6 +53,11 @@ export const styles: Record<string, SxProps<Theme>> = {
       sm: '8px 20px'
     },
 
+    '& .MuiButton-icon': {
+      marginLeft: 0,
+      marginRight: 0
+    },
+
     '&:hover': {
       background: mainHexPallete.blue[100]
     }


### PR DESCRIPTION
## Description

Make the PDF button non-sticky on mobile and sticky from the tablet breakpoint (≥768px).

> Behaviour confirmed with designer: we checked the variant with sticky button on both mobile and desktop and agreed to keep stickiness only from 768px+.

Note: also restore archive navigation button look by resetting `.MuiButton-icon` margins.

## Type of change

- [x] Bug fix

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open Archive Case page on mobile (<768px) -> PDF button scrolls with content (not sticky).
2. Open on tablet/desktop (≥768px) -> PDF button column is sticky while scrolling documents.
3. Navigation buttons look consistent with design.

## Video / Screenshots

https://github.com/user-attachments/assets/d23e95e8-ff98-43d4-b430-9b0d3ccc7ae6

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
