### PR TITLE
style: fix incorrect switcher width on small screen sizes

### DIFF
--- a/app/shared/components/blocks/payment-details/PaymentDetails.styles.ts
+++ b/app/shared/components/blocks/payment-details/PaymentDetails.styles.ts
@@ -60,7 +60,6 @@ export const styles = {
 
   iban: {
     display: 'flex',
-    pr: '24px',
     gap: '8px'
   },
 

--- a/app/shared/components/blocks/payment-details/PaymentDetails.styles.ts
+++ b/app/shared/components/blocks/payment-details/PaymentDetails.styles.ts
@@ -5,17 +5,19 @@ export const styles = {
     backgroundColor: mainHexPallete.brown[50],
     p: '4px',
 
+    width: { xs: '100%', sm: 'fit-content' },
+
     div: {
       p: '0px',
-      m: '0px'
+      m: '0px',
+      width: { xs: '100%', sm: 'auto' },
+      display: 'flex'
     },
-
     button: {
-      width: '67px'
+      width: { xs: 'auto', sm: '67px' },
+      flex: { xs: 1, sm: 'unset' }
     },
-
     '& [aria-label="indicator"]': {
-      width: '66px',
       height: 'calc(100% - 8px)',
       top: 4
     }

--- a/app/shared/components/blocks/payment-details/PaymentDetails.tsx
+++ b/app/shared/components/blocks/payment-details/PaymentDetails.tsx
@@ -30,7 +30,7 @@ function PaymentDetails() {
   }, []);
 
   return (
-    <Box sx={{ 'margin-right': '24px' }} data-testid="PaymentDetails">
+    <Box sx={{ mr: '24px' }} data-testid="PaymentDetails">
       <ButtonGroup
         sx={switcherSx}
         defaultActiveButton={0}

--- a/app/shared/components/blocks/payment-details/PaymentDetails.tsx
+++ b/app/shared/components/blocks/payment-details/PaymentDetails.tsx
@@ -14,10 +14,25 @@ function PaymentDetails() {
   const selectedPaymentDetails = useMemo(() => paymentDetails[currency], [currency]);
   const ibanRef = useRef<HTMLSpanElement>(null);
 
+  const switcherSx = useMemo(() => {
+    const buttonsCount = currencyList.length;
+
+    return {
+      ...styles.buttonGroup,
+      '& [aria-label="indicator"]': {
+        ...styles.buttonGroup['& [aria-label="indicator"]'],
+        width: {
+          xs: `calc((100% - 8px) / ${buttonsCount})`,
+          sm: '66px'
+        }
+      }
+    };
+  }, []);
+
   return (
-    <Box data-testid="PaymentDetails">
+    <Box sx={{ 'margin-right': '24px' }} data-testid="PaymentDetails">
       <ButtonGroup
-        sx={styles.buttonGroup}
+        sx={switcherSx}
         defaultActiveButton={0}
         buttons={currencyList.map((currency) => (
           <Button


### PR DESCRIPTION
## Description

Incorrect switcher width on mobile devices. It must be full-width on mobile screens instead of having a fixed width.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## Video / Screenshots

# Before
<img width="393" height="108" alt="image" src="https://github.com/user-attachments/assets/2819ad1e-33d1-42d2-8cd4-94511e76e116" />
<img width="389" height="845" alt="image" src="https://github.com/user-attachments/assets/ce757642-2afc-46cf-839c-6e3d13556263" />

# After
<img width="380" height="107" alt="image" src="https://github.com/user-attachments/assets/7c7f0cd5-ffe9-4e66-ba71-61b3a9b75673" />
<img width="391" height="845" alt="image" src="https://github.com/user-attachments/assets/ad1b2199-c8b3-46ba-8099-a54bd727c0c3" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board
