### PR TITLE
Fix(header): remove flicker when navigating

### DIFF
--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
@@ -163,7 +163,7 @@ const DesktopNav = ({
           activeButton={activeButton !== undefined ? activeButton : -1}
           buttons={renderedNavButtons}
           size="big"
-          animateIndicator={animateIndicator}
+          animateIndicator={animateIndicator && activeButton !== undefined}
         />
         {specialNav && specialNav.links.length > 0 && specialNav.links[0].visibility && (
           <Button


### PR DESCRIPTION
## Description

Fix header desktop navigation indicator behavior when navigating to the special nav button.  
The active indicator now dissapears instead of flickering when opening the special item.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the site and navigate between regular header nav items.
2. Click the special nav button (e.g. "War in Ukraine").
3. Confirm that the indicator does not flicker instead of jumping to the left.

## Video / Screenshots


https://github.com/user-attachments/assets/dd7f844c-263e-4d48-b79c-db8b35e4b58c

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
