### PR TITLE
feat: delete hardcoded paddings and add margins according to design

### DIFF
--- a/app/shared/components/enhanced-table/EnhancedTable.styles.ts
+++ b/app/shared/components/enhanced-table/EnhancedTable.styles.ts
@@ -4,7 +4,6 @@ export const enhancedTableStyles = {
   root: {
     display: 'flex',
     flexDirection: 'column',
-    py: 20,
     gap: 4,
     gridColumn: '1 / -1'
   },

--- a/app/shared/components/enhanced-table/EnhancedTable.tsx
+++ b/app/shared/components/enhanced-table/EnhancedTable.tsx
@@ -1,6 +1,15 @@
 'use client';
 
-import { Box, CircularProgress, Paper, SxProps, Table, TableBody, TableContainer, Theme } from '@mui/material';
+import {
+  Box,
+  CircularProgress,
+  Paper,
+  type SxProps,
+  Table,
+  TableBody,
+  TableContainer,
+  type Theme
+} from '@mui/material';
 import {
   ColumnDef,
   ColumnFiltersState,

--- a/app/shared/components/enhanced-table/EnhancedTable.tsx
+++ b/app/shared/components/enhanced-table/EnhancedTable.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Theme } from '@emotion/react';
-import { Box, CircularProgress, Paper, SxProps, Table, TableBody, TableContainer } from '@mui/material';
+import { Box, CircularProgress, Paper, SxProps, Table, TableBody, TableContainer, Theme } from '@mui/material';
 import {
   ColumnDef,
   ColumnFiltersState,

--- a/app/shared/components/enhanced-table/EnhancedTable.tsx
+++ b/app/shared/components/enhanced-table/EnhancedTable.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Box, CircularProgress, Paper, Table, TableBody, TableContainer } from '@mui/material';
+import { Theme } from '@emotion/react';
+import { Box, CircularProgress, Paper, SxProps, Table, TableBody, TableContainer } from '@mui/material';
 import {
   ColumnDef,
   ColumnFiltersState,
@@ -48,6 +49,7 @@ interface EnhancedTableProps<T extends RowData> {
   loading?: boolean;
   noResults?: React.ReactNode;
   rowSx?: object;
+  tableContainerSx?: SxProps<Theme>;
 }
 
 export const EnhancedTable = <T extends RowData>({
@@ -65,7 +67,8 @@ export const EnhancedTable = <T extends RowData>({
   defaultSorting = [],
   loading = false,
   noResults,
-  rowSx
+  rowSx,
+  tableContainerSx
 }: Readonly<EnhancedTableProps<T>>) => {
   const [sorting, setSorting] = useState<SortingState>(defaultSorting);
   const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({});
@@ -174,7 +177,7 @@ export const EnhancedTable = <T extends RowData>({
   };
 
   return (
-    <Box ref={tableRef} sx={styles.root} data-testid="EnhancedTable">
+    <Box ref={tableRef} sx={{ ...styles.root, ...tableContainerSx }} data-testid="EnhancedTable">
       <ControlPanel
         Search={Search}
         tableName={tableName}

--- a/app/shared/components/enhanced-table/EnhancedTable.tsx
+++ b/app/shared/components/enhanced-table/EnhancedTable.tsx
@@ -68,7 +68,7 @@ export const EnhancedTable = <T extends RowData>({
   loading = false,
   noResults,
   rowSx,
-  tableContainerSx
+  tableContainerSx,
   onRowClick
 }: Readonly<EnhancedTableProps<T>>) => {
   const [sorting, setSorting] = useState<SortingState>(defaultSorting);

--- a/app/shared/components/tables/CompositionTable/MusicTableSelection.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableSelection.tsx
@@ -274,6 +274,7 @@ export default function MusicTableSection() {
         isFiltersActive={isAnyFilterActive}
         activeFiltersCount={activeFiltersCount}
         onClearFilters={resetFilters}
+        tableContainerSx={{ mt: { xs: '80px', md: '88px', xl: '152px' }, mb: { xs: '120px', md: '160px' } }}
       />
       <GetNotesModal
         key={modalNotes[0]?.dateUploaded}

--- a/app/shared/components/tables/DocumentsTable/DocumentTableSelection.tsx
+++ b/app/shared/components/tables/DocumentsTable/DocumentTableSelection.tsx
@@ -104,6 +104,7 @@ export default function DocumentTableSelection({ documents }: { documents: Docum
       columnWidths={columnWidths}
       itemsPerPage={5}
       tableName={t('name')}
+      tableContainerSx={{ mt: { md: '80px', lg: '96px' }, mb: { md: '104px', lg: '160px' } }}
       rowSx={{
         cursor: 'pointer',
         transition: 'background-color 0.15s ease',

--- a/app/shared/components/tables/WorksTable/WorkTableSelection.tsx
+++ b/app/shared/components/tables/WorksTable/WorkTableSelection.tsx
@@ -194,6 +194,7 @@ export const WorkTableSection = () => {
       isFiltersActive={isAnyFilterActive}
       activeFiltersCount={activeFiltersCount}
       onClearFilters={resetFilters}
+      tableContainerSx={{ mt: { xs: '80px', md: '88px' }, mb: { xs: '120px', md: '160px' } }}
     />
   );
 };


### PR DESCRIPTION
## Description

Removed hardcoded padding styles in EnhancedTable component and added `tableContainerSx` prop to allow managing spacing externally. And used this prop to define margins according to design

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Just visit any page with table(Artistry, Research and Academic work, Fund Detail) and check margins

## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
