### PR TITLE
Fix(hydration errors): stabilize header and table hydration (SSR-safe breakpoints)

### DIFF
--- a/app/shared/components/enhanced-table/control-panel/ControlPanel.test.tsx
+++ b/app/shared/components/enhanced-table/control-panel/ControlPanel.test.tsx
@@ -1,12 +1,10 @@
-import { useMediaQuery } from '@mui/material';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import ControlPanel from './ControlPanel';
 
-jest.mock('@mui/material', () => ({
-  ...jest.requireActual('@mui/material'),
-  useMediaQuery: jest.fn(() => false)
-}));
+import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
+
+jest.mock('~/shared/hooks/use-breakpoints/useBreakpoints');
 
 jest.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key
@@ -45,7 +43,9 @@ jest.mock('~/ds-components/icon-button/IconButton', () => ({
 
 const MockSearch = () => <div data-testid="search-component">Search Component</div>;
 const MockFilters = () => <div data-testid="filters-component">Filters Component</div>;
-const mockedUseMediaQuery = useMediaQuery as jest.Mock;
+
+const mockedUseBreakpoints = useBreakpoints as jest.Mock;
+
 const tableName = 'Test Table';
 const activeFiltersCount = 3;
 
@@ -56,9 +56,22 @@ const defaultProps = {
   Filters: <MockFilters />
 };
 
+const desktopBreakpoints = {
+  isDesktop: false,
+  isLaptopAndAbove: false,
+  isLaptop: false,
+  isTablet: false,
+  isMobile: false
+};
+
+const mobileBreakpoints = {
+  ...desktopBreakpoints,
+  isMobile: true
+};
+
 describe('ControlPanel', () => {
   beforeEach(() => {
-    mockedUseMediaQuery.mockReturnValue(false);
+    mockedUseBreakpoints.mockReturnValue(desktopBreakpoints);
   });
 
   describe('Desktop View', () => {
@@ -92,17 +105,22 @@ describe('ControlPanel', () => {
     });
 
     it('should not display the badge count when activeFiltersCount is 0 (desktop)', () => {
-      render(<ControlPanel {...defaultProps} activeFiltersCount={0} />);
+      const { container } = render(<ControlPanel {...defaultProps} activeFiltersCount={0} />);
 
       expect(screen.getByText('controls.filters')).toBeInTheDocument();
       expect(screen.queryByTestId('filters-component')).not.toBeInTheDocument();
+
       expect(screen.queryByText('0')).not.toBeInTheDocument();
+
+      const badge = container.querySelector('.MuiBadge-badge') as HTMLElement | null;
+      expect(badge).not.toBeNull();
+      expect(badge).toHaveClass('MuiBadge-invisible');
     });
   });
 
   describe('Mobile View', () => {
     beforeEach(() => {
-      mockedUseMediaQuery.mockReturnValue(true);
+      mockedUseBreakpoints.mockReturnValue(mobileBreakpoints);
     });
 
     it('should toggle filters visibility on mobile button click', () => {

--- a/app/shared/components/enhanced-table/control-panel/ControlPanel.tsx
+++ b/app/shared/components/enhanced-table/control-panel/ControlPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Badge, Box, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { Badge, Box, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 
@@ -14,6 +14,7 @@ import { IconButtonColorVariant, IconButtonVariant } from '~/types/enums/common.
 
 import Filter from '~/public/icons/filter.svg';
 import SearchIcon from '~/public/icons/search.svg';
+import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
 
 interface ControlPanelProps {
   readonly Search: ReactNode;
@@ -31,9 +32,7 @@ export default function ControlPanel({
   sx
 }: Readonly<ControlPanelProps>) {
   const t = useTranslations('table');
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'), { noSsr: true });
-  const isLessThan1024 = useMediaQuery('(max-width:1024px)', { noSsr: true });
+  const { isMobile } = useBreakpoints();
   const hasFilters = Boolean(Filters);
 
   const [searchActive, setSearchActive] = useState(false);
@@ -117,7 +116,16 @@ export default function ControlPanel({
   return (
     <Box sx={{ ...ControlPanelStyles.root, ...sx }} data-testid="ControlPanel">
       <Box sx={ControlPanelStyles.header} data-testid="ControlPanel-header">
-        <Typography variant={isLessThan1024 ? 'customBold25' : 'customBold32'} data-testid="ControlPanel-tableName">
+        <Typography
+          variant="customBold25"
+          data-testid="ControlPanel-tableName"
+          sx={{
+            fontSize: {
+              xs: '25px',
+              md: '32px'
+            }
+          }}
+        >
           {tableName}
         </Typography>
         <Box sx={ControlPanelStyles.headerRight} data-testid="ControlPanel-header--right">

--- a/app/shared/hooks/use-breakpoints/useBreakpoints.test.tsx
+++ b/app/shared/hooks/use-breakpoints/useBreakpoints.test.tsx
@@ -1,10 +1,8 @@
 import * as styles from '@mui/material/styles';
-import * as mediaQuery from '@mui/material/useMediaQuery';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 import useBreakpoints from './useBreakpoints';
 
-jest.mock('@mui/material/useMediaQuery', () => jest.fn());
 jest.mock('@mui/material/styles', () => {
   const actual = jest.requireActual('@mui/material/styles');
   return {
@@ -13,35 +11,62 @@ jest.mock('@mui/material/styles', () => {
   };
 });
 
-const mockUseMediaQuery = mediaQuery.default as jest.Mock;
 const mockUseTheme = styles.useTheme as jest.Mock;
 
 describe('useBreakpoints', () => {
   beforeEach(() => {
     mockUseTheme.mockReturnValue({
       breakpoints: {
-        up: (key: string) => key,
-        between: (start: string, end: string) => `${start}-${end}`
+        values: {
+          xs: 0,
+          sm: 600,
+          md: 900,
+          lg: 1200
+        }
       }
     });
-
-    mockUseMediaQuery
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(false);
   });
 
-  it('should return correct breakpoints', () => {
+  it('should return correct breakpoints for desktop width', async () => {
+    Object.defineProperty(globalThis, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1300
+    });
+
     const { result } = renderHook(() => useBreakpoints());
 
-    expect(result.current).toEqual({
-      isDesktop: true,
-      isLaptopAndAbove: true,
-      isLaptop: false,
-      isTablet: false,
-      isMobile: false
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        isDesktop: true,
+        isLaptopAndAbove: true,
+        isLaptop: false,
+        isTablet: false,
+        isMobile: false
+      });
+    });
+  });
+
+  it('should return correct breakpoints for mobile width', async () => {
+    const { result } = renderHook(() => useBreakpoints());
+
+    act(() => {
+      Object.defineProperty(globalThis, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: 500
+      });
+      globalThis.dispatchEvent(new Event('resize'));
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        isDesktop: false,
+        isLaptopAndAbove: false,
+        isLaptop: false,
+        isTablet: false,
+        isMobile: true
+      });
     });
   });
 });

--- a/app/shared/hooks/use-breakpoints/useBreakpoints.tsx
+++ b/app/shared/hooks/use-breakpoints/useBreakpoints.tsx
@@ -1,25 +1,39 @@
-import { useTheme } from '@mui/material/styles';
-import useMediaQuery from '@mui/material/useMediaQuery';
+'use client';
 
-const useBreakpoints = () => {
+import { useTheme } from '@mui/material/styles';
+import { useEffect, useState } from 'react';
+
+type BreakpointsState = {
+  isDesktop: boolean;
+  isLaptopAndAbove: boolean;
+  isLaptop: boolean;
+  isTablet: boolean;
+  isMobile: boolean;
+};
+
+const useBreakpoints = (): BreakpointsState => {
   const theme = useTheme();
 
-  const isDesktop = useMediaQuery(theme.breakpoints.up('lg'), { noSsr: true });
-  const isLaptopAndAbove = useMediaQuery(theme.breakpoints.up('md'), {
-    noSsr: true
-  });
+  const [width, setWidth] = useState<number | null>(null);
 
-  const isLaptop = useMediaQuery(theme.breakpoints.between('md', 'lg'), {
-    noSsr: true
-  });
+  useEffect(() => {
+    const handleResize = () => {
+      setWidth(globalThis.innerWidth);
+    };
 
-  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'), {
-    noSsr: true
-  });
+    handleResize();
+    globalThis.addEventListener('resize', handleResize);
 
-  const isMobile = useMediaQuery(theme.breakpoints.between('xs', 'sm'), {
-    noSsr: true
-  });
+    return () => globalThis.removeEventListener('resize', handleResize);
+  }, []);
+
+  const values = theme.breakpoints.values;
+
+  const isDesktop = width !== null && width >= values.lg;
+  const isLaptopAndAbove = width !== null && width >= values.md;
+  const isLaptop = width !== null && width >= values.md && width < values.lg;
+  const isTablet = width !== null && width >= values.sm && width < values.md;
+  const isMobile = width !== null && width < values.sm;
 
   return { isDesktop, isLaptopAndAbove, isLaptop, isTablet, isMobile };
 };

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -176,7 +176,7 @@
       "downloadMusic": "Download"
     },
     "work": {
-      "name": "All works",
+      "name": "All documents",
       "filters": {
         "author": "Author",
         "yearLabel": "Year written"

--- a/i18n/messages/uk.json
+++ b/i18n/messages/uk.json
@@ -176,7 +176,7 @@
       "downloadMusic": "Завантажити"
     },
     "work": {
-      "name": "Усі твори",
+      "name": "Усі документи",
       "filters": {
         "author": "Автор",
         "yearLabel": "Рік написання"


### PR DESCRIPTION
## Description

This PR fixes hydration mismatches on small screens caused by client/server divergence in components that depended on `useMediaQuery` and `noSsr`.

Main changes:
- Reworked `useBreakpoints` to be SSR-safe: Removed `useMediaQuery` / `{ noSsr: true }`. Now uses `window.innerWidth` inside `useEffect` and computes `isMobile`, `isTablet`, `isLaptop`, `isLaptopAndAbove`, `isDesktop` from `theme.breakpoints.values`.
- Updated `ControlPanel`: Replaced dynamic `Typography` variant based and switched mobile/desktop logic to the new `useBreakpoints` hook instead of `useMediaQuery`.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Start the app in incognito mode (to prevent browser extensions hydration errors).
2. Set viewport width < 1024px.
3. Hard refresh /artistry.
4. Open DevTools console and verify there are no hydration errors.

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
