### PR TITLE
Feat: add nothing found picture for WorkTable

### DIFF
--- a/app/shared/components/tables/CompositionTable/no-results-found/TableNoResultsFound.styles.ts
+++ b/app/shared/components/tables/CompositionTable/no-results-found/TableNoResultsFound.styles.ts
@@ -1,5 +1,7 @@
 import { colors } from '@mui/material';
 
+import { AppTypography } from '~/constants';
+
 const styles = {
   container: {
     display: 'flex',
@@ -22,15 +24,13 @@ const styles = {
     ml: { sm: '10px', md: '75px', lg: '140px', xl: '0px' }
   },
   description: {
+    ...AppTypography.mulish16Medium,
     mt: 2,
     width: { xs: 272, sm: 350, md: 460 },
     height: { xs: 72, sm: 48 },
     ml: { sm: '10px', md: '90px', lg: '140px', xl: '0px' },
-    lineHeight: '150%',
-    color: colors.brown[800],
     letterSpacing: '0%',
-    fontWeight: 500,
-    fontSize: '16px'
+    color: colors.brown[800]
   },
   h4: {
     fontSize: { xs: 40, sm: 40, md: 48, lg: 48, xl: 48 },

--- a/app/shared/components/tables/CompositionTable/no-results-found/TableNoResultsFound.tsx
+++ b/app/shared/components/tables/CompositionTable/no-results-found/TableNoResultsFound.tsx
@@ -8,7 +8,7 @@ export default function TableNoResultsFound() {
   const t = useTranslations('table.composition.notFound');
   return (
     <TableRow data-testid="TableNoResultsFound">
-      <TableCell colSpan={1}>
+      <TableCell colSpan={1} sx={{ borderBottom: 0 }}>
         <Box sx={styles.container} data-testid="TableNoResultsFound-container">
           <Box sx={styles.image} data-testid="TableNoResultsFound-image">
             <Image src="/images/cat-no-results-found.svg" alt="No results found" fill />
@@ -16,12 +16,7 @@ export default function TableNoResultsFound() {
           <Typography variant="h4" sx={styles.h4} fontWeight="bold" data-testid="TableNoResultsFound-title">
             {t('title')}
           </Typography>
-          <Typography
-            sx={styles.description}
-            variant="subtitle2"
-            color="text.secondary"
-            data-testid="TableNoResultsFound-description"
-          >
+          <Typography sx={styles.description} color="text.secondary" data-testid="TableNoResultsFound-description">
             {t('description')}
           </Typography>
         </Box>

--- a/app/shared/components/tables/WorksTable/WorkTableSelection.tsx
+++ b/app/shared/components/tables/WorksTable/WorkTableSelection.tsx
@@ -4,6 +4,7 @@ import { ColumnDef } from '@tanstack/react-table';
 import { useTranslations } from 'next-intl';
 import { useCallback, useMemo } from 'react';
 
+import TableNoResultsFound from '../CompositionTable/no-results-found/TableNoResultsFound';
 import { getWorkTableColumnWidths } from './getColumnWidth';
 import {
   RenderActionCell,
@@ -174,6 +175,7 @@ export const WorkTableSection = () => {
   return (
     <EnhancedTable<ScientificWorkTableRow>
       data={data}
+      noResults={<TableNoResultsFound />}
       loading={isLoading}
       columns={columns}
       columnWidths={columnWidths}


### PR DESCRIPTION
## Description

Add proper empty state for Works table when filters/search return no rows.

## Type of change

- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open Works table.
2. Apply filters/search so no rows match.
3. Verify “Nothing found” placeholder is shown.
4. Confirm typography/spacing/alignment match the design system.

## Video / Screenshots

<img width="1685" height="697" alt="image" src="https://github.com/user-attachments/assets/89dc1acf-c67d-4e00-aa15-b0e7e0c5efb3" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
