### PR TITLE
test: fix audioplayer test

### DIFF
--- a/app/shared/components/Header/AudioPlayer/AudioPlayer.test.tsx
+++ b/app/shared/components/Header/AudioPlayer/AudioPlayer.test.tsx
@@ -57,7 +57,7 @@ describe('AudioPlayer', () => {
 
     HTMLMediaElement.prototype.play = jest.fn().mockResolvedValue(undefined);
     HTMLMediaElement.prototype.pause = jest.fn();
-    HTMLMediaElement.prototype.load = jest.fn(); // Додано виправлення тут
+    HTMLMediaElement.prototype.load = jest.fn();
   });
 
   beforeEach(() => {

--- a/app/shared/components/Header/AudioPlayer/AudioPlayer.test.tsx
+++ b/app/shared/components/Header/AudioPlayer/AudioPlayer.test.tsx
@@ -57,6 +57,7 @@ describe('AudioPlayer', () => {
 
     HTMLMediaElement.prototype.play = jest.fn().mockResolvedValue(undefined);
     HTMLMediaElement.prototype.pause = jest.fn();
+    HTMLMediaElement.prototype.load = jest.fn(); // Додано виправлення тут
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Description

This PR fixes a console error occurring during unit tests for the `AudioPlayer` component. The error `Not implemented: HTMLMediaElement.prototype.load` was thrown because the JSDOM environment does not natively support the `load()` method called within the component's `useEffect`.

The fix involves mocking `HTMLMediaElement.prototype.load` in the test setup configuration (`beforeAll` block), ensuring tests run cleanly and pass without environment-related errors.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: 

## How to test

1. Pull the changes locally.
2. Run the specific test suite for the Audio Player:
   `npm test app/shared/components/Header/AudioPlayer/AudioPlayer.test.tsx`
3. Verify that the tests pass successfully and the console output is clean of "Not implemented" errors.

## Screenshots

Before

<img width="1280" height="513" alt="image" src="https://github.com/user-attachments/assets/b061b4f9-a3c2-4600-bb97-66dd93defe55" />

After

<img width="1051" height="547" alt="image" src="https://github.com/user-attachments/assets/f980d724-c021-4a99-a59f-e41f096baed4" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board