### PR TITLE
Fix: add search icon to documents table

### DIFF
--- a/app/shared/components/tables/DocumentsTable/DocumentTableSelection.tsx
+++ b/app/shared/components/tables/DocumentsTable/DocumentTableSelection.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { ColumnDef } from '@tanstack/react-table';
 import { useTranslations } from 'next-intl';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import {
   RenderActionCell,
@@ -21,12 +21,16 @@ import MobileDocumentTable from './MobileDocumentTable/MobileDocumentTable';
 import { DocumentRecord } from '~/types/types/document.types';
 
 import { EnhancedTable } from '~/shared/components/enhanced-table/EnhancedTable';
+import { Search } from '~/shared/components/search/Search';
 import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
 
 export default function DocumentTableSelection({ documents }: { documents: DocumentRecord[] }) {
   const t = useTranslations('table.documents');
   const bp = useBreakpoints();
   const { isMobile, isTablet, isLaptop, isDesktop, isLaptopAndAbove } = bp;
+
+  const [search, setSearch] = useState('');
+  const searchOptions = useMemo(() => [], []);
 
   const columnWidths = useMemo(
     () =>
@@ -86,14 +90,17 @@ export default function DocumentTableSelection({ documents }: { documents: Docum
     []
   );
 
+  const searchNode = <Search search={search} setSearch={setSearch} options={searchOptions} />;
+
   if (isMobile || isTablet) {
-    return <MobileDocumentTable tableName={t('name')} data={documents} />;
+    return <MobileDocumentTable tableName={t('name')} data={documents} Search={searchNode} />;
   }
 
   return (
     <EnhancedTable
       data={documents}
       columns={baseColumns}
+      Search={searchNode}
       columnWidths={columnWidths}
       itemsPerPage={5}
       tableName={t('name')}


### PR DESCRIPTION
## Description

Fix Documents table search visibility by passing `Search` into `MobileDocumentTable` and `EnhancedTable`. No actual search/filter logic yet — input is controlled only.

## Type of change
- [x] Bug fix

## How to test
1. Open Documents table on desktop viewport.
2. Verify the search input is visible in the table header area.
3. Type into the search field — value should update (no filtering expected).

## Video / Screenshots


## Checklist
- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (not needed)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board
---

