### PR TITLE
feat: fund details page

### DIFF
--- a/app/[lang]/archive/[fund]/page.tsx
+++ b/app/[lang]/archive/[fund]/page.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 import FundSummaryHeader from '~/components/blocks/fund-summary-header/FundSummaryHeader';
 import {
   fundSummaryBacklinkText,
-  fundSummaryBacklinkUrl,
   fundSummaryContent,
-  fundSummaryTitle
+  fundSummaryTitle,
+  getFundSummaryHeaderBacklinkUrl
 } from '~/components/blocks/fund-summary-header/FundSummaryHeader.content';
 import DocumentTableSelection from '~/components/tables/DocumentsTable/DocumentTableSelection';
 import UnderDevelopment from '~/components/under-development/UnderDevelopment';
@@ -37,6 +37,8 @@ export default async function FundDetailsPage({ params }: Readonly<FundDetailsPa
   if (isProductionMode()) {
     return <UnderDevelopment />;
   }
+
+  const fundSummaryBacklinkUrl = await getFundSummaryHeaderBacklinkUrl();
 
   return (
     <MainLayout withLines>

--- a/app/[lang]/archive/[fund]/page.tsx
+++ b/app/[lang]/archive/[fund]/page.tsx
@@ -24,13 +24,13 @@ interface FundDetailsPageProps {
   }>;
 }
 
-export default async function FundDetailsPage({ params }: FundDetailsPageProps) {
+export default async function FundDetailsPage({ params }: Readonly<FundDetailsPageProps>) {
   const { lang, fund } = await params;
   const locale = lang as Locale;
 
   const fundId = Number(fund);
 
-  if (isNaN(fundId)) {
+  if (Number.isNaN(fundId)) {
     return notFound();
   }
 

--- a/app/[lang]/archive/[fund]/page.tsx
+++ b/app/[lang]/archive/[fund]/page.tsx
@@ -1,9 +1,54 @@
-'use client';
-import { useParams } from 'next/navigation';
+import { notFound } from 'next/navigation';
+import type { Locale } from 'next-intl';
+import React from 'react';
+
+import FundSummaryHeader from '~/components/blocks/fund-summary-header/FundSummaryHeader';
+import {
+  fundSummaryBacklinkText,
+  fundSummaryBacklinkUrl,
+  fundSummaryContent,
+  fundSummaryTitle
+} from '~/components/blocks/fund-summary-header/FundSummaryHeader.content';
+import DocumentTableSelection from '~/components/tables/DocumentsTable/DocumentTableSelection';
+import UnderDevelopment from '~/components/under-development/UnderDevelopment';
+
+import { isProductionMode } from '~/utils/isProductionMode';
 
 import MainLayout from '~/layouts/main-layout/MainLayout';
+import { mockDocuments } from '~/shared/components/tables/DocumentsTable/documents.mock';
 
-export default function FundDetailsPage() {
-  const { fund: fundId } = useParams();
-  return <MainLayout>{fundId}</MainLayout>;
+interface FundDetailsPageProps {
+  params: Promise<{
+    lang: string;
+    fund: string;
+  }>;
+}
+
+export default async function FundDetailsPage({ params }: FundDetailsPageProps) {
+  const { lang, fund } = await params;
+  const locale = lang as Locale;
+
+  const fundId = Number(fund);
+
+  if (isNaN(fundId)) {
+    return notFound();
+  }
+
+  if (isProductionMode()) {
+    return <UnderDevelopment />;
+  }
+
+  return (
+    <MainLayout withLines>
+      <FundSummaryHeader
+        backLinkUrl={fundSummaryBacklinkUrl}
+        backLinkText={fundSummaryBacklinkText[locale]}
+        title={fundSummaryTitle[locale]}
+        data={fundSummaryContent}
+        sx={{ pt: { xs: '80px', lg: '88px' } }}
+      />
+
+      <DocumentTableSelection documents={mockDocuments} />
+    </MainLayout>
+  );
 }

--- a/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.content.ts
+++ b/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.content.ts
@@ -12,7 +12,17 @@ function createDescriptionText(ukText: string, enText: string) {
       content: [
         {
           type: TipTapNodeTypes.paragraph as const,
-          content: [{ type: TipTapNodeTypes.text as const, text: ukText }]
+          content: [
+            {
+              type: TipTapNodeTypes.text as const,
+              text: ukText,
+              marks: [
+                {
+                  type: 'bold'
+                }
+              ]
+            } as any
+          ]
         }
       ]
     },
@@ -21,7 +31,17 @@ function createDescriptionText(ukText: string, enText: string) {
       content: [
         {
           type: TipTapNodeTypes.paragraph as const,
-          content: [{ type: TipTapNodeTypes.text as const, text: enText }]
+          content: [
+            {
+              type: TipTapNodeTypes.text as const,
+              text: enText,
+              marks: [
+                {
+                  type: 'bold'
+                }
+              ]
+            } as any
+          ]
         }
       ]
     }
@@ -34,7 +54,7 @@ function createFundItem(ukTitle: string, enTitle: string, ukDescription: string,
       uk: ukTitle,
       en: enTitle
     },
-    description: createDescriptionText(ukDescription, enDescription)
+    description: createDescriptionText(ukDescription, enDescription) as any
   };
 }
 

--- a/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.content.ts
+++ b/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.content.ts
@@ -78,8 +78,6 @@ export async function getFundSummaryHeaderBacklinkUrl(): Promise<string> {
   return '/archive';
 }
 
-export const fundSummaryBacklinkUrl = await getFundSummaryHeaderBacklinkUrl();
-
 export const fundSummaryBacklinkText: Record<Locale, string> = {
   uk: 'Повернутись до архіву',
   en: 'Back to archive'

--- a/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.styles.ts
+++ b/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.styles.ts
@@ -21,7 +21,6 @@ export const styles = {
       md: '1 / 6'
     },
     mb: '24px',
-    fontWeight: 'medium',
     justifySelf: 'start',
     alignSelf: 'start',
     '& .MuiButton-root': {
@@ -85,14 +84,13 @@ export const styles = {
   contentItem: {
     fontSize: '16px',
     lineHeight: '150%',
-    fontWeight: 'semibold',
     display: 'flex',
     flexDirection: 'column' as const
   },
 
   itemTitle: {
     fontSize: '16px',
-    fontWeight: 'regular',
+    fontWeight: 500,
     color: mainHexPallete.brown[600]
   }
 };

--- a/app/shared/components/tables/DocumentsTable/documents.mock.ts
+++ b/app/shared/components/tables/DocumentsTable/documents.mock.ts
@@ -1,0 +1,95 @@
+import { DocumentRecord } from '~/types/types/document.types';
+
+export const mockDocuments: DocumentRecord[] = [
+  {
+    id: '1',
+    cipher: 'Ф. 2, оп. 1, спр. 1',
+    name: 'Документи про народження і освіту',
+    dates: '1895–1955',
+    sheets: 11,
+    contentDescription: 'Метричні виписки, свідоцтва, студентські квитки, довідки з університету',
+    pdfUrl: '/files/example.pdf'
+  },
+  {
+    id: '2',
+    cipher: 'Ф. 2, оп. 1, спр. 2',
+    name: 'Похвальні листи гімназій',
+    dates: '1895–1955',
+    sheets: 5,
+    contentDescription: 'Похвальні листи Першої Київської, Немирівської, Златопільської гімназій',
+    pdfUrl: '/files/example.pdf'
+  },
+  {
+    id: '3',
+    cipher: 'Ф. 2, оп. 1, спр. 3',
+    name: 'Трудова діяльність',
+    dates: '1895–1955',
+    sheets: 26,
+    contentDescription:
+      'Витяги з наказів, протоколи, довідки про роботу, посвідчення працівника, атестат професора, пенсійне посвідчення',
+    pdfUrl: '/files/example.pdf'
+  },
+  {
+    id: '4',
+    cipher: 'Ф. 2, оп. 1, спр. 4',
+    name: 'Нагороди та звання',
+    dates: '1895–1955',
+    sheets: 14,
+    contentDescription: 'Орденські книжки, дипломи про присвоєння звань, посвідчення про нагороди, подяки',
+    pdfUrl: '/files/example.pdf'
+  },
+  {
+    id: '5',
+    cipher: 'Ф. 2, оп. 1, спр. 5',
+    name: 'Автобіографії та довідки',
+    dates: '1895–1955',
+    sheets: 8,
+    contentDescription: 'Автобіографії та довідки',
+    pdfUrl: '/files/example.pdf'
+  },
+  {
+    id: '6',
+    cipher: 'Ф. 2, оп. 1, спр. 6',
+    name: 'Членство в організаціях',
+    dates: '1895–1955',
+    sheets: 4,
+    contentDescription: 'Членські квитки',
+    pdfUrl: null
+  },
+  {
+    id: '7',
+    cipher: 'Ф. 2, оп. 1, спр. 7',
+    name: 'Поїздки за кордон',
+    dates: '1959–1966',
+    sheets: 4,
+    contentDescription: 'Довідки, рекомендації, запрошення, документи про перебування за кордоном',
+    pdfUrl: '/files/example.pdf'
+  },
+  {
+    id: '8',
+    cipher: 'Ф. 2, оп. 1, спр. 8',
+    name: 'Військова служба',
+    dates: '1915–1946',
+    sheets: null,
+    contentDescription: 'Військовий квиток, довідки про мобілізацію / відстрочку',
+    pdfUrl: null
+  },
+  {
+    id: '9',
+    cipher: 'Ф. 2, оп. 1, спр. 9',
+    name: 'Різне',
+    dates: '1955',
+    sheets: null,
+    contentDescription: 'Різне',
+    pdfUrl: null
+  },
+  {
+    id: '10',
+    cipher: 'Ф. 2, оп. 2, спр. 1',
+    name: 'Листи-привітання з 50-річчям',
+    dates: '1945',
+    sheets: 9,
+    contentDescription: 'Листи-привітання',
+    pdfUrl: '/files/example.pdf'
+  }
+];


### PR DESCRIPTION
## Description

Implemented the complete **Fund Details page** (`src/app/[lang]/archive/[fund]/page.tsx`).

This PR integrates previously created components to build the full page layout according to the Figma design.
Currently, the page uses **mock data** to display the fund summary and the list of cases (documents).

**Key changes:**
- Plugged in `FundSummaryHeader` at the top of the page.
- Added `DocumentTableSelection` (Fund Cases List) below the header.
- Ensured the layout is responsive.

> **⚠️ Known Issues / Future Work:**
> - The vertical spacing (padding) for the table component is currently hardcoded and will be refactored to be controllable from the parent page in task **#1077**.
> - The search button visibility issue (missing on desktop) in the `DocumentTableSelection` component is tracked and will be fixed in task **#1078**.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: 

## How to test

1. Navigate to a Fund Details page (e.g., `/en/archive/2` or click on a fund card from the Archive page).
2. Verify that the **Fund Summary Header** displays correct mock information (Title, Description, etc.).
3. Verify that the **"Back to archive"** link works correctly.
4. Check the **Documents Table** below the header.
5. Verify that the layout adapts correctly to Mobile and Desktop breakpoints.

## Video / Screenshots


https://github.com/user-attachments/assets/e7f08c96-6716-4613-a5dc-a1774a00bc3c


## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board