### PR TITLE
test: fix baseService test

### DIFF
--- a/app/services/client/baseService.test.ts
+++ b/app/services/client/baseService.test.ts
@@ -11,7 +11,6 @@ describe('baseService.request', () => {
   });
 
   afterEach(() => {
-    jest.runOnlyPendingTimers();
     jest.useRealTimers();
     global.fetch = originalFetch;
     jest.clearAllMocks();
@@ -84,6 +83,7 @@ describe('baseService.request', () => {
     });
 
     jest.advanceTimersByTime(200);
+
     await expect(promise).rejects.toEqual(new ResponseError(errors.REQUEST_TIMEOUT));
   });
 


### PR DESCRIPTION
## Description

This PR fixes a console warning occurring during unit tests for `baseService`. The warning `A function to advance timers was called but the timers APIs are not replaced with fake timers` was thrown because `jest.runOnlyPendingTimers()` was being invoked in the global `afterEach` hook, while fake timers were not enabled globally for the test suite.

The fix involves removing the incorrect `jest.runOnlyPendingTimers()` call from the `afterEach` block, ensuring that timer cleanup is handled correctly without causing warnings in tests that use real timers.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: 

## How to test

1. Pull the changes locally.
2. Run the specific test suite for the Base Service:
   `npm test app/services/client/baseService.test.ts`
3. Verify that the tests pass successfully and the console output is clean of "timers APIs are not replaced" warnings.

## Video / Screenshots

Before

<img width="1280" height="429" alt="image" src="https://github.com/user-attachments/assets/87b74baa-edd5-4f76-aa3a-fddd753814b3" />

After 

<img width="1168" height="465" alt="image" src="https://github.com/user-attachments/assets/b22e3d0c-4c6c-4147-9a39-6672dee9cb71" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board