### PR TITLE
fix(artistry-modals): add closing on outside click and ESC key

### DIFF
--- a/app/shared/components/get-notes-modal/GetNotesModal.tsx
+++ b/app/shared/components/get-notes-modal/GetNotesModal.tsx
@@ -83,7 +83,7 @@ const GetNotesModal = ({ composition, notes, opened, handleClose }: GetNotesModa
   );
 
   return (
-    <ModalComponent open={opened} sx={styles.backdrop}>
+    <ModalComponent open={opened} onClose={handleClose} sx={styles.backdrop} disableRestoreFocus>
       <Box sx={{ position: 'relative' }}>
         <IconButton sx={styles.closeIcon(state)} type={IconButtonVariant.icon} size="large" onClick={handleClose}>
           <SvgImage src="/icons/x.svg" alt="Close" width={30} height={30} />


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this PR and what was changed -->
Added the ability to close modals on Artistry page by clicking ouside and with ESC key.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open any of the three note modals (Notes, Contact Us and Thank you modals) on the Artistry page.
2. Click outside the modal content area.
3. Press the Esc key.
4. Confirm that modal closes.

## Video / Screenshots

<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->
https://github.com/user-attachments/assets/aa44f3b2-0f36-43a3-9726-f1e250cc0a20

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
