### PR TITLE
feat(archive): add SEO metadata for case details page

### DIFF
--- a/app/[lang]/archive/[fund]/[case]/page.test.tsx
+++ b/app/[lang]/archive/[fund]/[case]/page.test.tsx
@@ -2,7 +2,8 @@ import { render, screen } from '@testing-library/react';
 import { notFound } from 'next/navigation';
 import type { ReactNode } from 'react';
 
-import ArchiveCasePage from './page';
+import ArchiveCasePage, { generateMetadata } from './page';
+import { createSeoMeta } from '~/utils/createSeoMeta';
 
 import type { ArchiveCaseDetailsProps } from '~/shared/components/blocks/archive-case-details/ArchiveCaseDetails';
 
@@ -49,6 +50,13 @@ jest.mock('~/shared/components/blocks/archive-case-details/ArchiveCaseDetails', 
   }
 }));
 
+jest.mock('~/utils/createSeoMeta', () => ({
+  createSeoMeta: jest.fn((config) => config)
+}));
+
+const mockedNotFound = notFound as unknown as jest.Mock;
+const mockedCreateSeoMeta = createSeoMeta as unknown as jest.Mock;
+
 const mockCaseDetails = {
   name: 'Case name from backend',
   cipher: 'Ф. 2, оп. 1, спр. 3',
@@ -71,7 +79,50 @@ const mockCaseDetails = {
   }
 };
 
-const mockedNotFound = notFound as unknown as jest.Mock;
+describe('generateMetadata', () => {
+  beforeEach(() => {
+    mockGetCaseById.mockReset();
+    mockedCreateSeoMeta.mockClear();
+  });
+
+  it('builds Ukrainian SEO metadata for an existing case', async () => {
+    mockGetCaseById.mockResolvedValue(mockCaseDetails);
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ lang: 'en', fund: '2', case: 'op1-spr3' })
+    });
+
+    const expectedConfig = {
+      title: `Архівна справа ${mockCaseDetails.cipher} – ${mockCaseDetails.name}`,
+      description: `Архівна справа «${mockCaseDetails.name}» (${mockCaseDetails.cipher}). Дати: ${mockCaseDetails.dates}.`,
+      url: '/archive/2/op1-spr3'
+    };
+
+    expect(mockGetCaseById).toHaveBeenCalledWith('op1-spr3');
+    expect(mockedCreateSeoMeta).toHaveBeenCalledTimes(1);
+    expect(mockedCreateSeoMeta).toHaveBeenCalledWith(expectedConfig);
+    expect(metadata).toEqual(expectedConfig);
+  });
+
+  it('returns a Ukrainian fallback when the case is missing', async () => {
+    mockGetCaseById.mockResolvedValue(null);
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ lang: 'en', fund: '2', case: 'missing-id' })
+    });
+
+    const expectedConfig = {
+      title: 'Архівна справа не знайдена',
+      description: 'Запитувану архівну справу не знайдено.',
+      url: '/archive/2/missing-id'
+    };
+
+    expect(mockGetCaseById).toHaveBeenCalledWith('missing-id');
+    expect(mockedCreateSeoMeta).toHaveBeenCalledTimes(1);
+    expect(mockedCreateSeoMeta).toHaveBeenCalledWith(expectedConfig);
+    expect(metadata).toEqual(expectedConfig);
+  });
+});
 
 describe('ArchiveCasePage', () => {
   beforeEach(() => {

--- a/app/[lang]/archive/[fund]/[case]/page.tsx
+++ b/app/[lang]/archive/[fund]/[case]/page.tsx
@@ -1,6 +1,9 @@
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import type { Locale } from 'next-intl';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { createSeoMeta } from '~/utils/createSeoMeta';
 
 import { createRequestContainer } from '~/di/container';
 import type { CaseDetailsDTO } from '~/domain/dto/funds.dto';
@@ -21,19 +24,47 @@ type ArchiveCasePageProps = {
   params: Promise<ArchiveCasePageParams>;
 };
 
-export default async function ArchiveCasePage({ params }: Readonly<ArchiveCasePageProps>) {
-  const { lang, fund, case: caseId } = await params;
-
-  setRequestLocale(lang);
-
-  const t = await getTranslations({ locale: lang, namespace: 'archiveCase' });
-
+async function getCaseDetails(caseId: string) {
   const container = createRequestContainer();
   const fundsService = container.resolve('fundsService') as {
     getCaseById: (caseId: string) => Promise<CaseDetailsDTO | null>;
   };
 
-  const caseDetails = await fundsService.getCaseById(caseId);
+  return fundsService.getCaseById(caseId);
+}
+
+export async function generateMetadata({ params }: Readonly<ArchiveCasePageProps>): Promise<Metadata> {
+  const { fund, case: caseId } = await params;
+
+  const caseDetails = await getCaseDetails(caseId);
+
+  if (!caseDetails) {
+    return createSeoMeta({
+      title: 'Архівна справа не знайдена',
+      description: 'Запитувану архівну справу не знайдено.',
+      url: `/archive/${fund}/${caseId}`
+    });
+  }
+
+  const title = `Архівна справа ${caseDetails.cipher} – ${caseDetails.name}`;
+  const description = `Архівна справа «${caseDetails.name}» (${caseDetails.cipher}). Дати: ${caseDetails.dates}.`;
+
+  return createSeoMeta({
+    title,
+    description,
+    url: `/archive/${fund}/${caseId}`
+  });
+}
+
+export default async function ArchiveCasePage({ params }: Readonly<ArchiveCasePageProps>) {
+  const { lang, fund, case: caseId } = await params;
+
+  setRequestLocale(lang);
+
+  const [t, caseDetails] = await Promise.all([
+    getTranslations({ locale: lang, namespace: 'archiveCase' }),
+    getCaseDetails(caseId)
+  ]);
 
   if (!caseDetails) {
     notFound();


### PR DESCRIPTION
## Description

This PR adds SEO metadata for the archive case details page.
The page now:

- exposes a generateMetadata function that builds a localized <title> and meta description via createSeoMeta;
- reuses a small getCaseDetails(caseId) helper both in generateMetadata and in ArchiveCasePage to avoid duplicating DI wiring.

SEO behaviour

When the case exists:
- title: Архівна справа {cipher} – {name};
- description: includes the case name, cipher and date range
- (e.g. Архівна справа «{name}» (шифр {cipher}). Дати: {dates}.);
- url: /archive/{fund}/{caseId}
When the case is missing:
- title: Архівна справа не знайдена;
- description: Запитувану архівну справу не знайдено.;
- url: /archive/{fund}/{caseId}.

Additionally, this PR extends page.test.tsx:
Adds unit tests for generateMetadata to verify: 
- correct config is passed to createSeoMeta when the case exists;
- fallback SEO config is used when no case is found.

## Type of change

- [x] New feature

## How to test

1. Open an existing case, e.g. /uk/archive/2/69236afae427aafae7051acc
2. In browser devtools, check:
- <title> is in the format: Архівна справа {cipher} – {name};
- meta[name="description"] contains the case name, cipher and dates;

## Video / Screenshots

<img width="541" height="122" alt="image" src="https://github.com/user-attachments/assets/3a031f64-3910-4880-879e-c2dad0e58950" />


## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
