### PR TITLE
fix(nav): keep active section for dynamic routes

### DIFF
--- a/app/lib/utils/navPath.test.ts
+++ b/app/lib/utils/navPath.test.ts
@@ -1,0 +1,83 @@
+import { isPathWithin, normalizePath } from './navPath';
+
+type NormalizeInput = Parameters<typeof normalizePath>[0];
+
+interface NormalizeCase {
+  name: string;
+  input: NormalizeInput;
+  expected: string;
+}
+
+const normalizeCases: NormalizeCase[] = [
+  { name: 'null becomes root', input: null, expected: '/' },
+  { name: 'undefined becomes root', input: undefined, expected: '/' },
+  { name: 'empty string becomes root', input: '', expected: '/' },
+
+  { name: '"/uk" becomes root', input: '/uk', expected: '/' },
+  { name: '"/uk/" becomes root', input: '/uk/', expected: '/' },
+  { name: '"/uk/about-us" strips locale', input: '/uk/about-us', expected: '/about-us' },
+
+  { name: '"/en" becomes root', input: '/en', expected: '/' },
+  { name: '"/en/" becomes root', input: '/en/', expected: '/' },
+  { name: '"/en/news/latest" strips locale', input: '/en/news/latest', expected: '/news/latest' },
+
+  { name: '"archive" gets leading slash', input: 'archive', expected: '/archive' },
+  { name: '"archive/" trims and adds slash', input: 'archive/', expected: '/archive' },
+  { name: '"archive/fundId" becomes nested path', input: 'archive/fundId', expected: '/archive/fundId' },
+
+  { name: '"/" stays root', input: '/', expected: '/' },
+  { name: '"/archive/" trims trailing slash', input: '/archive/', expected: '/archive' },
+  { name: '"/archive/fundId/" trims trailing slash', input: '/archive/fundId/', expected: '/archive/fundId' },
+
+  { name: '"/archives" is not trimmed', input: '/archives', expected: '/archives' },
+  { name: '"/newsletter" is not trimmed', input: '/newsletter', expected: '/newsletter' }
+];
+
+describe('normalizePath', () => {
+  it.each(normalizeCases)('$name', ({ input, expected }) => {
+    expect(normalizePath(input)).toBe(expected);
+  });
+});
+
+interface WithinCase {
+  name: string;
+  root: string;
+  current: string;
+  expected: boolean;
+}
+
+const withinCases: WithinCase[] = [
+  { name: 'root vs root', root: '/', current: '/', expected: true },
+  { name: 'root vs /uk locale index', root: '/', current: '/uk', expected: true },
+  { name: 'root vs /en locale index', root: '/', current: '/en', expected: true },
+  { name: 'root does not match subpage', root: '/', current: '/about-us', expected: false },
+
+  { name: 'exact /archive', root: '/archive', current: '/archive', expected: true },
+  { name: 'exact /news', root: '/news', current: '/news', expected: true },
+
+  { name: 'archive → fund', root: '/archive', current: '/archive/fundId', expected: true },
+  { name: 'archive → fund/case', root: '/archive', current: '/archive/fundId/caseId', expected: true },
+  { name: 'news → latest', root: '/news', current: '/news/latest', expected: true },
+  { name: 'news → latest/today', root: '/news', current: '/news/latest/today', expected: true },
+
+  { name: 'archive with locale', root: '/archive', current: '/uk/archive', expected: true },
+  { name: 'archive nested with locale + slash', root: '/archive', current: '/uk/archive/fundId/', expected: true },
+  { name: 'news nested with locale + slash', root: '/news', current: '/en/news/latest/', expected: true },
+
+  { name: 'shorter current path does not match', root: '/archive/fund', current: '/archive', expected: false },
+  { name: 'same depth matches', root: '/archive/fund', current: '/archive/fund', expected: true },
+  { name: 'longer path under same root matches', root: '/archive/fund', current: '/archive/fund/case', expected: true },
+
+  { name: 'archive vs archives', root: '/archive', current: '/archives', expected: false },
+  { name: 'news vs newsletter', root: '/news', current: '/newsletter', expected: false },
+  { name: 'about-us vs about', root: '/about-us', current: '/about', expected: false },
+
+  { name: 'normalized root with locale', root: '/uk/archive', current: '/archive/fundId', expected: true },
+  { name: 'root without leading slash', root: 'archive', current: '/uk/archive/fundId', expected: true }
+];
+
+describe('isPathWithin', () => {
+  it.each(withinCases)('$name', ({ root, current, expected }) => {
+    expect(isPathWithin(root, current)).toBe(expected);
+  });
+});

