### PR TITLE
fix: missing Liatoshynsky Office block on the biography page

### DIFF
--- a/app/[lang]/biography/BiographyContent/BiographyContent.styles.ts
+++ b/app/[lang]/biography/BiographyContent/BiographyContent.styles.ts
@@ -7,7 +7,7 @@ export const biographyContentStyles = {
     gridTemplateColumns: 'subgrid',
     gridColumn: '1 / -1',
     rowGap: { xs: '48px', sm: '64px', md: '80px' },
-    marginBottom: '160px',
+    marginBottom: '80px',
     marginTop: { xs: '96px', md: '128px', lg: '144px', ultra: '80px' }
   },
 

--- a/app/[lang]/biography/page.test.tsx
+++ b/app/[lang]/biography/page.test.tsx
@@ -3,7 +3,8 @@ import { render, screen } from '@testing-library/react';
 import Biography from './page';
 
 jest.mock('next-intl/server', () => ({
-  setRequestLocale: jest.fn()
+  setRequestLocale: jest.fn(),
+  getTranslations: jest.fn()
 }));
 
 jest.mock('~/services/pages-data/resolvePageData', () => ({
@@ -25,9 +26,15 @@ jest.mock('./BiographyContent/BiographyContent', () => ({
   BiographyContent: () => <div>Biography content</div>
 }));
 
+jest.mock('~/components/blocks/Liatoshynsky-office/LiatoshynskyOffice', () => ({
+  __esModule: true,
+  default: () => <div>Liatoshynsky office</div>
+}));
+
 describe('Biography page', () => {
-  const { setRequestLocale } = jest.requireMock('next-intl/server') as {
+  const { setRequestLocale, getTranslations } = jest.requireMock('next-intl/server') as {
     setRequestLocale: jest.Mock;
+    getTranslations: jest.Mock;
   };
 
   const { resolvePageData } = jest.requireMock('~/services/pages-data/resolvePageData') as {
@@ -36,13 +43,15 @@ describe('Biography page', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    getTranslations.mockResolvedValue((key: string) => key);
   });
 
   it('should render biography blocks when page exists', async () => {
     resolvePageData.mockResolvedValueOnce({
       blocks: {
         heroSection: {},
-        biographyContent: [{ yearTitle: '1910' }, { yearTitle: null }, { yearTitle: '1930' }]
+        biographyContent: [{ yearTitle: '1910' }, { yearTitle: null }, { yearTitle: '1930' }],
+        LiatoshynskyOffice: {}
       }
     });
 
@@ -54,6 +63,7 @@ describe('Biography page', () => {
 
     expect(screen.getByText(/Hero section/i)).toBeInTheDocument();
     expect(screen.getByText(/Biography content/i)).toBeInTheDocument();
+    expect(screen.getByText(/Liatoshynsky office/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 
@@ -64,6 +74,7 @@ describe('Biography page', () => {
     render(ui);
 
     expect(resolvePageData).toHaveBeenCalledWith('biography', 'uk');
+    expect(getTranslations).toHaveBeenCalled();
     expect(screen.getByText(/Page not found/i)).toBeInTheDocument();
   });
 });

--- a/app/[lang]/biography/page.tsx
+++ b/app/[lang]/biography/page.tsx
@@ -1,6 +1,7 @@
-import { setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 import React, { ReactElement } from 'react';
 
+import LiatoshynskyOffice from '~/components/blocks/Liatoshynsky-office/LiatoshynskyOffice';
 import UnderDevelopment from '~/components/under-development/UnderDevelopment';
 
 import { PageNotFound } from '../[...unknown-route]/page-not-found/PageNotFound';
@@ -27,7 +28,7 @@ export default async function Biography({ params }: Readonly<Language>): Promise
     return <UnderDevelopment />;
   }
 
-  const page = await resolvePageData('biography', lang);
+  const [page, t] = await Promise.all([resolvePageData('biography', lang), getTranslations('home.liatoshynskyOffice')]);
 
   if (!page) {
     return <PageNotFound />;
@@ -41,6 +42,7 @@ export default async function Biography({ params }: Readonly<Language>): Promise
     <MainLayout withLines>
       {blocks.heroSection && <HeroSection data={blocks.heroSection} years={years} />}
       {blocks.biographyContent && <BiographyContent data={blocks.biographyContent} />}
+      {blocks.LiatoshynskyOffice && <LiatoshynskyOffice data={blocks.LiatoshynskyOffice} t={t} sx={{ mb: '80px' }} />}
     </MainLayout>
   );
 }

--- a/app/shared/components/blocks/Liatoshynsky-office/LiatoshynskyOffice.tsx
+++ b/app/shared/components/blocks/Liatoshynsky-office/LiatoshynskyOffice.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from '@mui/material';
+import { Box, SxProps, Theme, Typography } from '@mui/material';
 import { Oswald } from 'next/font/google';
 import type { useTranslations } from 'next-intl';
 import React from 'react';
@@ -12,10 +12,18 @@ import { ILiatoshynskyOffice } from '~/types/page/about-us.types';
 
 const oswald = Oswald({ weight: '700', subsets: ['latin'], display: 'swap' });
 
-const LiatoshynskyOffice = ({ data, t }: { data: ILiatoshynskyOffice; t: ReturnType<typeof useTranslations> }) => {
+const LiatoshynskyOffice = ({
+  data,
+  t,
+  sx
+}: {
+  data: ILiatoshynskyOffice;
+  t: ReturnType<typeof useTranslations>;
+  sx?: SxProps<Theme>;
+}) => {
   const { quote } = data;
   return (
-    <Box sx={styles.mainContainer} data-testid="LiatoshynskyOffice">
+    <Box sx={{ ...(styles.mainContainer as object), ...(sx as object) }} data-testid="LiatoshynskyOffice">
       <Box sx={styles.trapezoid} data-testid="LiatoshynskyOffice-trapezoid" />
       <Box sx={styles.contentContainer} data-testid="LiatoshynskyOffice-contentContainer">
         <Box sx={styles.quoteBlock} data-testid="LiatoshynskyOffice-quoteBlock">

--- a/app/validators/pagesSchemas/pages/biography.schema.ts
+++ b/app/validators/pagesSchemas/pages/biography.schema.ts
@@ -82,9 +82,14 @@ const HeroSectionBlockSchema = z.object({
   noteText: translatedFieldSchema
 });
 
+const LiatoshynskyOfficeBlockSchema = z.object({
+  quote: QuoteSchema
+});
+
 const BiographyBlocksSchema = z.object({
   heroSection: HeroSectionBlockSchema,
-  biographyContent: z.array(BiographyContentBlockSchema)
+  biographyContent: z.array(BiographyContentBlockSchema),
+  LiatoshynskyOffice: LiatoshynskyOfficeBlockSchema
 });
 
 export const BiographyPageSchema = z.object({


### PR DESCRIPTION
## Description

Added the Liatoshynsky Office block to the biography page.
This includes the required database updates performed via MongoDB Compass.
The biography page schema was updated to ensure correct typing.
Styles were adjusted, and the Liatoshynsky Office component was updated to support an external sx prop.
The biography page tests were updated to cover the Liatoshynsky Office block.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the `/biography` page
2. Check that the Liatoshynsky Office block is rendered correctly
3. Run tests

## Video / Screenshots

<img width="782" height="945" alt="image" src="https://github.com/user-attachments/assets/8e838b09-3031-40f4-8f35-f545293cde13" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
