### PR TITLE
fix(collapsible-row): add collapsing on row click

### DIFF
--- a/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.styles.ts
+++ b/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.styles.ts
@@ -11,7 +11,8 @@ export const collapsibleRowStyles = {
     py: collapsed ? 'auto' : 0,
     overflow: 'hidden',
     transition: 'height 400ms ease',
-    backgroundColor: collapsed ? mainHexPallete.blue[75] : 'transparent'
+    backgroundColor: collapsed ? mainHexPallete.blue[75] : 'transparent',
+    cursor: 'pointer'
   }),
 
   cell: {

--- a/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.test.tsx
+++ b/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.test.tsx
@@ -88,6 +88,21 @@ describe('CollapsibleRow', () => {
     expect(onToggle).toHaveBeenCalledTimes(1);
   });
 
+  it('should call action on row click', () => {
+    const onToggle = jest.fn();
+
+    render(
+      <table>
+        <tbody>
+          <CollapsibleRow data={mockData} collapsed={false} action={onToggle} columns={columns} />
+        </tbody>
+      </table>
+    );
+
+    fireEvent.click(screen.getByTestId('CollapsibleRow-mainOpus-name'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
   it('should render internal rows via CollapsibleDataRow when collapsed=true', () => {
     render(
       <table>

--- a/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.tsx
+++ b/app/shared/components/enhanced-table/collapsible-row/CollapsibleRow.tsx
@@ -51,7 +51,14 @@ export const CollapsibleRow = <T extends RowData>({
   let coveredUntil = -1;
   return (
     <>
-      <TableRow sx={styles.row(collapsed)} data-testid="CollapsibleRow-mainOpus">
+      <TableRow
+        sx={styles.row(collapsed)}
+        data-testid="CollapsibleRow-mainOpus"
+        onClick={(e) => {
+          e.preventDefault();
+          action();
+        }}
+      >
         {columns.map((col, idx) => {
           if (idx <= coveredUntil) return null;
 
@@ -65,6 +72,7 @@ export const CollapsibleRow = <T extends RowData>({
                     aria-label="toggle row"
                     onClick={(e) => {
                       e.preventDefault();
+                      e.stopPropagation();
                       action();
                     }}
                     variant={IconButtonColorVariant.Secondary}


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this PR and what was changed -->
Added the ability to collapse group rows by clicking on the row itself.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Go to the Artistry page
2. Click on any part of the opus row except the arrow icon the opus title (which will navigate to details)
3. Observe that the dropdown does expand/collapse

## Video / Screenshots

<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->

https://github.com/user-attachments/assets/df5914aa-3c84-4683-9e10-c5b6ed1f4ebc

## Checklist


- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
