### PR TITLE
fix: fix design mismatch on support us page

### DIFF
--- a/app/shared/components/blocks/FAQ/FAQ.tsx
+++ b/app/shared/components/blocks/FAQ/FAQ.tsx
@@ -37,9 +37,16 @@ const Faq = ({ data }: { readonly data: Readonly<FaqProps> }) => {
   return (
     <Box sx={styles.gridContainer} data-testid="Faq">
       <SectionTitle
+        sx={{
+          gridTemplateColumns: {
+            xs: 'repeat(4, 1fr)',
+            sm: 'repeat(8, 1fr)',
+            md: 'repeat(12, 1fr)'
+          }
+        }}
         title={t('title')}
         mb={48}
-        gridColumn={{ xs: '2 ', sm: '4 / -1', md: '6 / -1', lg: '5 / -1', xl: '6 / -1' }}
+        gridColumn={{ xs: '2/4 ', sm: '4 / -1', md: '6 / -1' }}
         dataTestId="Faq-titleContainer"
       />
       <Box sx={styles.contacts}>

--- a/app/shared/components/blocks/actions-help/ActionsHelp.consts.ts
+++ b/app/shared/components/blocks/actions-help/ActionsHelp.consts.ts
@@ -9,13 +9,15 @@ export const actionsHelpPageData = {
       {
         type: TipTapNodeTypes.paragraph,
         content: [
-          { type: TipTapNodeTypes.text, text: 'Допомагати можна не лише донатами — іноді ' },
-          { type: TipTapNodeTypes.text, text: 'найцінніша', marks: [{ type: TipTapMarkType.bold }] },
           {
             type: TipTapNodeTypes.text,
-            text: ' підтримка — це ваші знання, досвід і час. Навіть кілька годин на місяць можуть стати важливим внеском у розвиток фонду. Долучайтеся до наших ініціатив — '
+            text: 'Нам дуже потрібні люди — з вашою експертизою, енергією і дрібкою часу, адже саме ваша участь допомагає українській музиці ставати помітнішою у світі. А що '
           },
-          { type: TipTapNodeTypes.text, text: 'разом ми зможемо більше.', marks: [{ type: TipTapMarkType.bold }] }
+          { type: TipTapNodeTypes.text, text: 'гучніше й впевненіше', marks: [{ type: TipTapMarkType.bold }] },
+          {
+            type: TipTapNodeTypes.text,
+            text: ' вона звучить, то більше людей розуміють і підтримують нас — на всіх рівнях.'
+          }
         ]
       }
     ]

--- a/app/shared/components/blocks/actions-help/ActionsHelp.styles.ts
+++ b/app/shared/components/blocks/actions-help/ActionsHelp.styles.ts
@@ -17,9 +17,14 @@ export const styles = {
     mt: { xs: '56px', sm: '104px', md: '128px' }
   },
   typography: {
-    textAlign: { xs: 'center', sm: 'right', md: 'left' },
+    textAlign: 'left',
     gridColumn: { xs: '1', sm: '4 / 9', md: '6 / -1' },
-    textIndent: { xs: '7em', sm: '10em', md: '15em' },
+    textIndent: {
+      xs: 'calc((100vw - 48px) / 4 * 1 + 4px)',
+      sm: 'calc((100vw - 112px) / 8 * 3 - 11px)',
+      md: 'calc((100vw - 144px) / 12 * 3 + 11px)',
+      xxl: 'calc((1728px - 144px) / 12 * 3 + 11px)'
+    },
     color: mainHexPallete.brown[700]
   },
   papersContainer: {
@@ -31,10 +36,10 @@ export const styles = {
       xl: 'repeat(4, 296px)'
     },
     gridColumn: { xs: '1', sm: '1 / -1' },
-    columnGap: { xs: '0px', sm: '40px', md: '25px', lg: '15px', xl: '40px' },
+    columnGap: { xs: '0px', sm: '40px', md: '25px', lg: '16px', xl: '40px' },
     rowGap: { xs: '0px', sm: '45px', md: '35px', lg: '0px' },
-    justifyContent: { xs: 'center', sm: 'end', lg: 'center' },
-    mt: { xs: '64px', md: '132px' }
+    justifyContent: { xs: 'center', sm: 'end' },
+    mt: { xs: '64px', lg: '80px' }
   },
   paper: (index: number) => ({
     position: 'relative',

--- a/app/shared/components/blocks/actions-help/ActionsHelp.tsx
+++ b/app/shared/components/blocks/actions-help/ActionsHelp.tsx
@@ -37,9 +37,16 @@ const ActionsHelp = ({ data }: { readonly data: Readonly<ActionsHelpProps> }) =>
   return (
     <Box sx={styles.gridContainer} data-testid="ActionsHelp">
       <SectionTitle
+        sx={{
+          gridTemplateColumns: {
+            xs: 'repeat(4, 1fr)',
+            sm: 'repeat(8, 1fr)',
+            md: 'repeat(12, 1fr)'
+          }
+        }}
         title={title}
         mb={52}
-        gridColumn={{ xs: '2 ', sm: '4 / -1', md: '6 / -1', lg: '5 / -1', xl: '6 / -1' }}
+        gridColumn={{ xs: '2/4 ', sm: '4 / -1', md: '6 / -1' }}
         dataTestId="ActionsHelp-titleContainer"
       />
       <TipTapContent


### PR DESCRIPTION
## Description

Improved responsiveness of ActionsHelp block and fixed margins and card positioning on Support Us page

## Type of change

- [x] Bug fix
- [x] Refactoring / Tech debt

## How to test

1. Just find the Support Us page and check how it looks on different screen sizes.

## Video / Screenshots

Before fixing:



https://github.com/user-attachments/assets/c85364a8-d875-460b-b7fb-5d1345797871

After fixing:


https://github.com/user-attachments/assets/76d25330-b445-45a3-bf51-f6fb391a786e


## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
