### PR TITLE
fix: console warning when closing Year filter popover

### DIFF
--- a/app/shared/components/design-system/all-components/selector/FilterSelect.tsx
+++ b/app/shared/components/design-system/all-components/selector/FilterSelect.tsx
@@ -43,20 +43,20 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [selectedValues, setSelectedValues] = useState<string[]>(() => defaultValues ?? []);
-  const menuAnchorRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     setSelectedValues(defaultValues ?? []);
   }, [defaultValues]);
 
   const handleToggleMenu = () => {
-    if (!disabled && menuAnchorRef.current) {
-      setAnchorEl(menuAnchorRef.current);
-    }
+    if (disabled) return;
+    setAnchorEl((prev) => (prev ? null : triggerRef.current));
   };
 
   const handleCloseMenu = () => {
     setAnchorEl(null);
+    requestAnimationFrame(() => triggerRef.current?.focus());
   };
 
   const handleOptionClick = (option: FilterOption) => {
@@ -93,8 +93,8 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
 
           return (
             <FilterSelectItem
-              label={option.label}
               key={option.value}
+              label={option.label}
               onClick={() => !isDisabled && handleOptionClick(option)}
               selected={isSelected}
               disabled={isDisabled}
@@ -110,7 +110,15 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
 
   return (
     <Box>
-      <Box ref={menuAnchorRef} sx={filterSelectStyles.root(variant, disabled)} onClick={handleToggleMenu}>
+      <Box
+        ref={triggerRef}
+        sx={filterSelectStyles.root(variant, disabled)}
+        onClick={handleToggleMenu}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-haspopup="dialog"
+        aria-expanded={Boolean(anchorEl)}
+      >
         <Typography sx={filterSelectStyles.label(disabled)}>{label}</Typography>
         <Box sx={filterSelectStyles.chipContainer}>
           {selectedOptionsCount > 0 && (
@@ -120,6 +128,7 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
               disabled={disabled}
               onDelete={handleChipDelete}
               size="small"
+              onClick={(e) => e.stopPropagation()}
             />
           )}
           <Box sx={filterSelectStyles.dropdownIcon(disabled)}>

--- a/app/shared/components/tables/WorksTable/filters/YearNumericFilter.tsx
+++ b/app/shared/components/tables/WorksTable/filters/YearNumericFilter.tsx
@@ -32,12 +32,13 @@ export const YearNumericFilter: React.FC<YearNumericFilterProps> = ({
 
   const handleToggleMenu = useCallback(() => {
     if (buttonRef.current) {
-      setAnchorEl(buttonRef.current);
+      setAnchorEl((prev) => (prev ? null : buttonRef.current));
     }
   }, []);
 
   const handleCloseMenu = useCallback(() => {
     setAnchorEl(null);
+    requestAnimationFrame(() => buttonRef.current?.focus());
   }, []);
 
   const numericFilterElement = useMemo(
@@ -57,7 +58,14 @@ export const YearNumericFilter: React.FC<YearNumericFilterProps> = ({
 
   return (
     <>
-      <Box ref={buttonRef} sx={{ ...filterSelectStyles.root('filled', false) }} onClick={handleToggleMenu}>
+      <Box
+        component="button"
+        ref={buttonRef}
+        sx={{ ...filterSelectStyles.root('filled', false) }}
+        onClick={handleToggleMenu}
+        aria-haspopup="dialog"
+        aria-expanded={Boolean(anchorEl)}
+      >
         <Typography sx={filterSelectStyles.label(false)}>{label}</Typography>
         <Box sx={filterSelectStyles.dropdownIcon(false)}>
           <Image src="/icons/chevron-down.svg" alt="dropdown" width={16} height={16} />


### PR DESCRIPTION
## Description

Fixed accessibility and hydration issues in table filter dropdown triggers.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open All compositions page (table with filters).

2. Click Category / Genre / Year of composition filter - dropdown should open.

3. Select / change values (including numeric year range where applicable).

4. Click outside the dropdown - the dropdown should close and focus should return to the filter trigger (accessibility warning about aria-hidden should be gone or significantly reduced).

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
