### PR TITLE
refactor: create reusable resolvePageData helper for fetching page data

### DIFF
--- a/app/[lang]/about-us/page.test.tsx
+++ b/app/[lang]/about-us/page.test.tsx
@@ -2,8 +2,18 @@ import { render, screen } from '@testing-library/react';
 
 import Home from './page';
 
-jest.mock('next/headers', () => ({
-  draftMode: jest.fn().mockResolvedValue({ isEnabled: false })
+jest.mock('next-intl/server', () => ({
+  setRequestLocale: jest.fn(),
+  getTranslations: jest.fn().mockResolvedValue((k: string) => k)
+}));
+
+jest.mock('~/services/pages-data/resolvePageData', () => ({
+  resolvePageData: jest.fn()
+}));
+
+jest.mock('../[...unknown-route]/page-not-found/PageNotFound', () => ({
+  __esModule: true,
+  PageNotFound: () => <div>Page not found</div>
 }));
 
 jest.mock('~/components/blocks/FoundationFounders/FoundationFounders', () => ({
@@ -41,84 +51,50 @@ jest.mock('~/components/blocks/what-we-do/WhatWeDo', () => ({
   default: () => <div>What we do</div>
 }));
 
-jest.mock('next-intl/server', () => ({
-  setRequestLocale: jest.fn(),
-  getTranslations: jest.fn().mockResolvedValue((k: string) => k)
-}));
-
-jest.mock('~/di/container', () => {
-  const liveGetPageData = jest.fn().mockResolvedValue({
-    blocks: {
-      IntroSection: {},
-      FoundationInfo: {},
-      OurMission: {},
-      OurGoals: {},
-      LiatoshynskyOffice: {},
-      WhatWeDo: {},
-      FoundationFounders: {}
-    }
-  });
-  const draftGetPageData = jest.fn().mockResolvedValue({
-    blocks: {
-      IntroSection: {},
-      FoundationInfo: {},
-      OurMission: {},
-      OurGoals: {},
-      LiatoshynskyOffice: {},
-      WhatWeDo: {},
-      FoundationFounders: {}
-    }
-  });
-
-  const pagesDataService = { getPageData: liveGetPageData };
-  const draftPagesDataService = { getPageData: draftGetPageData };
-
-  return {
-    __esModule: true,
-    __pagesDataService: pagesDataService,
-    __draftPagesDataService: draftPagesDataService,
-    createRequestContainer: () => ({
-      resolve: (token: string) => {
-        if (token === 'draftPagesDataService') return draftPagesDataService;
-        if (token === 'pagesDataService') return pagesDataService;
-        return {};
-      }
-    })
-  };
-});
-
 describe('Home page', () => {
-  const { draftMode } = jest.requireMock('next/headers');
-  const { __pagesDataService, __draftPagesDataService } = jest.requireMock('~/di/container') as {
-    __pagesDataService: { getPageData: jest.Mock };
-    __draftPagesDataService: { getPageData: jest.Mock };
+  const { resolvePageData } = jest.requireMock('~/services/pages-data/resolvePageData') as {
+    resolvePageData: jest.Mock;
+  };
+  const { setRequestLocale, getTranslations } = jest.requireMock('next-intl/server') as {
+    setRequestLocale: jest.Mock;
+    getTranslations: jest.Mock;
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('uses pagesDataService when draftMode is disabled', async () => {
-    (draftMode as jest.Mock).mockResolvedValueOnce({ isEnabled: false });
+  it('renders blocks when page exists and calls resolvePageData', async () => {
+    resolvePageData.mockResolvedValueOnce({
+      blocks: {
+        IntroSection: {},
+        FoundationInfo: {},
+        OurMission: {},
+        OurGoals: {},
+        LiatoshynskyOffice: {},
+        WhatWeDo: {},
+        FoundationFounders: {}
+      }
+    });
 
     const ui = await Home({ params: Promise.resolve({ lang: 'en' }) });
     render(ui);
 
+    expect(setRequestLocale).toHaveBeenCalledWith('en');
+    expect(resolvePageData).toHaveBeenCalledWith('about-us', 'en');
+    expect(getTranslations).toHaveBeenCalledWith('home.liatoshynskyOffice');
+
     expect(screen.getByText(/Our mission/i)).toBeInTheDocument();
-    expect(__pagesDataService.getPageData).toHaveBeenCalledTimes(1);
-    expect(__pagesDataService.getPageData).toHaveBeenCalledWith('about-us', 'en');
-    expect(__draftPagesDataService.getPageData).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 
-  it('uses draftPagesDataService when draftMode is enabled', async () => {
-    (draftMode as jest.Mock).mockResolvedValueOnce({ isEnabled: true });
+  it('returns PageNotFound when page is missing', async () => {
+    resolvePageData.mockResolvedValueOnce(null);
 
     const ui = await Home({ params: Promise.resolve({ lang: 'uk' }) });
     render(ui);
 
-    expect(screen.getByText(/Our mission/i)).toBeInTheDocument();
-    expect(__draftPagesDataService.getPageData).toHaveBeenCalledTimes(1);
-    expect(__draftPagesDataService.getPageData).toHaveBeenCalledWith('about-us', 'uk');
-    expect(__pagesDataService.getPageData).not.toHaveBeenCalled();
+    expect(resolvePageData).toHaveBeenCalledWith('about-us', 'uk');
+    expect(screen.getByText(/Page not found/i)).toBeInTheDocument();
   });
 });

--- a/app/[lang]/about-us/page.tsx
+++ b/app/[lang]/about-us/page.tsx
@@ -1,5 +1,3 @@
-import { Box } from '@mui/material';
-import { draftMode } from 'next/headers';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import React from 'react';
 
@@ -12,11 +10,11 @@ import OurMission from '~/components/blocks/our-mission/OurMission';
 import WhatWeDo from '~/components/blocks/what-we-do/WhatWeDo';
 import UnderDevelopment from '~/components/under-development/UnderDevelopment';
 
+import { PageNotFound } from '../[...unknown-route]/page-not-found/PageNotFound';
 import { Language } from '~/types/types/language';
 import { createSeoMeta } from '~/utils/createSeoMeta';
 import { isProductionMode } from '~/utils/isProductionMode';
 
-import { createRequestContainer } from '~/di/container';
 import MainLayout from '~/layouts/main-layout/MainLayout';
 
 export const metadata = createSeoMeta({
@@ -25,37 +23,33 @@ export const metadata = createSeoMeta({
   url: '/'
 });
 
+import { resolvePageData } from '~/services/pages-data/resolvePageData';
+
 export default async function Home({ params }: Readonly<Language>) {
   const { lang } = await params;
   setRequestLocale(lang);
-
-  const { isEnabled } = await draftMode();
-  const container = createRequestContainer();
-
-  const selectedPagesService = isEnabled
-    ? container.resolve('draftPagesDataService')
-    : container.resolve('pagesDataService');
-
-  const [page, t] = await Promise.all([
-    selectedPagesService.getPageData('about-us', lang),
-    getTranslations('home.liatoshynskyOffice')
-  ]);
-
-  if (!page) return <Box />;
 
   if (isProductionMode()) {
     return <UnderDevelopment />;
   }
 
+  const [page, t] = await Promise.all([resolvePageData('about-us', lang), getTranslations('home.liatoshynskyOffice')]);
+
+  if (!page) {
+    return <PageNotFound />;
+  }
+
+  const blocks = page.blocks;
+
   return (
     <MainLayout withLines>
-      {page.blocks.IntroSection && <IntroSection data={page.blocks.IntroSection} />}
-      {page.blocks.FoundationInfo && <FoundationInfo data={page.blocks.FoundationInfo} />}
-      {page.blocks.OurMission && <OurMission data={page.blocks.OurMission} />}
-      {page.blocks.OurGoals && <OurGoals data={page.blocks.OurGoals} />}
-      {page.blocks.LiatoshynskyOffice && <LiatoshynskyOffice data={page.blocks.LiatoshynskyOffice} t={t} />}
-      {page.blocks.WhatWeDo && <WhatWeDo data={page.blocks.WhatWeDo} />}
-      {page.blocks.FoundationFounders && <FoundationFounders data={page.blocks.FoundationFounders} />}
+      {blocks.IntroSection && <IntroSection data={blocks.IntroSection} />}
+      {blocks.FoundationInfo && <FoundationInfo data={blocks.FoundationInfo} />}
+      {blocks.OurMission && <OurMission data={blocks.OurMission} />}
+      {blocks.OurGoals && <OurGoals data={blocks.OurGoals} />}
+      {blocks.LiatoshynskyOffice && <LiatoshynskyOffice data={blocks.LiatoshynskyOffice} t={t} />}
+      {blocks.WhatWeDo && <WhatWeDo data={blocks.WhatWeDo} />}
+      {blocks.FoundationFounders && <FoundationFounders data={blocks.FoundationFounders} />}
     </MainLayout>
   );
 }

--- a/app/[lang]/biography/page.test.tsx
+++ b/app/[lang]/biography/page.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+
+import Biography from './page';
+
+jest.mock('next-intl/server', () => ({
+  setRequestLocale: jest.fn()
+}));
+
+jest.mock('~/services/pages-data/resolvePageData', () => ({
+  resolvePageData: jest.fn()
+}));
+
+jest.mock('../[...unknown-route]/page-not-found/PageNotFound', () => ({
+  __esModule: true,
+  PageNotFound: () => <div>Page not found</div>
+}));
+
+jest.mock('~/shared/components/blocks/HeroSection/HeroSection', () => ({
+  __esModule: true,
+  HeroSection: () => <div>Hero section</div>
+}));
+
+jest.mock('./BiographyContent/BiographyContent', () => ({
+  __esModule: true,
+  BiographyContent: () => <div>Biography content</div>
+}));
+
+describe('Biography page', () => {
+  const { setRequestLocale } = jest.requireMock('next-intl/server') as {
+    setRequestLocale: jest.Mock;
+  };
+
+  const { resolvePageData } = jest.requireMock('~/services/pages-data/resolvePageData') as {
+    resolvePageData: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render biography blocks when page exists', async () => {
+    resolvePageData.mockResolvedValueOnce({
+      blocks: {
+        heroSection: {},
+        biographyContent: [{ yearTitle: '1910' }, { yearTitle: null }, { yearTitle: '1930' }]
+      }
+    });
+
+    const ui = await Biography({ params: Promise.resolve({ lang: 'en' }) });
+    render(ui);
+
+    expect(setRequestLocale).toHaveBeenCalledWith('en');
+    expect(resolvePageData).toHaveBeenCalledWith('biography', 'en');
+
+    expect(screen.getByText(/Hero section/i)).toBeInTheDocument();
+    expect(screen.getByText(/Biography content/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+
+  it('should return PageNotFound when page is missing', async () => {
+    resolvePageData.mockResolvedValueOnce(null);
+
+    const ui = await Biography({ params: Promise.resolve({ lang: 'uk' }) });
+    render(ui);
+
+    expect(resolvePageData).toHaveBeenCalledWith('biography', 'uk');
+    expect(screen.getByText(/Page not found/i)).toBeInTheDocument();
+  });
+});

--- a/app/[lang]/biography/page.tsx
+++ b/app/[lang]/biography/page.tsx
@@ -8,9 +8,9 @@ import { BiographyContent } from './BiographyContent/BiographyContent';
 import { Language } from '~/types/types/language';
 import { isProductionMode } from '~/utils/isProductionMode';
 
-import { createRequestContainer } from '~/di/container';
 import MainLayout from '~/layouts/main-layout/MainLayout';
 import { createSeoMeta } from '~/lib/utils/createSeoMeta';
+import { resolvePageData } from '~/services/pages-data/resolvePageData';
 import { HeroSection } from '~/shared/components/blocks/HeroSection/HeroSection';
 
 export const metadata = createSeoMeta({
@@ -27,20 +27,20 @@ export default async function Biography({ params }: Readonly<Language>): Promise
     return <UnderDevelopment />;
   }
 
-  const pageService = await createRequestContainer().resolve('pagesDataService');
-
-  const page = await pageService.getPageData('biography', lang);
+  const page = await resolvePageData('biography', lang);
 
   if (!page) {
     return <PageNotFound />;
   }
 
-  const years = page.blocks.biographyContent.map((year) => year.yearTitle).filter((year) => year !== null);
+  const blocks = page.blocks;
+
+  const years = blocks.biographyContent.map((year) => year.yearTitle).filter((year) => year !== null);
 
   return (
     <MainLayout withLines>
-      {page.blocks.heroSection && <HeroSection data={page.blocks.heroSection} years={years} />}
-      {page.blocks.biographyContent && <BiographyContent data={page.blocks.biographyContent} />}
+      {blocks.heroSection && <HeroSection data={blocks.heroSection} years={years} />}
+      {blocks.biographyContent && <BiographyContent data={blocks.biographyContent} />}
     </MainLayout>
   );
 }

--- a/app/[lang]/privacy-policy/page.test.tsx
+++ b/app/[lang]/privacy-policy/page.test.tsx
@@ -2,7 +2,18 @@ import { render, screen } from '@testing-library/react';
 
 import PrivacyPolicy from './page';
 
-import { createRequestContainer } from '~/di/container';
+jest.mock('next-intl/server', () => ({
+  setRequestLocale: jest.fn()
+}));
+
+jest.mock('~/services/pages-data/resolvePageData', () => ({
+  resolvePageData: jest.fn()
+}));
+
+jest.mock('../[...unknown-route]/page-not-found/PageNotFound', () => ({
+  __esModule: true,
+  PageNotFound: () => <div>Page not found</div>
+}));
 
 jest.mock('~/components/blocks/privacy-policy/intro-section/IntroSection', () => {
   const MockIntroSection = ({ title }: { title: string }) => <div>Intro section: {title}</div>;
@@ -16,37 +27,36 @@ jest.mock('~/components/blocks/privacy-policy/policy-section/PolicySection', () 
   return MockPolicySection;
 });
 
-jest.mock('~/di/container', () => {
-  const createRequestContainer = jest.fn(() => ({
-    resolve: () => ({
-      getPageData: jest.fn().mockResolvedValue({
-        title: 'Privacy Policy',
-        blocks: {
-          IntroSection: { trustAndSecurity: {}, agreement: {} },
-          DataWeCollect: { title: 'Data We Collect', description: {}, sections: [] },
-          DataUsage: { title: 'How We Use Data', description: {}, list: [] },
-          Cookies: { title: 'Cookies', description: {}, list: [], note: {} },
-          GoogleAuth: { title: 'Google Auth', description: {}, list: [], note: {} },
-          SocialNetworks: { title: 'Social Networks', description: {} },
-          TargetedAds: { title: 'Targeted Ads', description: {} },
-          NewsletterSubscription: { title: 'Newsletter', description: {} },
-          DataRetention: { title: 'Data Retention', description: {} },
-          UserRights: { title: 'Your Rights', description: {}, list: [], note: {} },
-          ContactUs: { title: 'Contact Us', description: {} }
-        }
-      })
-    })
-  }));
-  return { createRequestContainer };
-});
-
-jest.mock('next-intl/server', () => ({
-  setRequestLocale: jest.fn()
-}));
-
 describe('PrivacyPolicy page', () => {
+  const { resolvePageData } = jest.requireMock('~/services/pages-data/resolvePageData') as {
+    resolvePageData: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render all available blocks', async () => {
+    resolvePageData.mockResolvedValueOnce({
+      title: 'Privacy Policy',
+      blocks: {
+        IntroSection: { trustAndSecurity: {}, agreement: {} },
+        DataWeCollect: { title: 'Data We Collect', description: {}, sections: [], note: {} },
+        DataUsage: { title: 'How We Use Data', description: {}, list: [] },
+        Cookies: { title: 'Cookies', description: {}, list: [], note: {} },
+        GoogleAuth: { title: 'Google Auth', description: {}, list: [], note: {} },
+        SocialNetworks: { title: 'Social Networks', description: {} },
+        TargetedAds: { title: 'Targeted Ads', description: {} },
+        NewsletterSubscription: { title: 'Newsletter', description: {} },
+        DataRetention: { title: 'Data Retention', description: {} },
+        UserRights: { title: 'Your Rights', description: {}, list: [], note: {} },
+        ContactUs: { title: 'Contact Us', description: {} }
+      }
+    });
+
     render(await PrivacyPolicy({ params: Promise.resolve({ lang: 'en' }) }));
+
+    expect(resolvePageData).toHaveBeenCalledWith('privacy-policy', 'en');
 
     expect(screen.getByText(/Intro section: Privacy Policy/i)).toBeInTheDocument();
     expect(screen.getByText(/Policy section: Data We Collect/i)).toBeInTheDocument();
@@ -61,44 +71,12 @@ describe('PrivacyPolicy page', () => {
     expect(screen.getByText(/Policy section: Contact Us/i)).toBeInTheDocument();
   });
 
-  it('should render nothing when page has no blocks', async () => {
-    (createRequestContainer as jest.Mock).mockReturnValueOnce({
-      resolve: () => ({
-        getPageData: jest.fn().mockResolvedValue({ title: 'Empty', blocks: {} })
-      })
-    });
-
-    const { container } = render(await PrivacyPolicy({ params: Promise.resolve({ lang: 'en' }) }));
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('should render only present blocks', async () => {
-    (createRequestContainer as jest.Mock).mockReturnValueOnce({
-      resolve: () => ({
-        getPageData: jest.fn().mockResolvedValue({
-          title: 'Selective',
-          blocks: {
-            IntroSection: { trustAndSecurity: {}, agreement: {} },
-            DataUsage: { title: 'How We Use Data', description: {}, list: [] },
-            ContactUs: { title: 'Contact Us', description: {} }
-          }
-        })
-      })
-    });
+  it('should render PageNotFound when page is missing', async () => {
+    resolvePageData.mockResolvedValueOnce(null);
 
     render(await PrivacyPolicy({ params: Promise.resolve({ lang: 'en' }) }));
 
-    expect(screen.getByText(/Intro section: Selective/i)).toBeInTheDocument();
-    expect(screen.getByText(/Policy section: How We Use Data/i)).toBeInTheDocument();
-    expect(screen.getByText(/Policy section: Contact Us/i)).toBeInTheDocument();
-
-    expect(screen.queryByText(/Data We Collect/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Cookies/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Google Auth/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Social Networks/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Targeted Ads/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Newsletter/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Data Retention/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Your Rights/i)).not.toBeInTheDocument();
+    expect(resolvePageData).toHaveBeenCalledWith('privacy-policy', 'en');
+    expect(screen.getByText(/Page not found/i)).toBeInTheDocument();
   });
 });

--- a/app/[lang]/privacy-policy/page.tsx
+++ b/app/[lang]/privacy-policy/page.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import { setRequestLocale } from 'next-intl/server';
 import React from 'react';
 
@@ -6,12 +5,13 @@ import IntroSection from '~/components/blocks/privacy-policy/intro-section/Intro
 import PolicySection from '~/components/blocks/privacy-policy/policy-section/PolicySection';
 import UnderDevelopment from '~/components/under-development/UnderDevelopment';
 
+import { PageNotFound } from '../[...unknown-route]/page-not-found/PageNotFound';
 import { Language } from '~/types/types/language';
 import { createSeoMeta } from '~/utils/createSeoMeta';
 import { isProductionMode } from '~/utils/isProductionMode';
 
-import { createRequestContainer } from '~/di/container';
 import MainLayout from '~/layouts/main-layout/MainLayout';
+import { resolvePageData } from '~/services/pages-data/resolvePageData';
 
 export const metadata = createSeoMeta({
   title: 'Політика Конфіденційності',
@@ -24,22 +24,17 @@ export default async function PrivacyPolicy({ params }: Readonly<Language>) {
   const { lang } = await params;
   setRequestLocale(lang);
 
-  const pageService = createRequestContainer().resolve('pagesDataService');
-  const page = await pageService.getPageData('privacy-policy', lang);
-
-  if (!page) {
-    return <Box />;
-  }
-
-  const blocks = page.blocks ?? {};
-
-  if (Object.keys(blocks).length === 0) {
-    return <></>;
-  }
-
   if (isProductionMode()) {
     return <UnderDevelopment />;
   }
+
+  const page = await resolvePageData('privacy-policy', lang);
+
+  if (!page) {
+    return <PageNotFound />;
+  }
+
+  const blocks = page.blocks;
 
   return (
     <MainLayout withLines>

--- a/app/[lang]/research/page.test.tsx
+++ b/app/[lang]/research/page.test.tsx
@@ -8,6 +8,15 @@ jest.mock('next-intl/server', () => ({
   setRequestLocale: jest.fn()
 }));
 
+jest.mock('~/services/pages-data/resolvePageData', () => ({
+  resolvePageData: jest.fn()
+}));
+
+jest.mock('../[...unknown-route]/page-not-found/PageNotFound', () => ({
+  __esModule: true,
+  PageNotFound: () => <div>Page not found</div>
+}));
+
 jest.mock('~/components/research-and-scientific-work/ResearchAndScientificWork', () => {
   const Mock = (props: any) =>
     React.createElement('div', { 'data-testid': 'mock-hero' }, props?.data ? 'Hero Section' : 'No Hero');
@@ -21,44 +30,51 @@ jest.mock('~/components/tables/WorksTable/WorkTableSelection', () => {
   return { __esModule: true, WorkTableSection: MockWorkTable };
 });
 
-const mockGetPageData = jest.fn();
-jest.mock('~/di/container', () => ({
-  createRequestContainer: () => ({
-    resolve: () => ({
-      getPageData: mockGetPageData
-    })
-  })
-}));
-
 describe('Research Page', () => {
+  const { resolvePageData } = jest.requireMock('~/services/pages-data/resolvePageData') as {
+    resolvePageData: jest.Mock;
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('should render all components when data is successfully fetched', async () => {
-    mockGetPageData.mockResolvedValue({
+    resolvePageData.mockResolvedValueOnce({
       blocks: {
         HeroSection: { title: 'Some hero data' }
       }
     });
-    const element = await ResearchPage({ params: { lang: 'uk' } } as any);
+
+    const element = await ResearchPage({ params: Promise.resolve({ lang: 'uk' }) } as any);
     render(element);
+
     expect(await screen.findByText('Hero Section')).toBeInTheDocument();
     expect(await screen.findByText('Work Table Section')).toBeInTheDocument();
 
-    expect(mockGetPageData).toHaveBeenCalledWith('research', 'uk');
+    expect(resolvePageData).toHaveBeenCalledWith('research', 'uk');
   });
 
   it('should render only the table when hero section data is missing', async () => {
-    mockGetPageData.mockResolvedValue({
+    resolvePageData.mockResolvedValueOnce({
       blocks: {}
     });
-    const element = await ResearchPage({ params: { lang: 'en' } } as any);
-    render(element);
-    expect(screen.queryByText('Hero Section')).not.toBeInTheDocument();
 
+    const element = await ResearchPage({ params: Promise.resolve({ lang: 'en' }) } as any);
+    render(element);
+
+    expect(screen.queryByText('Hero Section')).not.toBeInTheDocument();
     expect(await screen.findByText('Work Table Section')).toBeInTheDocument();
 
-    expect(mockGetPageData).toHaveBeenCalledWith('research', 'en');
+    expect(resolvePageData).toHaveBeenCalledWith('research', 'en');
+  });
+  it('should render PageNotFound when page is missing', async () => {
+    resolvePageData.mockResolvedValueOnce(null);
+
+    const element = await ResearchPage({ params: Promise.resolve({ lang: 'en' }) } as any);
+    render(element);
+
+    expect(await screen.findByText(/Page not found/i)).toBeInTheDocument();
+    expect(resolvePageData).toHaveBeenCalledWith('research', 'en');
   });
 });

--- a/app/[lang]/research/page.tsx
+++ b/app/[lang]/research/page.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import { setRequestLocale } from 'next-intl/server';
 import React from 'react';
 
@@ -6,12 +5,13 @@ import ResearchAndScientificWork from '~/components/research-and-scientific-work
 import { WorkTableSection } from '~/components/tables/WorksTable/WorkTableSelection';
 import UnderDevelopment from '~/components/under-development/UnderDevelopment';
 
+import { PageNotFound } from '../[...unknown-route]/page-not-found/PageNotFound';
 import { Language } from '~/types/types/language';
 import { createSeoMeta } from '~/utils/createSeoMeta';
 import { isProductionMode } from '~/utils/isProductionMode';
 
-import { createRequestContainer } from '~/di/container';
 import MainLayout from '~/layouts/main-layout/MainLayout';
+import { resolvePageData } from '~/services/pages-data/resolvePageData';
 
 export const metadata = createSeoMeta({
   title: 'Дослідження та наукові роботи - Фундація Лятошинського',
@@ -23,21 +23,21 @@ export default async function ResearchPage({ params }: Readonly<Language>) {
   const { lang } = await params;
   setRequestLocale(lang);
 
-  const pageService = await createRequestContainer().resolve('pagesDataService');
-
-  const page = await pageService.getPageData('research', lang);
-
-  if (!page) {
-    return <Box />;
-  }
-
   if (isProductionMode()) {
     return <UnderDevelopment />;
   }
 
+  const page = await resolvePageData('research', lang);
+
+  if (!page) {
+    return <PageNotFound />;
+  }
+
+  const blocks = page.blocks;
+
   return (
     <MainLayout>
-      {page.blocks.HeroSection && <ResearchAndScientificWork data={page.blocks.HeroSection} />}
+      {blocks.HeroSection && <ResearchAndScientificWork data={blocks.HeroSection} />}
       <WorkTableSection />
     </MainLayout>
   );

--- a/app/services/pages-data/resolvePageData.test.ts
+++ b/app/services/pages-data/resolvePageData.test.ts
@@ -1,0 +1,55 @@
+import { draftMode } from 'next/headers';
+
+import { resolvePageData } from './resolvePageData';
+
+import { createRequestContainer } from '~/di/container';
+
+jest.mock('next/headers', () => ({
+  draftMode: jest.fn()
+}));
+
+jest.mock('~/di/container', () => ({
+  createRequestContainer: jest.fn()
+}));
+
+describe('resolvePageData', () => {
+  const mockDraftService = { getPageData: jest.fn() };
+  const mockProdService = { getPageData: jest.fn() };
+
+  const mockContainer = {
+    resolve: jest.fn((key: string) => {
+      if (key === 'draftPagesDataService') return mockDraftService;
+      if (key === 'pagesDataService') return mockProdService;
+      throw new Error(`Unknown service: ${key}`);
+    })
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createRequestContainer as jest.Mock).mockReturnValue(mockContainer);
+  });
+
+  it('should use draftPagesDataService when draftMode is enabled', async () => {
+    (draftMode as jest.Mock).mockResolvedValue({ isEnabled: true });
+    mockDraftService.getPageData.mockResolvedValue({ some: 'data' });
+
+    const result = await resolvePageData('about-us', 'uk');
+
+    expect(mockContainer.resolve).toHaveBeenCalledWith('draftPagesDataService');
+    expect(mockDraftService.getPageData).toHaveBeenCalledWith('about-us', 'uk');
+    expect(mockProdService.getPageData).not.toHaveBeenCalled();
+    expect(result).toEqual({ some: 'data' });
+  });
+
+  it('should use pagesDataService when draftMode is disabled', async () => {
+    (draftMode as jest.Mock).mockResolvedValue({ isEnabled: false });
+    mockProdService.getPageData.mockResolvedValue({ other: 'data' });
+
+    const result = await resolvePageData('about-us', 'uk');
+
+    expect(mockContainer.resolve).toHaveBeenCalledWith('pagesDataService');
+    expect(mockProdService.getPageData).toHaveBeenCalledWith('about-us', 'uk');
+    expect(mockDraftService.getPageData).not.toHaveBeenCalled();
+    expect(result).toEqual({ other: 'data' });
+  });
+});

--- a/app/services/pages-data/resolvePageData.ts
+++ b/app/services/pages-data/resolvePageData.ts
@@ -1,0 +1,19 @@
+import 'server-only';
+import { draftMode } from 'next/headers';
+import type { Locale } from 'next-intl';
+
+import type { PageSlug } from './schema-factory';
+import { PageDataMap } from '~/types/page/pagesBase.type';
+
+import { createRequestContainer } from '~/di/container';
+
+export async function resolvePageData<S extends PageSlug>(slug: S, locale: Locale): Promise<PageDataMap[S] | null> {
+  const { isEnabled } = await draftMode();
+  const container = createRequestContainer();
+
+  const selectedPagesService = isEnabled
+    ? container.resolve('draftPagesDataService')
+    : container.resolve('pagesDataService');
+
+  return selectedPagesService.getPageData(slug, locale);
+}


### PR DESCRIPTION
## Description

Refactored page data fetching by introducing a reusable resolvePageData helper. Updated multiple pages to use the helper, removed redundant boilerplate, and replaced empty fallbacks (empty Box) with PageNotFound where page data is missing. Updated/adjusted unit tests accordingly.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Pull the branch and run:
   * npm run test
  
2. Run the app locally:
   * npm run dev
   
3. Check pages:
   * /about-us
   * /research
   * /biography
   * /privacy-policy

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board
