### PR TITLE
fix: fix worktable responsiveness on small screens

### DIFF
--- a/app/shared/components/tables/WorksTable/WorkTableSelection.tsx
+++ b/app/shared/components/tables/WorksTable/WorkTableSelection.tsx
@@ -71,7 +71,7 @@ export const WorkTableSection = () => {
     [setParam]
   );
 
-  const columns = useMemo<ColumnDef<ScientificWorkTableRow>[]>(
+  let columns = useMemo<ColumnDef<ScientificWorkTableRow>[]>(
     () => [
       { id: 'name', accessorKey: 'name', header: RenderNameHeader, cell: renderNameCell, sortingFn: 'alphanumeric' },
       {
@@ -92,6 +92,13 @@ export const WorkTableSection = () => {
       { id: 'actions', header: '', cell: RenderActionCell }
     ],
     []
+  );
+
+  const hideColumnsOnSmallScreen = useMemo(() => new Set(['author', 'sortableYear']), []);
+
+  columns = useMemo<ColumnDef<ScientificWorkTableRow>[]>(
+    () => (bp.isTablet || bp.isMobile ? columns.filter((c) => !hideColumnsOnSmallScreen.has(String(c.id))) : columns),
+    [bp.isTablet, bp.isMobile, columns, hideColumnsOnSmallScreen]
   );
 
   const isYearActive =


### PR DESCRIPTION
## Description

I adapted The Scientific Works table on the Research page on small screens according to Figma design.

## Type of change

- [x] Bug fix

## How to test

1. Go to the research page
2. Make the width of the screen <1024px

## Video / Screenshots

768px
<img width="565" height="746" alt="image" src="https://github.com/user-attachments/assets/ff188b72-ee58-49a1-b4d7-5e78b1b37cc3" />

320px
<img width="320" height="623" alt="image" src="https://github.com/user-attachments/assets/2d146c35-0d0f-4993-81b2-56e8f54e5f7a" />


## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