--- a/app/lib/utils/navPath.ts
+++ b/app/lib/utils/navPath.ts
@@ -1,0 +1,47 @@
+const SUPPORTED_LOCALES = ['uk', 'en'] as const;
+
+export function normalizePath(path: string | null | undefined): string {
+  if (!path) return '/';
+
+  let result = path;
+
+  for (const locale of SUPPORTED_LOCALES) {
+    const prefix = `/${locale}`;
+
+    if (result === prefix) {
+      result = '/';
+      break;
+    }
+
+    if (result.startsWith(prefix + '/')) {
+      result = result.slice(prefix.length);
+      break;
+    }
+  }
+
+  if (!result.startsWith('/')) {
+    result = `/${result}`;
+  }
+
+  while (result.length > 1 && result.endsWith('/')) {
+    result = result.slice(0, -1);
+  }
+
+  return result;
+}
+
+export function isPathWithin(rootPath: string, currentPath: string): boolean {
+  const root = normalizePath(rootPath);
+  const path = normalizePath(currentPath);
+
+  if (root === '/') {
+    return path === '/';
+  }
+
+  const rootSegments = root.split('/').filter(Boolean);
+  const pathSegments = path.split('/').filter(Boolean);
+
+  if (pathSegments.length < rootSegments.length) return false;
+
+  return rootSegments.every((seg, index) => seg === pathSegments[index]);
+}

--- a/app/shared/components/design-system/all-components/navigation-accordion/NavAccordion.test.tsx
+++ b/app/shared/components/design-system/all-components/navigation-accordion/NavAccordion.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { usePathname } from 'next/navigation';
 
 import { NavAccordion } from './NavAccordion';
 
@@ -90,5 +91,14 @@ describe('NavAccordion', () => {
     render(<NavAccordion items={items} />);
     const submenuLinks = screen.getAllByTestId('mock-link-/section/page-a')[0];
     expect(submenuLinks).toHaveAttribute('href', '/section/page-a');
+  });
+
+  test('marks dropdown as active for localized nested path', () => {
+    (usePathname as jest.Mock).mockReturnValue('/uk/section/page-a');
+
+    render(<NavAccordion items={items} />);
+
+    const activeTitle = screen.getByTestId('NavAccordion-item-Section1--title--active');
+    expect(activeTitle).toHaveTextContent('Section 1');
   });
 });

--- a/app/shared/components/design-system/all-components/navigation-accordion/NavAccordion.tsx
+++ b/app/shared/components/design-system/all-components/navigation-accordion/NavAccordion.tsx
@@ -7,6 +7,8 @@ import { useCallback, useState } from 'react';
 import { styles } from './NavAccordion.styles';
 import { AccordionItem } from './NavAccordionItem';
 
