### PR TITLE
fix: fix name of archive in about us page

### DIFF
--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -65,9 +65,9 @@
   },
   "home": {
     "liatoshynskyOffice": {
-      "office": "OfFicE",
+      "office": "ArcHive",
       "name": "LIaTosHynSKy",
-      "goToOfficeButton": "Go to the office"
+      "goToOfficeButton": "Go to the archive"
     }
   },
   "common": {

--- a/i18n/messages/uk.json
+++ b/i18n/messages/uk.json
@@ -65,9 +65,9 @@
   },
   "home": {
     "liatoshynskyOffice": {
-      "office": "КабІНет",
+      "office": "АрХів",
       "name": "ЛЯтоШинСькоГO",
-      "goToOfficeButton": "Увійти до кабінету"
+      "goToOfficeButton": "Увійти до архіву"
     }
   },
   "common": {


### PR DESCRIPTION
## Description

Updated the text related to “Archive” on the About Us page to match the latest design changes.


## Type of change
- [x] Bug fix


## Screenshots
<img width="1639" height="710" alt="image" src="https://github.com/user-attachments/assets/13f53a8f-7c00-49ba-86da-be6f236fa52a" />


---
