### PR TITLE
Feat(cases table): implement clickable rows

### DIFF
--- a/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.styles.ts
+++ b/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.styles.ts
@@ -1,5 +1,7 @@
 import { mainHexPallete } from '~/components/design-system/all-components/theme/colors';
 
+import { AppTypography } from '~/constants';
+
 export const TITLE_GRID_COLUMN = { xs: '1 / -1' } as const;
 export const TITLE_SX = {
   '& h2': {
@@ -89,8 +91,7 @@ export const styles = {
   },
 
   itemTitle: {
-    fontSize: '16px',
-    fontWeight: 500,
+    ...AppTypography.mulish16Regular,
     color: mainHexPallete.brown[600]
   }
 };

--- a/app/shared/components/enhanced-table/EnhancedTable.tsx
+++ b/app/shared/components/enhanced-table/EnhancedTable.tsx
@@ -48,6 +48,7 @@ interface EnhancedTableProps<T extends RowData> {
   loading?: boolean;
   noResults?: React.ReactNode;
   rowSx?: object;
+  onRowClick?: (row: T) => void;
 }
 
 export const EnhancedTable = <T extends RowData>({
@@ -65,7 +66,8 @@ export const EnhancedTable = <T extends RowData>({
   defaultSorting = [],
   loading = false,
   noResults,
-  rowSx
+  rowSx,
+  onRowClick
 }: Readonly<EnhancedTableProps<T>>) => {
   const [sorting, setSorting] = useState<SortingState>(defaultSorting);
   const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({});
@@ -202,7 +204,13 @@ export const EnhancedTable = <T extends RowData>({
                       columns={getGroupColumns(columns, entry.items)}
                     />
                   ) : (
-                    <EnhancedTableRow key={entry.item.id} data={entry.item} table={headerTable} sx={rowSx} />
+                    <EnhancedTableRow
+                      key={entry.item.id}
+                      data={entry.item}
+                      table={headerTable}
+                      sx={rowSx}
+                      onClick={onRowClick ? () => onRowClick(entry.item) : undefined}
+                    />
                   )
                 )}
               </TableBody>

--- a/app/shared/components/enhanced-table/enhanced-table-row/EnhancedTableRow.tsx
+++ b/app/shared/components/enhanced-table/enhanced-table-row/EnhancedTableRow.tsx
@@ -7,18 +7,44 @@ interface EnhancedTableRowProps<T extends { id: string }> {
   data: T;
   table: Table<T>;
   sx?: object;
+  onClick?: () => void;
 }
 
 export default function EnhancedTableRow<T extends { id: string }>({
   data,
   table,
-  sx
+  sx,
+  onClick
 }: Readonly<EnhancedTableRowProps<T>>) {
   const row = table.getRowModel().rows.find((row) => row.original.id === data.id);
   if (!row) return null;
 
+  const handleRowClick = (e: React.MouseEvent<HTMLElement>) => {
+    if (!onClick) return;
+
+    const target = e.target as HTMLElement | null;
+
+    if (target?.closest('button, a')) return;
+
+    onClick();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    if (!onClick) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
   return (
-    <TableRow data-testid="EnhancedTableRow-mainNoOpus" sx={sx}>
+    <TableRow
+      data-testid="EnhancedTableRow-mainNoOpus"
+      sx={sx}
+      onClick={onClick ? handleRowClick : undefined}
+      onKeyDown={onClick ? handleKeyDown : undefined}
+      tabIndex={onClick ? 0 : undefined}
+    >
       {row.getVisibleCells().map((cell) => (
         <TableCell
           key={cell.id}

--- a/app/shared/components/tables/DocumentsTable/DocumentTableSelection.test.tsx
+++ b/app/shared/components/tables/DocumentsTable/DocumentTableSelection.test.tsx
@@ -12,6 +12,16 @@ jest.mock('~/i18n/navigation', () => ({
   Link: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>
 }));
 
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+    prefetch: jest.fn()
+  }),
+  usePathname: () => '/uk/archive/fund-1'
+}));
+
 const mockUseBreakpoints = jest.fn();
 
 jest.mock('~/shared/hooks/use-breakpoints/useBreakpoints', () => {

--- a/app/shared/components/tables/DocumentsTable/DocumentTableSelection.tsx
+++ b/app/shared/components/tables/DocumentsTable/DocumentTableSelection.tsx
@@ -1,5 +1,7 @@
 'use client';
+
 import { ColumnDef } from '@tanstack/react-table';
+import { usePathname, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useMemo, useState } from 'react';
 
@@ -26,8 +28,18 @@ import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
 
 export default function DocumentTableSelection({ documents }: { documents: DocumentRecord[] }) {
   const t = useTranslations('table.documents');
+  const router = useRouter();
+  const pathname = usePathname();
+
   const bp = useBreakpoints();
   const { isMobile, isTablet, isLaptop, isDesktop, isLaptopAndAbove } = bp;
+
+  const handleRowClick = (row: DocumentRecord) => {
+    const caseId = row.id;
+    if (!caseId) return;
+
+    router.push(`${pathname.replace(/\/$/, '')}/${encodeURIComponent(caseId)}`);
+  };
 
   const [search, setSearch] = useState('');
   const searchOptions = useMemo(() => [], []);
@@ -53,20 +65,8 @@ export default function DocumentTableSelection({ documents }: { documents: Docum
         cell: RenderCodeCell,
         sortingFn: 'alphanumeric'
       },
-      {
-        id: 'name',
-        accessorKey: 'name',
-        header: RenderNameHeader,
-        cell: RenderNameCell,
-        sortingFn: 'alphanumeric'
-      },
-      {
-        id: 'dates',
-        accessorKey: 'dates',
-        header: RenderDateHeader,
-        cell: RenderDateCell,
-        sortingFn: 'alphanumeric'
-      },
+      { id: 'name', accessorKey: 'name', header: RenderNameHeader, cell: RenderNameCell, sortingFn: 'alphanumeric' },
+      { id: 'dates', accessorKey: 'dates', header: RenderDateHeader, cell: RenderDateCell, sortingFn: 'alphanumeric' },
       {
         id: 'sheets',
         accessorKey: 'sheets',
@@ -81,11 +81,7 @@ export default function DocumentTableSelection({ documents }: { documents: Docum
         cell: RenderContentCell,
         sortingFn: 'alphanumeric'
       },
-      {
-        id: 'actions',
-        header: '',
-        cell: RenderActionCell
-      }
+      { id: 'actions', header: '', cell: RenderActionCell }
     ],
     []
   );
@@ -104,6 +100,7 @@ export default function DocumentTableSelection({ documents }: { documents: Docum
       columnWidths={columnWidths}
       itemsPerPage={5}
       tableName={t('name')}
+      onRowClick={handleRowClick}
       rowSx={{
         cursor: 'pointer',
         transition: 'background-color 0.15s ease',

--- a/app/shared/components/tables/DocumentsTable/documents.mock.ts
+++ b/app/shared/components/tables/DocumentsTable/documents.mock.ts
@@ -2,7 +2,7 @@ import { DocumentRecord } from '~/types/types/document.types';
 
 export const mockDocuments: DocumentRecord[] = [
   {
-    id: '1',
+    id: '69236afae427aafae7051acb',
     cipher: 'Ф. 2, оп. 1, спр. 1',
     name: 'Документи про народження і освіту',
     dates: '1895–1955',
@@ -11,7 +11,7 @@ export const mockDocuments: DocumentRecord[] = [
     pdfUrl: '/files/example.pdf'
   },
   {
-    id: '2',
+    id: '69236afae427aafae7051acc',
     cipher: 'Ф. 2, оп. 1, спр. 2',
     name: 'Похвальні листи гімназій',
     dates: '1895–1955',
@@ -20,7 +20,7 @@ export const mockDocuments: DocumentRecord[] = [
     pdfUrl: '/files/example.pdf'
   },
   {
-    id: '3',
+    id: '69236afae427aafae7051acd',
     cipher: 'Ф. 2, оп. 1, спр. 3',
     name: 'Трудова діяльність',
     dates: '1895–1955',
@@ -30,7 +30,7 @@ export const mockDocuments: DocumentRecord[] = [
     pdfUrl: '/files/example.pdf'
   },
   {
-    id: '4',
+    id: '69236afae427aafae7051ace',
     cipher: 'Ф. 2, оп. 1, спр. 4',
     name: 'Нагороди та звання',
     dates: '1895–1955',
@@ -39,7 +39,7 @@ export const mockDocuments: DocumentRecord[] = [
     pdfUrl: '/files/example.pdf'
   },
   {
-    id: '5',
+    id: '69236afae427aafae7051acf',
     cipher: 'Ф. 2, оп. 1, спр. 5',
     name: 'Автобіографії та довідки',
     dates: '1895–1955',
@@ -48,7 +48,7 @@ export const mockDocuments: DocumentRecord[] = [
     pdfUrl: '/files/example.pdf'
   },
   {
-    id: '6',
+    id: '69236afae427aafae7051ad0',
     cipher: 'Ф. 2, оп. 1, спр. 6',
     name: 'Членство в організаціях',
     dates: '1895–1955',
@@ -57,7 +57,7 @@ export const mockDocuments: DocumentRecord[] = [
     pdfUrl: null
   },
   {
-    id: '7',
+    id: '69236afae427aafae7051ad1',
     cipher: 'Ф. 2, оп. 1, спр. 7',
     name: 'Поїздки за кордон',
     dates: '1959–1966',
@@ -66,7 +66,7 @@ export const mockDocuments: DocumentRecord[] = [
     pdfUrl: '/files/example.pdf'
   },
   {
-    id: '8',
+    id: '69236afae427aafae7051ad2',
     cipher: 'Ф. 2, оп. 1, спр. 8',
     name: 'Військова служба',
     dates: '1915–1946',
@@ -75,7 +75,7 @@ export const mockDocuments: DocumentRecord[] = [
     pdfUrl: null
   },
   {
-    id: '9',
+    id: '69236afae427aafae7051ad3',
     cipher: 'Ф. 2, оп. 1, спр. 9',
     name: 'Різне',
     dates: '1955',
@@ -84,7 +84,7 @@ export const mockDocuments: DocumentRecord[] = [
     pdfUrl: null
   },
   {
-    id: '10',
+    id: '6923766fe427aafae7051ae6',
     cipher: 'Ф. 2, оп. 2, спр. 1',
     name: 'Листи-привітання з 50-річчям',
     dates: '1945',


### PR DESCRIPTION
## Description

Enables navigation from the Documents table on Fund Details: makes table rows clickable and route to the corresponding Archive Case page.
Also fixes the root cause of navigation failing by ensuring each DocumentRecord carries the real case ObjectId (caseId), instead of using the UI index-like id.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open any Fund Details page with the Documents table.
2. Hover a row → cursor should be pointer + hover background style applies.
3. Click a row → should navigate to /{lang}/archive/{fund}/{caseId} and open the correct Archive Case page.
4. Click action buttons/links inside a row → should not trigger row navigation.

## Video / Screenshots

<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->

## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
