### PR TITLE
fix: content overflow on support us page

### DIFF
--- a/app/shared/components/blocks/payment-details/PaymentDetails.styles.ts
+++ b/app/shared/components/blocks/payment-details/PaymentDetails.styles.ts
@@ -4,7 +4,6 @@ export const styles = {
   buttonGroup: {
     backgroundColor: mainHexPallete.brown[50],
     p: '4px',
-
     width: { xs: '100%', sm: 'fit-content' },
 
     div: {
@@ -27,7 +26,6 @@ export const styles = {
     border: 'none',
     display: 'flex',
     alignItems: 'center',
-
     '&, &:hover': {
       background: 'transparent',
       borderRadius: '28px'
@@ -39,28 +37,36 @@ export const styles = {
     display: 'flex',
     flexDirection: 'column',
     gap: '16px',
+    width: '100%',
 
     '& h6.MuiTypography-root': {
       lineHeight: '150%',
       color: mainHexPallete.brown[500],
-      width: '115px'
+      width: { xs: '100%', sm: '150px', lg: '180px' },
+      flexShrink: 0
     },
 
     '& p.MuiTypography-root': {
-      lineHeight: '150%'
+      lineHeight: '150%',
+      width: '100%'
     }
   },
 
   paymentDetailsRow: {
     display: 'flex',
-    alignItems: 'center',
-    gap: { xs: '0px', sm: '25px' },
-    flexWrap: { xs: 'wrap', sm: 'nowrap' }
+    flexDirection: { xs: 'column', sm: 'row' },
+    justifyContent: 'flex-start',
+    alignItems: { xs: 'flex-start', sm: 'flex-start' },
+    gap: { xs: '4px', sm: '25px' },
+    width: '100%',
+    py: '4px'
   },
 
   iban: {
     display: 'flex',
-    gap: '8px'
+    gap: '8px',
+    width: '100%',
+    alignItems: 'center'
   },
 
   ibanText: {

--- a/app/shared/components/blocks/payment-details/PaymentDetails.tsx
+++ b/app/shared/components/blocks/payment-details/PaymentDetails.tsx
@@ -28,7 +28,7 @@ function PaymentDetails() {
   }, []);
 
   return (
-    <Box sx={{ mr: '24px' }} data-testid="PaymentDetails">
+    <Box data-testid="PaymentDetails">
       <ButtonGroup
         sx={switcherSx}
         defaultActiveButton={0}

--- a/app/shared/components/blocks/support-foundation/SupportFoundation.styles.ts
+++ b/app/shared/components/blocks/support-foundation/SupportFoundation.styles.ts
@@ -1,59 +1,42 @@
+import { mainHexPallete } from '~/ds-components/theme/colors';
+
 export const styles = {
   wrapper: {
-    display: 'grid',
-    gridTemplateColumns: {
-      xs: '1fr',
-      sm: '1fr',
-      md: 'repeat(12, 1fr)'
-    },
-    columnGap: {
-      xs: '16px',
-      sm: '24px',
-      md: '40px'
-    },
-    gridColumn: '1 / -1',
-    mt: { xs: '80px', sm: '108px', md: '156px', lg: '121px' }
+    display: 'contents'
   },
 
   sectionTitle: {
     mb: { xs: '48px', sm: '32px' },
-    gridColumn: { xs: '1 / -1', sm: '1 / -1' },
+    gridColumn: '1 / -1',
+    mt: { xs: '80px', sm: '108px', md: '156px', lg: '121px' },
     fontSize: {
       xs: '40px',
       md: '64px'
     }
   },
 
-  donationSection: {
-    display: 'grid',
-    gridColumn: { xs: '1', md: '1 / 9', lg: '1 / -1' },
-    gridTemplateColumns: {
-      xs: '1fr',
-      sm: 'repeat(8, 1fr)',
-      md: 'repeat(12, 1fr)'
-    },
-    columnGap: {
-      xs: '16px',
-      sm: '24px',
-      md: '40px'
-    }
-  },
-
   donationFormWrapper: {
-    gridColumn: { xs: '1', md: '1 / 11', lg: '1/6' },
+    gridColumn: { xs: '1 / -1', md: '1 / 11', lg: '1 / 6' },
     height: '565px'
   },
 
   infoSection: {
     width: '100%',
     mt: { xs: '70px', lg: 0 },
-    gridColumn: { xs: '1 / -1', sm: '1/ 6', md: '1 / -1', lg: '7 / -1' }
+    gridColumn: {
+      xs: '1 / -1',
+      sm: '1 / 8',
+      md: '1 / -5',
+      lg: '7 / -1'
+    }
   },
+
   sectionSubtitle: {
     width: '100%',
     mb: { xs: '32px', sm: '64px' },
-    textAlign: 'left',
-    textIndent: { xs: '15%', sm: '10%', lg: '25%' },
-    lineHeight: '160%'
+    textAlign: { xs: 'left', lg: 'justify' },
+    textIndent: { xs: '26%', sm: '15%', md: '14%', lg: '60%' },
+    lineHeight: '160%',
+    color: mainHexPallete.brown[700]
   }
 };

--- a/app/shared/components/blocks/support-foundation/SupportFoundation.tsx
+++ b/app/shared/components/blocks/support-foundation/SupportFoundation.tsx
@@ -1,10 +1,12 @@
 'use client';
+
 import { Box, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { useCallback } from 'react';
 
-import DonationForm from '../../forms/donation-form/DonationForm';
-import PaymentDetails from '../payment-details/PaymentDetails';
+import PaymentDetails from '~/components/blocks/payment-details/PaymentDetails';
+import DonationForm from '~/components/forms/donation-form/DonationForm';
+
 import { styles } from './SupportFoundation.styles';
 
 function SupportFoundation() {
@@ -17,16 +19,14 @@ function SupportFoundation() {
         {t('title')}
       </Typography>
 
-      <Box sx={styles.donationSection} data-testid="SupportFoundation-donationSection">
-        <Box sx={styles.donationFormWrapper}>
-          <DonationForm />
-        </Box>
-        <Box sx={styles.infoSection} data-testid="SupportFoundation-infoSection">
-          <Typography variant="body2" sx={styles.sectionSubtitle} data-testid="SupportFoundation-infoSection-subtitle">
-            {t.rich('subTitle', { b: bold })}
-          </Typography>
-          <PaymentDetails />
-        </Box>
+      <Box sx={styles.donationFormWrapper}>
+        <DonationForm />
+      </Box>
+      <Box sx={styles.infoSection} data-testid="SupportFoundation-infoSection">
+        <Typography variant="body2" sx={styles.sectionSubtitle} data-testid="SupportFoundation-infoSection-subtitle">
+          {t.rich('subTitle', { b: bold })}
+        </Typography>
+        <PaymentDetails />
       </Box>
     </Box>
   );

--- a/app/shared/components/design-system/all-components/copy-link/CopyLink.styles.ts
+++ b/app/shared/components/design-system/all-components/copy-link/CopyLink.styles.ts
@@ -4,7 +4,9 @@ const commonCopyLinkBaseStyles = {
   fontFamily: 'Mulish, Sans-serif',
   transition: 'color 0.2s ease',
   lineHeight: '110%',
-  textDecoration: 'none'
+  textDecoration: 'none',
+  wordBreak: 'break-all',
+  overflowWrap: 'break-word'
 };
 
 interface ColorConfig {
@@ -104,10 +106,13 @@ export const styles = {
     padding: 0,
     margin: 0,
     font: 'inherit',
-    outline: 'none'
+    outline: 'none',
+    maxWidth: '100%',
+    textAlign: 'left'
   },
 
   iconWrapper: {
-    transition: 'stroke 0.2s ease'
+    transition: 'stroke 0.2s ease',
+    flexShrink: 0
   }
 };


### PR DESCRIPTION
## Description

Fixed the responsive layout and grid alignment on the "Support the Foundation" page. These fixes include not only mobile layout but also tablet and desktop

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:

 ## How to test

1. Navigate to the `/support-us` page.
2. Open DevTools and enable mobile emulation (320x767 resolution).
3. Verify that the "All contributions..." text block and payment details match the design.
4. Switch to tablet and desktop views and ensure the text aligns perfectly with the vertical guidelines.

## Video / Screenshots


https://github.com/user-attachments/assets/d786a67d-5273-487b-8314-d6366bf2cba5


## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board