### PR TITLE
Fix: locale-unaware navigation links in NavAccordion

### DIFF
--- a/app/shared/components/design-system/all-components/navigation-accordion/NavAccordion.test.tsx
+++ b/app/shared/components/design-system/all-components/navigation-accordion/NavAccordion.test.tsx
@@ -8,13 +8,18 @@ jest.mock('next/navigation', () => ({
   usePathname: jest.fn(() => '/section/page-a')
 }));
 
-jest.mock('next/link', () => ({
+jest.mock('~/../i18n/navigation', () => ({
   __esModule: true,
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
-    <a href={href} data-testid={`mock-link-${href}`}>
-      {children}
-    </a>
-  )
+  usePathname: jest.fn(() => '/section/page-a'),
+  useRouter: () => ({ replace: jest.fn(), push: jest.fn(), prefetch: jest.fn() }),
+  Link: ({ href, children, ...props }: any) => {
+    const h = typeof href === 'string' ? href : (href?.pathname ?? '');
+    return (
+      <a href={h} data-testid={`mock-link-${h}`} {...props}>
+        {children}
+      </a>
+    );
+  }
 }));
 
 jest.mock('~/shared/components/colored-svg/ColoredSvg', () => ({
@@ -93,7 +98,7 @@ describe('NavAccordion', () => {
     expect(submenuLinks).toHaveAttribute('href', '/section/page-a');
   });
 
-  test('marks dropdown as active for localized nested path', () => {
+  test('should mark dropdown as active for localized nested path', () => {
     (usePathname as jest.Mock).mockReturnValue('/uk/section/page-a');
 
     render(<NavAccordion items={items} />);

--- a/app/shared/components/design-system/all-components/navigation-accordion/NavAccordionItem.tsx
+++ b/app/shared/components/design-system/all-components/navigation-accordion/NavAccordionItem.tsx
@@ -1,10 +1,10 @@
 import { Box, Typography } from '@mui/material';
-import Link from 'next/link';
 
 import { mainHexPallete } from '../theme/colors';
 import { NavDropdownItem, NavItem, NavLinkItem } from './NavAccordion';
 import { styles } from './NavAccordion.styles';
 
+import { Link } from '~/i18n/navigation';
 import { isPathWithin } from '~/lib/utils/navPath';
 import MinusIconSvg from '~/public/icons/minus.svg';
 import PlusIconSvg from '~/public/icons/plus.svg';


### PR DESCRIPTION
## Description
Fix locale-aware navigation links in NavAccordion and update unit tests to mock the correct i18n Link module.

## Type of change
- [x] Bug fix

## How to test
1. Run `pnpm test` (or `npm test`) and ensure `NavAccordion.test.tsx` passes.
2. Open the app, switch locale, and verify accordion links keep the current locale.

## Video / Screenshots
https://github.com/user-attachments/assets/96b825d5-e88b-44e7-9755-4ed21488a5d9



## Checklist
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linked issue/task included
