### PR TITLE
fix: prevent header shift caused by scrollbar and update MusicTableSection test

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,10 @@
   --foreground: #171717;
 }
 
+html {
+  scrollbar-gutter: stable;
+}
+
 body {
   color: var(--foreground);
   background: var(--background);

--- a/app/shared/components/tables/CompositionTable/MusicTableSection.test.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableSection.test.tsx
@@ -44,7 +44,7 @@ const staticFiltersData = {
   categories: [{ key: 'classic', name: 'classic' }],
   genres: [{ key: 'rock', name: 'rock' }],
   titles: [{ title: 'Symphony' }],
-  yearRange: { minYear: 1900, maxYear: 2025 }
+  yearRange: { minYear: 1900, maxYear: 2026 }
 };
 
 jest.mock('~/shared/hooks/use-fetch-static-filters/useFetchStaticFilters', () => ({
@@ -53,7 +53,7 @@ jest.mock('~/shared/hooks/use-fetch-static-filters/useFetchStaticFilters', () =>
       categories: [{ key: 'classic', name: 'classic' }],
       genres: [{ key: 'rock', name: 'rock' }],
       titles: [{ title: 'Symphony' }],
-      yearRange: { minYear: 1900, maxYear: 2025 }
+      yearRange: { minYear: 1900, maxYear: 2026 }
     },
     isLoading: false
   }))
@@ -196,6 +196,6 @@ describe('MusicTableSection (cleaned)', () => {
   it('year range uses provided values', () => {
     render(<MusicTableSection />);
     expect(screen.getByTestId('min-year')).toHaveTextContent('1900');
-    expect(screen.getByTestId('max-year')).toHaveTextContent('2025');
+    expect(screen.getByTestId('max-year')).toHaveTextContent('2026');
   });
 });


### PR DESCRIPTION
## Description

Fixed horizontal layout shift of the header caused by the appearance/disappearance of the vertical scrollbar by adding scrollbar-gutter: stable to the root `html` element.
Updated a failing test that was using a hardcoded year (2025) to reflect the current year (2026).

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:

## How to test

1. Open any modal with scroll lock, for example, the three dots button on the `/artistry` page.
2. Check that the header does not move horizontally.
3. Run tests.

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
