### PR TITLE
feat: create reusable OverflowMenu component

### DIFF
--- a/app/shared/components/design-system/all-components/overflow-menu/OverflowMenu.styles.ts
+++ b/app/shared/components/design-system/all-components/overflow-menu/OverflowMenu.styles.ts
@@ -1,0 +1,23 @@
+export const overflowMenuSx = {
+  menuListSx: {
+    maxWidth: '280px',
+    borderRadius: '8px',
+    boxShadow: '0px 4px 8px 0px rgba(0, 0, 0, 0.06)',
+    bgcolor: 'rgba(252, 252, 252, 1)',
+    padding: '4px 8px'
+  }
+};
+
+export const overflowMenuItemSx = {
+  menuItemContainerSx: {
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+    gap: '11px',
+    padding: '8px 0px'
+  },
+  menuLabelItemSx: {
+    fontWeight: '400',
+    fontSize: '16px'
+  }
+};

--- a/app/shared/components/design-system/all-components/overflow-menu/OverflowMenu.styles.ts
+++ b/app/shared/components/design-system/all-components/overflow-menu/OverflowMenu.styles.ts
@@ -1,5 +1,5 @@
 export const overflowMenuSx = {
-  menuListSx: {
+  menuContainerSx: {
     maxWidth: '280px',
     borderRadius: '8px',
     boxShadow: '0px 4px 8px 0px rgba(0, 0, 0, 0.06)',

--- a/app/shared/components/design-system/all-components/overflow-menu/OverflowMenu.test.tsx
+++ b/app/shared/components/design-system/all-components/overflow-menu/OverflowMenu.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import OverflowMenu from './OverflowMenu';
+
+describe('OverflowMenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const Trigger = (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button data-testid="trigger" type="button" {...props}>
+      open
+    </button>
+  );
+
+  it('should render trigger element', () => {
+    render(<OverflowMenu items={[]} trigger={<Trigger />} />);
+
+    expect(screen.getByTestId('trigger')).toBeInTheDocument();
+  });
+
+  it('should open menu on trigger click and sets aria attributes', async () => {
+    render(<OverflowMenu items={[{ id: 'a', label: 'Item A', onClick: jest.fn() }]} trigger={<Trigger />} />);
+
+    const trigger = screen.getByTestId('trigger');
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger.getAttribute('aria-controls')).toBeTruthy();
+
+    expect(await screen.findByRole('menu')).toBeInTheDocument();
+  });
+  it('should call original trigger onClick and still opens menu', async () => {
+    const triggerOnClick = jest.fn();
+
+    render(
+      <OverflowMenu
+        items={[{ id: 'a', label: 'Item A', onClick: jest.fn() }]}
+        trigger={<Trigger onClick={triggerOnClick} />}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(triggerOnClick).toHaveBeenCalled();
+    expect(await screen.findByRole('menu')).toBeInTheDocument();
+  });
+
+  it('should not render hidden items', async () => {
+    render(
+      <OverflowMenu
+        items={[
+          { id: 'visible', label: 'Visible', onClick: jest.fn() },
+          { id: 'hidden', label: 'Hidden', onClick: jest.fn(), hidden: true }
+        ]}
+        trigger={<Trigger />}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(await screen.findByRole('menu')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Visible/ })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /Hidden/ })).not.toBeInTheDocument();
+  });
+
+  it('should pass data-testid to Menu Paper', async () => {
+    render(
+      <OverflowMenu
+        dataTestId="my-menu-paper"
+        items={[{ id: 'a', label: 'Item A', onClick: jest.fn() }]}
+        trigger={<Trigger />}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(await screen.findByTestId('my-menu-paper')).toBeInTheDocument();
+  });
+
+  it('should call item.onClick and close menu by clicking an item', async () => {
+    const onItemClick = jest.fn();
+
+    render(<OverflowMenu items={[{ id: 'a', label: 'Item A', onClick: onItemClick }]} trigger={<Trigger />} />);
+
+    fireEvent.click(screen.getByTestId('trigger'));
+    const item = await screen.findByRole('menuitem', { name: /Item A/ });
+
+    fireEvent.click(item);
+
+    expect(onItemClick).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should disable item has aria-disabled=true and does not call onClick', async () => {
+    const onItemClick = jest.fn();
+
+    render(
+      <OverflowMenu
+        items={[{ id: 'a', label: 'Item A', onClick: onItemClick, disabled: true }]}
+        trigger={<Trigger />}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    const item = await screen.findByRole('menuitem', { name: /Item A/ });
+    expect(item).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(item);
+    expect(onItemClick).not.toHaveBeenCalled();
+  });
+});

--- a/app/shared/components/design-system/all-components/overflow-menu/OverflowMenu.tsx
+++ b/app/shared/components/design-system/all-components/overflow-menu/OverflowMenu.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { Menu, type SxProps, Theme } from '@mui/material';
+import React, { useId, useMemo, useState } from 'react';
+
+import { overflowMenuSx } from './OverflowMenu.styles';
+import { OverflowMenuItem } from './OverflowMenuItem';
+import type { OverflowMenuItemConfig, TriggerProps } from '~/types/types/menu.types';
+
+import { sxToArray } from '~/lib/utils/sxToArray';
+
+interface OverflowMenuProps {
+  items: OverflowMenuItemConfig[];
+  trigger: React.ReactElement<TriggerProps>;
+  menuContainerSx?: SxProps<Theme>;
+  menuListSx?: SxProps<Theme>;
+  dataTestId?: string;
+}
+
+export default function OverflowMenu({
+  items,
+  trigger,
+  menuContainerSx,
+  menuListSx,
+  dataTestId
+}: Readonly<OverflowMenuProps>) {
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const open = Boolean(menuAnchor);
+  const menuId = useId();
+
+  const visibleItems = useMemo(() => items.filter((item) => !item.hidden), [items]);
+
+  const handleOpen = (e: React.MouseEvent<HTMLElement>) => setMenuAnchor(e.currentTarget);
+  const handleClose = () => setMenuAnchor(null);
+
+  const triggerEl = React.cloneElement(trigger, {
+    ...trigger.props,
+    'aria-haspopup': 'menu',
+    'aria-controls': open ? menuId : undefined,
+    'aria-expanded': open ? 'true' : undefined,
+    onClick: (e: React.MouseEvent<HTMLElement>) => {
+      trigger.props.onClick?.(e);
+      handleOpen(e);
+    }
+  });
+
+  return (
+    <React.Fragment>
+      {triggerEl}
+
+      <Menu
+        id={menuId}
+        anchorEl={menuAnchor}
+        open={open}
+        onClose={handleClose}
+        PaperProps={{
+          sx: menuContainerSx,
+          'data-testid': dataTestId
+        }}
+        MenuListProps={{
+          sx: [overflowMenuSx.menuListSx, ...sxToArray(menuListSx)]
+        }}
+      >
+        {visibleItems.map((item) => (
+          <OverflowMenuItem
+            key={item.id}
+            label={item.label}
+            icon={item.icon}
+            iconPosition={item.iconPosition}
+            containerSx={item.containerSx}
+            labelSx={item.labelSx}
+            disabled={item.disabled}
+            onClick={() => {
+              handleClose();
+              item.onClick();
+            }}
+          />
+        ))}
+      </Menu>
+    </React.Fragment>
+  );
+}