+import { normalizePath } from '~/lib/utils/navPath';
+
 export interface NavLinkItem {
   label: string;
   href: string;
@@ -25,7 +27,7 @@ interface NavAccordionProps {
 }
 
 export function NavAccordion({ items, sx }: Readonly<NavAccordionProps>) {
-  const pathname = usePathname().replace(/^\/[a-z]{2}(?=\/)/, '');
+  const pathname = normalizePath(usePathname());
   const [openItems, setOpenItems] = useState<Record<string, boolean>>({});
 
   const toggle = useCallback((label: string) => {

--- a/app/shared/components/design-system/all-components/navigation-accordion/NavAccordionItem.tsx
+++ b/app/shared/components/design-system/all-components/navigation-accordion/NavAccordionItem.tsx
@@ -5,6 +5,7 @@ import { mainHexPallete } from '../theme/colors';
 import { NavDropdownItem, NavItem, NavLinkItem } from './NavAccordion';
 import { styles } from './NavAccordion.styles';
 
+import { isPathWithin } from '~/lib/utils/navPath';
 import MinusIconSvg from '~/public/icons/minus.svg';
 import PlusIconSvg from '~/public/icons/plus.svg';
 import { Svg } from '~/shared/components/colored-svg/ColoredSvg';
@@ -24,22 +25,9 @@ function isLinkItem(item: NavItem): item is NavLinkItem {
   return 'href' in item && !('dropdown' in item);
 }
 
-function normalizePath(path: string): string {
-  let end = path.length;
-
-  while (end > 1 && path[end - 1] === '/') {
-    end--;
-  }
-
-  return path.slice(0, end);
-}
-
 export function AccordionItem({ item, pathname, isOpen, onToggle }: Readonly<AccordionItemProps>) {
-  const normalizedPath = normalizePath(pathname);
-
-  const isLinkActive = isLinkItem(item) && normalizePath(item.href) === normalizedPath;
-  const isDropdownActive =
-    isDropdownItem(item) && item.dropdown.some((child) => normalizePath(child.href) === normalizedPath);
+  const isLinkActive = isLinkItem(item) && isPathWithin(item.href, pathname);
+  const isDropdownActive = isDropdownItem(item) && item.dropdown.some((child) => isPathWithin(child.href, pathname));
 
   const isActive = isLinkActive || isDropdownActive;
   const iconColor = isActive ? mainHexPallete.burgundy[700] : mainHexPallete.brown[900];

--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
@@ -14,6 +14,7 @@ import type { ScrollDirection } from '~/types/types/common.types';
 
 import { NavigationDTO } from '~/domain/dto/navigation.dto';
 import { usePathname } from '~/i18n/navigation';
+import { isPathWithin, normalizePath } from '~/lib/utils/navPath';
 import ChevronDown from '~/public/icons/chevron-down.svg';
 import ChevronUp from '~/public/icons/chevron-up.svg';
 import { Svg } from '~/shared/components/colored-svg/ColoredSvg';
@@ -48,6 +49,7 @@ const DesktopNav = ({
   }, [navLabels]);
 
   const pathname = usePathname();
+  const normalizedPath = normalizePath(pathname);
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [openDropdownState, setOpenDropdownState] = useState<{ label: string; items: DropdownItem[] } | null>(null);
@@ -55,7 +57,8 @@ const DesktopNav = ({
   const [animateIndicator, setAnimateIndicator] = useState(true);
 
   const prevActiveButtonRef = useRef<number | undefined>(undefined);
-  const isSpecialActive = pathname === specialNav?.links[0].href;
+
+  const isSpecialActive = !!specialNav?.links?.[0] && isPathWithin(specialNav.links[0].href, normalizedPath);
 
   useEffect(() => {
     if (scrollDirection === 'down' && anchorEl) {
@@ -64,23 +67,23 @@ const DesktopNav = ({
   }, [scrollDirection, anchorEl]);
 
   useEffect(() => {
-    if (pathname === specialNav?.links[0].href) {
+    const currentPath = normalizedPath;
+
+    if (specialNav?.links?.[0] && isPathWithin(specialNav.links[0].href, currentPath)) {
       setActiveButton(undefined);
       return;
     }
 
-    const index = NAV_ITEMS.findIndex(
-      (item) => item.href === pathname || item.dropdown?.some((dropdownItem) => dropdownItem.href === pathname)
-    );
+    const groupIndex = navLabels.findIndex((group) => group.links.some((link) => isPathWithin(link.href, currentPath)));
 
-    if (index !== -1) {
-      setActiveButton(index);
-    } else if (pathname === '/') {
+    if (groupIndex !== -1) {
+      setActiveButton(groupIndex);
+    } else if (currentPath === '/') {
       setActiveButton(1);
     } else {
       setActiveButton(undefined);
     }
-  }, [pathname, NAV_ITEMS, specialNav?.links]);
+  }, [normalizedPath, navLabels, specialNav]);
 
   useEffect(() => {
     const becameDefined = prevActiveButtonRef.current === undefined && activeButton !== undefined;


### PR DESCRIPTION
## Description

Improve navigation so that a section stays active not only on its root URL, but also on its nested pages and localized routes.
Introduce a shared helper for navigation paths and update both desktop and mobile navigation to keep sections active for dynamic and localized routes.

Changes:
1. Added `navPath` helper with:
- `normalizePath` – strips `uk`/`en` locale prefix and normalizes leading/trailing slashes;
- `isPathWithin` – checks if the current path belongs to a given section root;
2. Wired the helper into `DesktopNav`:
- active button is now resolved by checking if the current path is within any group link;
- special navigation uses the same logic to detect its active state.
3. Updated `NavAccordion` and `NavAccordionItem` to use the same path matching on mobile.
4. Added unit tests for `navPath` and a localized nested-path test for `NavAccordion`.

## Type of change

- [x] New feature
- [x] Refactoring / Tech debt

## How to test

1. Open `/uk/about-us`, `/uk/news`: "Фундація" is highlighted in header and mobile menu.
2. Open `/uk/archive`, `/uk/archive/{fundId}`, `/uk/archive/{fundId}/{caseId}`: "Архів" is highlighted in header and mobile menu.
3. Repeat 1-2 for `/en/...` routes and confirm the same behaviour.

## Video / Screenshots

https://github.com/user-attachments/assets/2a74222d-cbc2-43cb-a61e-0aad912024aa

## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
