### PR TITLE
fix: FundSummaryHeader styles

### DIFF
--- a/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.styles.ts
+++ b/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.styles.ts
@@ -21,6 +21,7 @@ export const styles = {
       md: '1 / 6'
     },
     mb: '24px',
+    fontWeight: 'medium',
     justifySelf: 'start',
     alignSelf: 'start',
     '& .MuiButton-root': {
@@ -84,12 +85,14 @@ export const styles = {
   contentItem: {
     fontSize: '16px',
     lineHeight: '150%',
+    fontWeight: 'semibold',
     display: 'flex',
     flexDirection: 'column' as const
   },
 
   itemTitle: {
     fontSize: '16px',
+    fontWeight: 'regular',
     color: mainHexPallete.brown[600]
   }
 };

--- a/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.tsx
+++ b/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from '@mui/material';
+import { Box, type SxProps, type Theme, Typography } from '@mui/material';
 import Image from 'next/image';
 import type { Locale } from 'next-intl';
 import { useLocale } from 'next-intl';
@@ -11,6 +11,7 @@ import CustomLink from '~/ds-components/link/CustomLink';
 import { styles, TITLE_GRID_COLUMN, TITLE_SX } from './FundSummaryHeader.styles';
 import { TipTapNodeTypes } from '~/types/enums/common.enums';
 import { TipTapDoc } from '~/types/types/tiptap.types';
+import { sxToArray } from '~/utils/sxToArray';
 
 type LocalizedString = Record<Locale, string>;
 type LocalizedTipTapDoc = Record<Locale, TipTapDoc>;
@@ -30,6 +31,7 @@ export interface FundSummaryHeaderProps {
   title: string;
   data: FundSummaryHeaderData;
   dataTestId?: string;
+  sx?: SxProps<Theme>;
 }
 
 const ARROW_BACK_ICON = <Image src="/icons/arrow-left.svg" alt="" width={24} height={24} aria-hidden="true" />;
@@ -75,14 +77,15 @@ const FundSummaryHeader: React.FC<FundSummaryHeaderProps> = ({
   backLinkText,
   title,
   data,
-  dataTestId
+  dataTestId,
+  sx
 }) => {
   const locale = useLocale() as Locale;
 
   const { leftColumn, rightColumn } = useMemo(() => splitIntoColumns(data.items), [data.items]);
 
   return (
-    <Box sx={styles.container} data-testid={dataTestId}>
+    <Box sx={[styles.container, ...sxToArray(sx)]} data-testid={dataTestId}>
       <Box sx={styles.backLink}>
         <CustomLink path={backLinkUrl} startIcon={ARROW_BACK_ICON} labelSx={{ fontSize: '16px' }}>
           {backLinkText}


### PR DESCRIPTION
## Description

This PR refactors the `FundSummaryHeader` component to improve its flexibility and styling consistency.

**Key changes:**
- **Added `sx` prop support:** The component now accepts the `sx` prop, allowing external styles (like margins) to be applied directly to the root container.
- **Improved Typography:** Standardized the font size for TipTap content paragraphs to `16px` using a custom renderer.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board