--- a/app/shared/components/design-system/all-components/overflow-menu/OverflowMenu.tsx
+++ b/app/shared/components/design-system/all-components/overflow-menu/OverflowMenu.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Menu, type SxProps, Theme } from '@mui/material';
-import React, { useId, useMemo, useState } from 'react';
+import type { MouseEvent, ReactElement } from 'react';
+import { cloneElement, Fragment, useId, useMemo, useState } from 'react';
 
 import { overflowMenuSx } from './OverflowMenu.styles';
 import { OverflowMenuItem } from './OverflowMenuItem';
@@ -11,7 +12,7 @@ import { sxToArray } from '~/lib/utils/sxToArray';
 
 interface OverflowMenuProps {
   items: OverflowMenuItemConfig[];
-  trigger: React.ReactElement<TriggerProps>;
+  trigger: ReactElement<TriggerProps>;
   menuContainerSx?: SxProps<Theme>;
   menuListSx?: SxProps<Theme>;
   dataTestId?: string;
@@ -30,22 +31,22 @@ export default function OverflowMenu({
 
   const visibleItems = useMemo(() => items.filter((item) => !item.hidden), [items]);
 
-  const handleOpen = (e: React.MouseEvent<HTMLElement>) => setMenuAnchor(e.currentTarget);
+  const handleOpen = (e: MouseEvent<HTMLElement>) => setMenuAnchor(e.currentTarget);
   const handleClose = () => setMenuAnchor(null);
 
-  const triggerEl = React.cloneElement(trigger, {
+  const triggerEl = cloneElement(trigger, {
     ...trigger.props,
     'aria-haspopup': 'menu',
     'aria-controls': open ? menuId : undefined,
     'aria-expanded': open ? 'true' : undefined,
-    onClick: (e: React.MouseEvent<HTMLElement>) => {
+    onClick: (e: MouseEvent<HTMLElement>) => {
       trigger.props.onClick?.(e);
       handleOpen(e);
     }
   });
 
   return (
-    <React.Fragment>
+    <Fragment>
       {triggerEl}
 
       <Menu
@@ -54,11 +55,11 @@ export default function OverflowMenu({
         open={open}
         onClose={handleClose}
         PaperProps={{
-          sx: menuContainerSx,
+          sx: [overflowMenuSx.menuContainerSx, ...sxToArray(menuContainerSx)],
           'data-testid': dataTestId
         }}
         MenuListProps={{
-          sx: [overflowMenuSx.menuListSx, ...sxToArray(menuListSx)]
+          sx: menuListSx
         }}
       >
         {visibleItems.map((item) => (
@@ -77,6 +78,6 @@ export default function OverflowMenu({
           />
         ))}
       </Menu>
-    </React.Fragment>
+    </Fragment>
   );
 }

--- a/app/shared/components/design-system/all-components/overflow-menu/OverflowMenuItem.test.tsx
+++ b/app/shared/components/design-system/all-components/overflow-menu/OverflowMenuItem.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { OverflowMenuItem } from './OverflowMenuItem';
+
+describe('OverflowMenuItem', () => {
+  it('should render left icon by default', () => {
+    render(<OverflowMenuItem label="Label" icon={<span data-testid="icon" />} onClick={jest.fn()} />);
+
+    const icon = screen.getByTestId('icon');
+    expect(icon).toBeInTheDocument();
+
+    const menuItem = screen.getByRole('menuitem', { name: /Label/ });
+    expect(menuItem).toBeInTheDocument();
+  });
+
+  it('should render right icon when iconPosition="right"', () => {
+    render(
+      <OverflowMenuItem label="Label" icon={<span data-testid="icon" />} iconPosition="right" onClick={jest.fn()} />
+    );
+
+    const menuItem = screen.getByRole('menuitem', { name: /Label/ });
+    const icon = screen.getByTestId('icon');
+
+    const labelNode = screen.getByText('Label');
+    expect(labelNode.compareDocumentPosition(icon) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(menuItem).toBeInTheDocument();
+  });
+
+  it('should render Typography for string label', () => {
+    render(<OverflowMenuItem label="Hello" onClick={jest.fn()} />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('Hello').tagName.toLowerCase()).toBe('span');
+  });
+
+  it('should render ReactNode label via Box branch', () => {
+    render(<OverflowMenuItem label={<span data-testid="custom-label">NodeLabel</span>} onClick={jest.fn()} />);
+
+    expect(screen.getByTestId('custom-label')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /NodeLabel/ })).toBeInTheDocument();
+  });
+
+  it('should call onClick when enabled', () => {
+    const onClick = jest.fn();
+    render(<OverflowMenuItem label="ClickMe" onClick={onClick} />);
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /ClickMe/ }));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('should not call onClick when disabled', () => {
+    const onClick = jest.fn();
+    render(<OverflowMenuItem label="Disabled" onClick={onClick} disabled />);
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /Disabled/ }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/app/shared/components/design-system/all-components/overflow-menu/OverflowMenuItem.tsx
+++ b/app/shared/components/design-system/all-components/overflow-menu/OverflowMenuItem.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Box, MenuItem, type SxProps, Theme, Typography } from '@mui/material';
+
+import { overflowMenuItemSx } from './OverflowMenu.styles';
+import type { IconPosition, OverflowMenuItemConfig } from '~/types/types/menu.types';
+
+import { sxToArray } from '~/lib/utils/sxToArray';
+
+type OverflowMenuItemProps = Omit<OverflowMenuItemConfig, 'id' | 'hidden'> & {
+  iconPosition?: IconPosition;
+  containerSx?: SxProps<Theme>;
+  labelSx?: SxProps<Theme>;
+};
+
+export function OverflowMenuItem({
+  label,
+  icon,
+  iconPosition = 'left',
+  containerSx,
+  labelSx,
+  disabled,
+  onClick
+}: Readonly<OverflowMenuItemProps>) {
+  return (
+    <MenuItem disabled={disabled} onClick={disabled ? undefined : onClick}>
+      <Box sx={[overflowMenuItemSx.menuItemContainerSx, ...sxToArray(containerSx)]}>
+        {icon && iconPosition === 'left' ? icon : null}
+
+        {typeof label === 'string' ? (
+          <Typography component="span" sx={labelSx}>
+            {label}
+          </Typography>
+        ) : (
+          <Box sx={[overflowMenuItemSx.menuLabelItemSx, ...sxToArray(labelSx)]}>{label}</Box>
+        )}
+
+        {icon && iconPosition === 'right' ? icon : null}
+      </Box>
+    </MenuItem>
+  );
+}

--- a/app/shared/components/tables/CompositionTable/MusicTableCells.styles.ts
+++ b/app/shared/components/tables/CompositionTable/MusicTableCells.styles.ts
@@ -50,13 +50,10 @@ export const groupLabelRowSx: SxProps<Theme> = {
   alignItems: 'center'
 };
 
-export const overflowMenuSx = {
-  menuLabelItemSx: {
-    fontFamily: 'Mulish',
-    fontWeight: '500',
-    fontStyle: 'Medium',
-    fontSize: '16px',
-    lineHeight: '150%',
-    letterSpacing: '0%'
-  }
+export const menuLabelItemSx: SxProps<Theme> = {
+  fontFamily: 'Mulish',
+  fontWeight: '500',
+  fontSize: '16px',
+  lineHeight: '150%',
+  letterSpacing: '0%'
 };

--- a/app/shared/components/tables/CompositionTable/MusicTableCells.styles.ts
+++ b/app/shared/components/tables/CompositionTable/MusicTableCells.styles.ts
@@ -49,3 +49,14 @@ export const groupLabelRowSx: SxProps<Theme> = {
   justifyContent: 'space-between',
   alignItems: 'center'
 };
+
+export const overflowMenuSx = {
+  menuLabelItemSx: {
+    fontFamily: 'Mulish',
+    fontWeight: '500',
+    fontStyle: 'Medium',
+    fontSize: '16px',
+    lineHeight: '150%',
+    letterSpacing: '0%'
+  }
+};

--- a/app/shared/components/tables/CompositionTable/MusicTableCells.test.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableCells.test.tsx
@@ -236,9 +236,9 @@ describe('MusicTableCells', () => {
 
       const notesText = screen.getByText('viewSheetMusic');
       const notesItem = notesText.closest('[role="menuitem"]');
-      expect(notesItem).toBeTruthy();
+      if (!notesItem) throw new Error('Menuitem not found');
 
-      fireEvent.click(notesItem!);
+      fireEvent.click(notesItem);
     });
 
     it('should disable play menu item when canPlay=false', () => {

--- a/app/shared/components/tables/CompositionTable/MusicTableCells.test.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableCells.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { CellContext, Row } from '@tanstack/react-table';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import {
@@ -35,9 +35,7 @@ jest.mock('~/i18n/navigation', () => ({
 }));
 
 jest.mock('~/shared/components/design-system/all-components/Ellipsis/Ellipsis', () => {
-  const Ellipsis = ({ text }: { text: string }) => {
-    return <div>{text}</div>;
-  };
+  const Ellipsis = ({ text }: { text: string }) => <div>{text}</div>;
   return { __esModule: true, Ellipsis };
 });
 
@@ -80,6 +78,12 @@ const mockCellContext = {
 describe('MusicTableCells', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseCompositionPlayback.mockReturnValue({
+      canPlay: true,
+      isCurrentTrack: false,
+      isPlaying: false,
+      handlePlayClick: jest.fn()
+    });
   });
 
   describe('Header renderers', () => {
@@ -92,6 +96,7 @@ describe('MusicTableCells', () => {
           <RenderGenreHeader />
         </>
       );
+
       expect(screen.getByText('opus')).toBeInTheDocument();
       expect(screen.getByText('name')).toBeInTheDocument();
       expect(screen.getByText('year')).toBeInTheDocument();
@@ -103,20 +108,22 @@ describe('MusicTableCells', () => {
     it('should render name and year cells with values', () => {
       const nameCell = renderNameCell({ getValue: () => 'Poem about the Forest' } as CellContext<Music, unknown>);
       const yearCell = renderYearCell({ getValue: () => '1918' } as CellContext<Music, unknown>);
+
       const { getByText } = render(
         <>
           {nameCell}
           {yearCell}
         </>
       );
+
       expect(getByText('Poem about the Forest')).toBeInTheDocument();
       expect(getByText('1918')).toBeInTheDocument();
     });
 
     it('should render genre cell joined with commas', () => {
       const genreCell = RenderGenreCell({ getValue: () => ['Classical', 'Romantic'] } as CellContext<Music, unknown>);
-      const { getByText } = render(<>{genreCell}</>);
-      expect(getByText('Classical, Romantic')).toBeInTheDocument();
+      render(<>{genreCell}</>);
+      expect(screen.getByText('Classical, Romantic')).toBeInTheDocument();
     });
 
     it('should render nothing if no genres', () => {
@@ -127,25 +134,7 @@ describe('MusicTableCells', () => {
   });
 
   describe('PlayCell', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-
-      mockUseCompositionPlayback.mockReturnValue({
-        canPlay: true,
-        isCurrentTrack: false,
-        isPlaying: false,
-        handlePlayClick: jest.fn()
-      });
-    });
-
     it('should render play icon when canPlay=true', () => {
-      mockUseCompositionPlayback.mockReturnValue({
-        canPlay: true,
-        isCurrentTrack: false,
-        isPlaying: false,
-        handlePlayClick: jest.fn()
-      });
-
       render(RenderPlayCell(mockCellContext));
       expect(screen.getByTestId('mock-svg')).toBeInTheDocument();
     });
@@ -175,6 +164,7 @@ describe('MusicTableCells', () => {
       });
 
       render(RenderPlayCell(mockCellContext));
+
       fireEvent.click(screen.getByRole('button', { hidden: true }));
       expect(handlePlayClick).toHaveBeenCalled();
     });
@@ -182,24 +172,29 @@ describe('MusicTableCells', () => {
 
   describe('ActionsCell', () => {
     it('should render button when desktop', () => {
-      mockUseBreakpoints.mockReturnValue({
-        isDesktop: true
-      });
+      mockUseBreakpoints.mockReturnValue({ isDesktop: true });
+
       const onAction = jest.fn();
-      const { getByText } = render(RenderActionsCell(mockCellContext, onAction));
-      const desktopBtn = getByText('viewSheetMusic');
+      render(RenderActionsCell(mockCellContext, onAction));
+
+      const desktopBtn = screen.getByText('viewSheetMusic');
       expect(desktopBtn).toBeInTheDocument();
+
       fireEvent.click(desktopBtn);
-      expect(onAction).toHaveBeenCalled();
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(onAction).toHaveBeenCalledWith({
+        composition: mockMusic.name,
+        notes: mockMusic.sheetMusic
+      });
     });
 
     it('should render icon button on laptop', () => {
-      mockUseBreakpoints.mockReturnValue({
-        isLaptop: true
-      });
+      mockUseBreakpoints.mockReturnValue({ isLaptop: true });
+
       const onAction = jest.fn();
-      const { getByAltText } = render(RenderActionsCell(mockCellContext, onAction));
-      expect(getByAltText('viewSheetMusic')).toBeInTheDocument();
+      render(RenderActionsCell(mockCellContext, onAction));
+
+      expect(screen.getByAltText('viewSheetMusic')).toBeInTheDocument();
     });
 
     it('should open overflow menu and render play item', () => {
@@ -221,10 +216,11 @@ describe('MusicTableCells', () => {
       expect(screen.getByText('viewSheetMusic')).toBeInTheDocument();
 
       fireEvent.click(screen.getByTestId('Artistry-overflowMenuButton'));
-      expect(screen.queryByRole('menuitem', { name: 'viewSheetMusic' })).not.toBeInTheDocument();
+
+      expect(screen.queryByRole('menuitem', { name: /viewSheetMusic/i })).not.toBeInTheDocument();
     });
 
-    it('should render "viewSheetMusic" in menu on mobile and call onAction', () => {
+    it('should render "viewSheetMusic" in menu on mobile and call onAction', async () => {
       mockUseBreakpoints.mockReturnValue({ isDesktop: false, isLaptop: false });
 
       const onAction = jest.fn();
@@ -233,12 +229,20 @@ describe('MusicTableCells', () => {
       expect(screen.queryByText('viewSheetMusic')).not.toBeInTheDocument();
 
       fireEvent.click(screen.getByTestId('Artistry-overflowMenuButton'));
+      expect(screen.getByRole('menu')).toBeInTheDocument();
 
-      const notesText = screen.getByText('viewSheetMusic');
-      const notesItem = notesText.closest('[role="menuitem"]');
-      if (!notesItem) throw new Error('Menuitem not found');
-
+      const notesItem = screen.getByRole('menuitem', { name: /viewSheetMusic/i });
       fireEvent.click(notesItem);
+
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(onAction).toHaveBeenCalledWith({
+        composition: mockMusic.name,
+        notes: mockMusic.sheetMusic
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
     });
 
     it('should disable play menu item when canPlay=false', () => {
@@ -261,26 +265,19 @@ describe('MusicTableCells', () => {
 
   describe('Group renderers', () => {
     it('should render opus label', () => {
-      const { getByText } = render(renderOpusGroupLabel([mockMusic]));
-      expect(getByText('op.50')).toBeInTheDocument();
+      render(renderOpusGroupLabel([mockMusic]));
+      expect(screen.getByText('op.50')).toBeInTheDocument();
     });
 
     it('should render opus title label', () => {
-      const { getByText } = render(renderOpusTitleGroupLabel([mockMusic]));
-      expect(getByText('Symphony No. 3 in B minor')).toBeInTheDocument();
+      render(renderOpusTitleGroupLabel([mockMusic]));
+      expect(screen.getByText('Symphony No. 3 in B minor')).toBeInTheDocument();
     });
   });
 
   describe('RenderExpanderCell', () => {
     it('should render expander icon for group rows', () => {
       mockUseBreakpoints.mockReturnValue({ isMobile: true, isTablet: false });
-
-      mockUseCompositionPlayback.mockReturnValue({
-        canPlay: true,
-        isCurrentTrack: false,
-        isPlaying: false,
-        handlePlayClick: jest.fn()
-      });
 
       render(RenderExpanderCell(mockCellContext));
       expect(screen.getByTestId('mock-svg')).toBeInTheDocument();

--- a/app/shared/components/tables/CompositionTable/MusicTableCells.test.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableCells.test.tsx
@@ -8,7 +8,6 @@ import {
   RenderExpanderCell,
   RenderGenreCell,
   RenderGenreHeader,
-  renderGroupActions,
   renderNameCell,
   RenderNameHeader,
   renderOpusGroupLabel,
@@ -20,8 +19,12 @@ import {
 } from './MusicTableCells';
 import { Music } from '~/types/types/enhancedTable';
 
-import { useAudioPlayer } from '~/shared/context/AudioPlayerContext';
 import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
+import { useCompositionPlayback } from '~/shared/hooks/use-composition-playback/useCompositionPlayback';
+
+jest.mock('~/shared/hooks/use-composition-playback/useCompositionPlayback', () => ({
+  useCompositionPlayback: jest.fn()
+}));
 
 jest.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key
@@ -43,14 +46,10 @@ jest.mock('~/components/colored-svg/ColoredSvg', () => {
   return { __esModule: true, Svg };
 });
 
-jest.mock('~/shared/context/AudioPlayerContext', () => ({
-  useAudioPlayer: jest.fn()
-}));
-
 jest.mock('~/shared/hooks/use-breakpoints/useBreakpoints', () => jest.fn());
 
-const mockUseAudioPlayer = useAudioPlayer as jest.Mock;
 const mockUseBreakpoints = useBreakpoints as jest.Mock;
+const mockUseCompositionPlayback = useCompositionPlayback as jest.Mock;
 
 const mockMusic: Music = {
   id: '1',
@@ -77,13 +76,6 @@ const mockRow = {
 const mockCellContext = {
   row: mockRow
 } as CellContext<Music, unknown>;
-
-const useAudioPlayerMockReturn = {
-  playTrack: jest.fn(),
-  togglePlay: jest.fn(),
-  isPlaying: true,
-  src: `/api/blob-url?blobName=${encodeURIComponent(mockMusic.name)}&folderName=compositions`
-};
 
 describe('MusicTableCells', () => {
   beforeEach(() => {
@@ -135,27 +127,56 @@ describe('MusicTableCells', () => {
   });
 
   describe('PlayCell', () => {
-    it('should render play icon', () => {
-      mockUseAudioPlayer.mockReturnValue(useAudioPlayerMockReturn);
-      const { getByTestId } = render(RenderPlayCell(mockCellContext));
-      expect(getByTestId('mock-svg')).toBeInTheDocument();
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      mockUseCompositionPlayback.mockReturnValue({
+        canPlay: true,
+        isCurrentTrack: false,
+        isPlaying: false,
+        handlePlayClick: jest.fn()
+      });
     });
 
-    it('should call playTrack when clicked if different track', () => {
-      mockUseAudioPlayer.mockReturnValue({ ...useAudioPlayerMockReturn, src: 'different-src' });
-      const { getByRole } = render(RenderPlayCell(mockCellContext));
-      fireEvent.click(getByRole('button', { hidden: true }));
-      expect(useAudioPlayerMockReturn.playTrack).toHaveBeenCalledWith(
-        expect.stringContaining('compositions'),
-        mockMusic.name
-      );
+    it('should render play icon when canPlay=true', () => {
+      mockUseCompositionPlayback.mockReturnValue({
+        canPlay: true,
+        isCurrentTrack: false,
+        isPlaying: false,
+        handlePlayClick: jest.fn()
+      });
+
+      render(RenderPlayCell(mockCellContext));
+      expect(screen.getByTestId('mock-svg')).toBeInTheDocument();
     });
 
-    it('should call togglePlay when same track is playing', () => {
-      mockUseAudioPlayer.mockReturnValue(useAudioPlayerMockReturn);
-      const { getByRole } = render(RenderPlayCell(mockCellContext));
-      fireEvent.click(getByRole('button', { hidden: true }));
-      expect(useAudioPlayerMockReturn.togglePlay).toHaveBeenCalled();
+    it('should not render icon when canPlay=false', () => {
+      mockUseCompositionPlayback.mockReturnValue({
+        canPlay: false,
+        isCurrentTrack: false,
+        isPlaying: false,
+        handlePlayClick: jest.fn()
+      });
+
+      render(RenderPlayCell(mockCellContext));
+
+      expect(screen.queryByTestId('mock-svg')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { hidden: true })).not.toBeInTheDocument();
+    });
+
+    it('should call handlePlayClick on click', () => {
+      const handlePlayClick = jest.fn();
+
+      mockUseCompositionPlayback.mockReturnValue({
+        canPlay: true,
+        isCurrentTrack: false,
+        isPlaying: false,
+        handlePlayClick
+      });
+
+      render(RenderPlayCell(mockCellContext));
+      fireEvent.click(screen.getByRole('button', { hidden: true }));
+      expect(handlePlayClick).toHaveBeenCalled();
     });
   });
 
@@ -180,6 +201,62 @@ describe('MusicTableCells', () => {
       const { getByAltText } = render(RenderActionsCell(mockCellContext, onAction));
       expect(getByAltText('viewSheetMusic')).toBeInTheDocument();
     });
+
+    it('should open overflow menu and render play item', () => {
+      mockUseBreakpoints.mockReturnValue({ isDesktop: false, isLaptop: false });
+
+      render(RenderActionsCell(mockCellContext, jest.fn()));
+
+      fireEvent.click(screen.getByTestId('Artistry-overflowMenuButton'));
+
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'listenToComposition' })).toBeInTheDocument();
+    });
+
+    it('should not render "viewSheetMusic" in menu when showNotesInline=true', () => {
+      mockUseBreakpoints.mockReturnValue({ isDesktop: true, isLaptop: false });
+
+      render(RenderActionsCell(mockCellContext, jest.fn()));
+
+      expect(screen.getByText('viewSheetMusic')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('Artistry-overflowMenuButton'));
+      expect(screen.queryByRole('menuitem', { name: 'viewSheetMusic' })).not.toBeInTheDocument();
+    });
+
+    it('should render "viewSheetMusic" in menu on mobile and call onAction', () => {
+      mockUseBreakpoints.mockReturnValue({ isDesktop: false, isLaptop: false });
+
+      const onAction = jest.fn();
+      render(RenderActionsCell(mockCellContext, onAction));
+
+      expect(screen.queryByText('viewSheetMusic')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('Artistry-overflowMenuButton'));
+
+      const notesText = screen.getByText('viewSheetMusic');
+      const notesItem = notesText.closest('[role="menuitem"]');
+      expect(notesItem).toBeTruthy();
+
+      fireEvent.click(notesItem!);
+    });
+
+    it('should disable play menu item when canPlay=false', () => {
+      mockUseBreakpoints.mockReturnValue({ isDesktop: false, isLaptop: false });
+
+      mockUseCompositionPlayback.mockReturnValue({
+        canPlay: false,
+        isCurrentTrack: false,
+        isPlaying: false,
+        handlePlayClick: jest.fn()
+      });
+
+      render(RenderActionsCell(mockCellContext, jest.fn()));
+      fireEvent.click(screen.getByTestId('Artistry-overflowMenuButton'));
+
+      const playItem = screen.getByRole('menuitem', { name: 'listenToComposition' });
+      expect(playItem).toHaveAttribute('aria-disabled', 'true');
+    });
   });
 
   describe('Group renderers', () => {
@@ -192,21 +269,21 @@ describe('MusicTableCells', () => {
       const { getByText } = render(renderOpusTitleGroupLabel([mockMusic]));
       expect(getByText('Symphony No. 3 in B minor')).toBeInTheDocument();
     });
-
-    it('should render group actions icon', () => {
-      const { getByAltText } = render(renderGroupActions());
-      expect(getByAltText('menu')).toBeInTheDocument();
-    });
   });
 
   describe('RenderExpanderCell', () => {
     it('should render expander icon for group rows', () => {
-      mockUseBreakpoints.mockReturnValue({
-        isMobile: true
+      mockUseBreakpoints.mockReturnValue({ isMobile: true, isTablet: false });
+
+      mockUseCompositionPlayback.mockReturnValue({
+        canPlay: true,
+        isCurrentTrack: false,
+        isPlaying: false,
+        handlePlayClick: jest.fn()
       });
-      mockUseAudioPlayer.mockReturnValue(useAudioPlayerMockReturn);
-      const { getByTestId } = render(RenderExpanderCell(mockCellContext));
-      expect(getByTestId('mock-svg')).toBeInTheDocument();
+
+      render(RenderExpanderCell(mockCellContext));
+      expect(screen.getByTestId('mock-svg')).toBeInTheDocument();
     });
   });
 });

--- a/app/shared/components/tables/CompositionTable/MusicTableCells.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableCells.tsx
@@ -11,7 +11,7 @@ import {
   headerTypographySx,
   iconButtonSecondaryOutlinedSx,
   iconButtonSecondaryPlainSx,
-  overflowMenuSx,
+  menuLabelItemSx,
   playCellSx
 } from './MusicTableCells.styles';
 import { IconButtonColorVariant, IconButtonVariant } from '~/types/enums/common.enums';
@@ -131,7 +131,7 @@ export const ActionsCell: React.FC<RowProp> = ({ row, onAction }) => {
         />
       ),
       disabled: !canPlay,
-      labelSx: overflowMenuSx.menuLabelItemSx,
+      labelSx: menuLabelItemSx,
       onClick: handlePlayClick
     },
     {
@@ -140,7 +140,7 @@ export const ActionsCell: React.FC<RowProp> = ({ row, onAction }) => {
       icon: <SvgImage src="/icons/music-4.svg" alt={t('viewSheetMusic')} width={24} height={24} />,
       disabled: !rowData.sheetMusic,
       hidden: showNotesInline,
-      labelSx: overflowMenuSx.menuLabelItemSx,
+      labelSx: menuLabelItemSx,
       onClick: handleNotesClick
     }
   ];

--- a/app/shared/components/tables/CompositionTable/MusicTableCells.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableCells.tsx
@@ -6,7 +6,6 @@ import { useTranslations } from 'next-intl';
 
 import Button from '~/ds-components/button/Button';
 
-import OverflowMenu from '../../design-system/all-components/overflow-menu/OverflowMenu';
 import {
   actionsCellContainerSx,
   headerTypographySx,
@@ -24,6 +23,7 @@ import PlayIcon from '~/public/icons/play.svg';
 import { Svg } from '~/shared/components/colored-svg/ColoredSvg';
 import { Ellipsis } from '~/shared/components/design-system/all-components/Ellipsis/Ellipsis';
 import { IconButton } from '~/shared/components/design-system/all-components/icon-button/IconButton';
+import OverflowMenu from '~/shared/components/design-system/all-components/overflow-menu/OverflowMenu';
 import { mainHexPallete } from '~/shared/components/design-system/all-components/theme/colors';
 import { SvgImage } from '~/shared/components/svg-image/SvgImage';
 import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';

--- a/app/shared/components/tables/CompositionTable/MusicTableCells.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableCells.tsx
@@ -6,15 +6,18 @@ import { useTranslations } from 'next-intl';
 
 import Button from '~/ds-components/button/Button';
 
+import OverflowMenu from '../../design-system/all-components/overflow-menu/OverflowMenu';
 import {
   actionsCellContainerSx,
   headerTypographySx,
   iconButtonSecondaryOutlinedSx,
   iconButtonSecondaryPlainSx,
+  overflowMenuSx,
   playCellSx
 } from './MusicTableCells.styles';
 import { IconButtonColorVariant, IconButtonVariant } from '~/types/enums/common.enums';
 import type { CompositionWithNotes, Music } from '~/types/types/enhancedTable';
+import type { OverflowMenuItemConfig } from '~/types/types/menu.types';
 
 import PauseIcon from '~/public/icons/pause.svg';
 import PlayIcon from '~/public/icons/play.svg';
@@ -23,8 +26,8 @@ import { Ellipsis } from '~/shared/components/design-system/all-components/Ellip
 import { IconButton } from '~/shared/components/design-system/all-components/icon-button/IconButton';
 import { mainHexPallete } from '~/shared/components/design-system/all-components/theme/colors';
 import { SvgImage } from '~/shared/components/svg-image/SvgImage';
-import { useAudioPlayer } from '~/shared/context/AudioPlayerContext';
 import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
+import { useCompositionPlayback } from '~/shared/hooks/use-composition-playback/useCompositionPlayback';
 
 type RowProp = Readonly<{ row: Row<Music>; onAction?: (data: CompositionWithNotes) => void }>;
 
@@ -80,23 +83,13 @@ export const RenderGenreCell = (info: CellContext<Music, unknown>) => {
 
 export const PlayCell: React.FC<RowProp> = ({ row }) => {
   const rowData = row.original;
-  const { playTrack, togglePlay, isPlaying, src } = useAudioPlayer();
+  const { canPlay, isCurrentTrack, isPlaying, handlePlayClick } = useCompositionPlayback(rowData);
 
-  if (!rowData.audioAvailable) return <Box />;
-
-  const trackUrl = `/api/blob-url?blobName=${encodeURIComponent(rowData.name)}&folderName=compositions`;
-  const isCurrentTrack = src?.startsWith(trackUrl);
+  if (!canPlay) return <Box />;
 
   return (
     <Box sx={playCellSx}>
-      <IconButton
-        size="small"
-        type={IconButtonVariant.icon}
-        onClick={() => {
-          if (isCurrentTrack) togglePlay();
-          else playTrack(trackUrl, rowData.name);
-        }}
-      >
+      <IconButton size="small" type={IconButtonVariant.icon} onClick={handlePlayClick}>
         <Svg
           Component={isCurrentTrack && isPlaying ? PauseIcon : PlayIcon}
           alt="play/pause"
@@ -113,25 +106,56 @@ export const ActionsCell: React.FC<RowProp> = ({ row, onAction }) => {
   const rowData = row.original;
   const t = useTranslations('table.buttons');
   const { isDesktop, isLaptop } = useBreakpoints();
-  const shouldRender = isDesktop || isLaptop;
 
-  const handleActionClick = () => {
+  const showNotesInline = isDesktop || isLaptop;
+
+  const { canPlay, isCurrentTrack, isPlaying, handlePlayClick } = useCompositionPlayback(rowData);
+
+  const handleNotesClick = () => {
     if (onAction && rowData.sheetMusic) {
       onAction({ composition: rowData.name, notes: rowData.sheetMusic });
     }
   };
 
+  const menuItems: OverflowMenuItemConfig[] = [
+    {
+      id: 'play',
+      label: t('listenToComposition'),
+      icon: (
+        <Svg
+          Component={isCurrentTrack && isPlaying ? PauseIcon : PlayIcon}
+          alt="play/pause"
+          width="24px"
+          height="24px"
+          color={mainHexPallete.blue[800]}
+        />
+      ),
+      disabled: !canPlay,
+      labelSx: overflowMenuSx.menuLabelItemSx,
+      onClick: handlePlayClick
+    },
+    {
+      id: 'notes',
+      label: t('viewSheetMusic'),
+      icon: <SvgImage src="/icons/music-4.svg" alt={t('viewSheetMusic')} width={24} height={24} />,
+      disabled: !rowData.sheetMusic,
+      hidden: showNotesInline,
+      labelSx: overflowMenuSx.menuLabelItemSx,
+      onClick: handleNotesClick
+    }
+  ];
+
   return (
     <Box sx={actionsCellContainerSx}>
       {rowData.sheetAvailable &&
-        shouldRender &&
+        showNotesInline &&
         (isDesktop ? (
-          <Button onClick={handleActionClick} variant="outlined">
+          <Button onClick={handleNotesClick} variant="outlined">
             {t('viewSheetMusic')}
           </Button>
         ) : (
           <IconButton
-            onClick={handleActionClick}
+            onClick={handleNotesClick}
             size="small"
             variant={IconButtonColorVariant.Secondary}
             sx={iconButtonSecondaryOutlinedSx}
@@ -140,9 +164,20 @@ export const ActionsCell: React.FC<RowProp> = ({ row, onAction }) => {
           </IconButton>
         ))}
 
-      <IconButton size="small" variant={IconButtonColorVariant.Secondary} sx={iconButtonSecondaryPlainSx}>
-        <SvgImage src="/icons/ellipsis-vertical.svg" alt="menu" width={24} height={24} />
-      </IconButton>
+      <OverflowMenu
+        items={menuItems}
+        trigger={
+          <IconButton
+            size="small"
+            variant={IconButtonColorVariant.Secondary}
+            sx={iconButtonSecondaryPlainSx}
+            data-testid="Artistry-overflowMenuButton"
+          >
+            <SvgImage src="/icons/ellipsis-vertical.svg" alt="menu" width={24} height={24} />
+          </IconButton>
+        }
+        dataTestId="Artistry-overflowMenu"
+      />
     </Box>
   );
 };
@@ -170,13 +205,5 @@ export const renderOpusTitleGroupLabel = (items: Music[]) => (
     <Typography variant="customBold16" fontWeight={600}>
       {items[0]?.opusTitle}
     </Typography>
-  </Box>
-);
-
-export const renderGroupActions = () => (
-  <Box sx={{ display: 'flex', justifyContent: 'flex-end', width: '100%', pr: { xs: '10px', sm: '15px', md: '40px' } }}>
-    <IconButton size="small" variant={IconButtonColorVariant.Secondary} sx={iconButtonSecondaryPlainSx}>
-      <SvgImage src="/icons/ellipsis-vertical.svg" alt="menu" width={24} height={24} />
-    </IconButton>
   </Box>
 );

--- a/app/shared/components/tables/CompositionTable/MusicTableSelection.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableSelection.tsx
@@ -10,7 +10,6 @@ import {
   RenderExpanderCell,
   RenderGenreCell,
   RenderGenreHeader,
-  renderGroupActions,
   renderNameCell,
   RenderNameHeader,
   renderOpusGroupLabel,
@@ -116,8 +115,7 @@ export default function MusicTableSection() {
       {
         id: 'actions',
         header: '',
-        cell: (info) => RenderActionsCell(info, handleOpenModal),
-        meta: { groupLabelContentFactory: renderGroupActions }
+        cell: (info) => RenderActionsCell(info, handleOpenModal)
       }
     ],
     []

--- a/app/shared/hooks/use-composition-playback/useCompositionPlayback.test.ts
+++ b/app/shared/hooks/use-composition-playback/useCompositionPlayback.test.ts
@@ -27,7 +27,7 @@ const makeAudioPlayerMock = (overrides?: Partial<ReturnType<typeof useAudioPlaye
   togglePlay: jest.fn(),
   isPlaying: false,
   src: undefined,
-  ...(overrides ?? {})
+  ...overrides
 });
 
 describe('useCompositionPlayback', () => {

--- a/app/shared/hooks/use-composition-playback/useCompositionPlayback.test.ts
+++ b/app/shared/hooks/use-composition-playback/useCompositionPlayback.test.ts
@@ -1,0 +1,134 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useCompositionPlayback } from './useCompositionPlayback';
+import type { Music } from '~/types/types/enhancedTable';
+
+import { useAudioPlayer } from '~/shared/context/AudioPlayerContext';
+
+jest.mock('~/shared/context/AudioPlayerContext', () => ({
+  useAudioPlayer: jest.fn()
+}));
+
+const mockUseAudioPlayer = useAudioPlayer as jest.Mock;
+
+const baseRow: Music = {
+  id: '1',
+  name: 'Poem about the Forest',
+  year: 1918,
+  opus: 'op.50',
+  opusTitle: 'Symphony No. 3 in B minor',
+  audioAvailable: true,
+  sheetAvailable: true,
+  sheetMusic: [{ url: '', isFree: true, dateUploaded: '' }]
+};
+
+const makeAudioPlayerMock = (overrides?: Partial<ReturnType<typeof useAudioPlayer>>) => ({
+  playTrack: jest.fn(),
+  togglePlay: jest.fn(),
+  isPlaying: false,
+  src: undefined,
+  ...(overrides ?? {})
+});
+
+describe('useCompositionPlayback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return canPlay=true when audioAvailable=true', () => {
+    mockUseAudioPlayer.mockReturnValue(makeAudioPlayerMock());
+
+    const { result } = renderHook(() => useCompositionPlayback(baseRow));
+    expect(result.current.canPlay).toBe(true);
+  });
+
+  it('should return canPlay=false when audioAvailable=false', () => {
+    mockUseAudioPlayer.mockReturnValue(makeAudioPlayerMock());
+
+    const { result } = renderHook(() => useCompositionPlayback({ ...baseRow, audioAvailable: false }));
+
+    expect(result.current.canPlay).toBe(false);
+  });
+
+  it('should return isCurrentTrack=true when src startsWith trackUrl', () => {
+    const trackUrl = `/api/blob-url?blobName=${encodeURIComponent(baseRow.name)}&folderName=compositions`;
+
+    mockUseAudioPlayer.mockReturnValue(
+      makeAudioPlayerMock({
+        src: `${trackUrl}&anything=else`
+      })
+    );
+
+    const { result } = renderHook(() => useCompositionPlayback(baseRow));
+    expect(result.current.isCurrentTrack).toBe(true);
+  });
+
+  it('should return isCurrentTrack=false when src is different', () => {
+    mockUseAudioPlayer.mockReturnValue(
+      makeAudioPlayerMock({
+        src: 'different-src'
+      })
+    );
+
+    const { result } = renderHook(() => useCompositionPlayback(baseRow));
+    expect(result.current.isCurrentTrack).toBe(false);
+  });
+
+  it('should call playTrack(trackUrl, name) when not current track', () => {
+    const audioMock = makeAudioPlayerMock({ src: 'different-src' });
+    mockUseAudioPlayer.mockReturnValue(audioMock);
+
+    const { result } = renderHook(() => useCompositionPlayback(baseRow));
+
+    act(() => {
+      result.current.handlePlayClick();
+    });
+
+    expect(audioMock.playTrack).toHaveBeenCalledWith(expect.stringContaining('folderName=compositions'), baseRow.name);
+    expect(audioMock.togglePlay).not.toHaveBeenCalled();
+  });
+
+  it('should call togglePlay when current track', () => {
+    const trackUrl = `/api/blob-url?blobName=${encodeURIComponent(baseRow.name)}&folderName=compositions`;
+
+    const audioMock = makeAudioPlayerMock({
+      src: trackUrl,
+      isPlaying: true
+    });
+    mockUseAudioPlayer.mockReturnValue(audioMock);
+
+    const { result } = renderHook(() => useCompositionPlayback(baseRow));
+
+    act(() => {
+      result.current.handlePlayClick();
+    });
+
+    expect(audioMock.togglePlay).toHaveBeenCalled();
+    expect(audioMock.playTrack).not.toHaveBeenCalled();
+  });
+
+  it('should do nothing when canPlay=false', () => {
+    const audioMock = makeAudioPlayerMock({ src: 'different-src' });
+    mockUseAudioPlayer.mockReturnValue(audioMock);
+
+    const { result } = renderHook(() => useCompositionPlayback({ ...baseRow, audioAvailable: false }));
+
+    act(() => {
+      result.current.handlePlayClick();
+    });
+
+    expect(audioMock.playTrack).not.toHaveBeenCalled();
+    expect(audioMock.togglePlay).not.toHaveBeenCalled();
+  });
+
+  it('should expose isPlaying from useAudioPlayer', () => {
+    mockUseAudioPlayer.mockReturnValue(
+      makeAudioPlayerMock({
+        isPlaying: true
+      })
+    );
+
+    const { result } = renderHook(() => useCompositionPlayback(baseRow));
+    expect(result.current.isPlaying).toBe(true);
+  });
+});

--- a/app/shared/hooks/use-composition-playback/useCompositionPlayback.ts
+++ b/app/shared/hooks/use-composition-playback/useCompositionPlayback.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+
+import type { Music } from '~/types/types/enhancedTable';
+
+import { useAudioPlayer } from '~/shared/context/AudioPlayerContext';
+
+export function useCompositionPlayback(rowData: Music) {
+  const { playTrack, togglePlay, isPlaying, src } = useAudioPlayer();
+
+  const trackUrl = useMemo(
+    () => `/api/blob-url?blobName=${encodeURIComponent(rowData.name)}&folderName=compositions`,
+    [rowData.name]
+  );
+
+  const isCurrentTrack = Boolean(src?.startsWith(trackUrl));
+  const canPlay = Boolean(rowData.audioAvailable);
+
+  const handlePlayClick = useCallback(() => {
+    if (!canPlay) return;
+
+    if (isCurrentTrack) togglePlay();
+    else playTrack(trackUrl, rowData.name);
+  }, [canPlay, isCurrentTrack, togglePlay, playTrack, trackUrl, rowData.name]);
+
+  return {
+    canPlay,
+    isCurrentTrack,
+    isPlaying,
+    handlePlayClick
+  };
+}

--- a/app/types/types/menu.types.ts
+++ b/app/types/types/menu.types.ts
@@ -1,0 +1,19 @@
+import { SxProps, Theme } from '@mui/material';
+
+export type IconPosition = Readonly<'left' | 'right'>;
+
+export type OverflowMenuItemConfig = Readonly<{
+  id: string;
+  label: React.ReactNode;
+  icon?: React.ReactNode;
+  iconPosition?: IconPosition;
+  containerSx?: SxProps<Theme>;
+  labelSx?: SxProps<Theme>;
+  disabled?: boolean;
+  hidden?: boolean;
+  onClick: () => void;
+}>;
+
+export type TriggerProps = React.HTMLAttributes<HTMLElement> & {
+  'data-testid'?: string;
+};

--- a/app/types/types/menu.types.ts
+++ b/app/types/types/menu.types.ts
@@ -2,10 +2,12 @@ import { SxProps, Theme } from '@mui/material';
 
 export type IconPosition = Readonly<'left' | 'right'>;
 
+import type { HTMLAttributes, ReactNode } from 'react';
+
 export type OverflowMenuItemConfig = Readonly<{
   id: string;
-  label: React.ReactNode;
-  icon?: React.ReactNode;
+  label: ReactNode;
+  icon?: ReactNode;
   iconPosition?: IconPosition;
   containerSx?: SxProps<Theme>;
   labelSx?: SxProps<Theme>;
@@ -14,6 +16,6 @@ export type OverflowMenuItemConfig = Readonly<{
   onClick: () => void;
 }>;
 
-export type TriggerProps = React.HTMLAttributes<HTMLElement> & {
+export type TriggerProps = HTMLAttributes<HTMLElement> & {
   'data-testid'?: string;
 };

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -174,7 +174,8 @@
     },
     "buttons": {
       "viewSheetMusic": "View sheet music",
-      "downloadMusic": "Download"
+      "downloadMusic": "Download",
+      "listenToComposition": "Listen to the composition"
     },
     "work": {
       "name": "All documents",

--- a/i18n/messages/uk.json
+++ b/i18n/messages/uk.json
@@ -174,7 +174,8 @@
     },
     "buttons": {
       "viewSheetMusic": "Переглянути ноти",
-      "downloadMusic": "Завантажити"
+      "downloadMusic": "Завантажити",
+      "listenToComposition": "Прослухати композицію"
     },
     "work": {
       "name": "Усі документи",


### PR DESCRIPTION
## Description

1. Created reusable OverflowMenu component with predicated base styles and test coverage. 

2. Implemented into the MusicTableCells component; added needed menu items: 
   - "Listen to the composition" is available across all screen sizes.
   - "View sheet music" is available on small screen sizes and as a separate button on large screens.
 
3. Add styles according to the Figma design.

4. Provided coverage with tests and correction of existing.

5. Small refactor the MusicTableCells by adding the useCompositionPlayback hook to avoid code duplication.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. npm run dev

2. Open /artistry

3. Find the compositions table and click the **three-dots (overflow) menu** on the right side of any row.

4. Verify the menu opens and contains **“Listen to the composition”**.

5. If the row has sheet music and you are on **mobile/tablet** (or narrow the viewport), verify the menu also contains **“View sheet music”** and clicking it opens the sheet music flow/modal.

6. If the row has **no audio** (audioAvailable=false), verify the **“Listen to the composition”** item is disabled.

7. Click outside the menu (or select an item) and verify the menu closes.

## Video / Screenshots

### Large screen, enabled/disabled the "Listen to the composition" button, "View sheet music" as a separate button:

<img width="395" height="125" alt="image" src="https://github.com/user-attachments/assets/d6ed10ba-cd42-448a-a5a4-ed72fea66e66" />
<img width="369" height="124" alt="image" src="https://github.com/user-attachments/assets/07e0a53a-2bae-4b19-be7c-fe36ae478521" />

### Small screens, enabled/disabled the "Listen to the composition" button and "View sheet music" moved to the menu and hidden as a separate button that available only on large screens: 

<img width="688" height="180" alt="image" src="https://github.com/user-attachments/assets/76fa30ab-07db-4c5b-b78d-af8794b662e4" />
<img width="673" height="177" alt="image" src="https://github.com/user-attachments/assets/034c9b7e-1189-4e7a-a46e-35b68db03c92" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
