### PR TITLE
Fix: follow up to #1088

### DIFF
--- a/app/shared/components/Header/SupportButton/SupportButton.tsx
+++ b/app/shared/components/Header/SupportButton/SupportButton.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mui/material';
-import Link from 'next/link';
 import React from 'react';
 
 import { SvgImage } from '~/components/svg-image/SvgImage';
@@ -7,6 +6,8 @@ import Button from '~/ds-components/button/Button';
 
 import { styles } from './SupportButton.styles';
 import type { SupportButtonData } from '~/types/types/header.type';
+
+import { Link } from '~/i18n/navigation';
 
 type SupportButtonProps = {
   data: SupportButtonData;


### PR DESCRIPTION
## Description

Fix locale-aware navigation links in mobile support us button to use the correct i18n Link.

## Type of change

- [x] Bug fix

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open the app, switch locale to en, and verify mobile support-us button link keep the current locale.

## Video / Screenshots

<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
