### PR TITLE
fix: prevent uneven wrapping in archive case navigation

### DIFF
--- a/app/shared/components/blocks/archive-case-details/navigation/Navigation.styles.ts
+++ b/app/shared/components/blocks/archive-case-details/navigation/Navigation.styles.ts
@@ -10,7 +10,6 @@ export const styles: Record<string, SxProps<Theme>> = {
       md: '40px'
     },
     display: 'flex',
-    alignItems: 'center',
     justifyContent: 'flex-start',
     gap: '16px'
   },
@@ -18,7 +17,9 @@ export const styles: Record<string, SxProps<Theme>> = {
   navItemLeft: {
     display: 'flex',
     flexDirection: 'column',
-    alignItems: 'flex-start'
+    alignItems: 'flex-start',
+    flex: '1 1 0',
+    minWidth: 0
   },
 
   navItemRight: {
@@ -26,7 +27,8 @@ export const styles: Record<string, SxProps<Theme>> = {
     flexDirection: 'column',
     alignItems: 'flex-end',
     textAlign: 'right',
-    marginLeft: 'auto'
+    flex: '1 1 0',
+    minWidth: 0
   },
 
   navButton: {


### PR DESCRIPTION
## Description

This PR fixes the layout of the archive case navigation so "Попередня справа" and "Наступна справа" share the row evenly on mobile:

- both navigation items are now flex children that take equal width when present;
- text inside each item can wrap within its own column instead of squeezing one side.

## Type of change

- [x] Bug fix

## How to test

1. Open an archive case with both neighbours, e.g. `/uk/archive/2/69236afae427aafae7051acc`.
2. Switch to a mobile viewport (~360px width).
3. Scroll to the navigation: "Попередня справа" and "Наступна справа" should have roughly equal width and wrap text inside their halves.
4. Open a case that has only a previous or only a next case: the single navigation item should stretch to the full width.

## Video / Screenshots

<img width="409" height="237" alt="image" src="https://github.com/user-attachments/assets/9bb24272-a027-4afc-af6e-ce2b75077820" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
