### PR TITLE
fix: localize buttons and add links

### DIFF
--- a/app/[lang]/war-in-ukraine/page.tsx
+++ b/app/[lang]/war-in-ukraine/page.tsx
@@ -13,6 +13,8 @@ import { isProductionMode } from '~/utils/isProductionMode';
 import {
   carsForAFU,
   carsForAFUData,
+  principleOfHopeButtonLink,
+  principleOfHopeButtonText,
   principleOfHopeDoc,
   principleOfHopeLinks,
   yermolenkoDoc,
@@ -38,7 +40,8 @@ export default function WarInUkraine() {
       <WarInfoSection />
 
       <BulletTextWithLinks
-        buttonText="Підтримати фонд"
+        buttonText={principleOfHopeButtonText[locale]}
+        buttonLink={principleOfHopeButtonLink}
         description={principleOfHopeDoc[locale]}
         buttons={principleOfHopeLinks}
       />
@@ -49,6 +52,7 @@ export default function WarInUkraine() {
         buttonText="Підтримати"
         description={yermolenkoDoc[locale]}
         buttons={yermolenkoLinks}
+        showMainButton={false}
         sx={{ marginBottom: 12 }}
       />
 

--- a/app/[lang]/war-in-ukraine/war.const.ts
+++ b/app/[lang]/war-in-ukraine/war.const.ts
@@ -3,10 +3,20 @@ import { PaymentMethod } from '~/components/blocks/volunteer-donation/VolunteerD
 import { TipTapDoc } from '~/types/types/tiptap.types';
 import { boldText, makeDoc, normalText } from '~/utils/tiptapHelpers';
 
-type LocalizedTipTapDoc = {
-  uk: TipTapDoc;
-  en: TipTapDoc;
+type Localized<T> = {
+  uk: T;
+  en: T;
 };
+
+type LocalizedTipTapDoc = Localized<TipTapDoc>;
+type LocalizedString = Localized<string>;
+
+type LocalizedButtonItem = {
+  shortText: LocalizedString;
+  fullText: LocalizedString;
+  link: string;
+};
+
 export const warSupportDoc: LocalizedTipTapDoc = {
   uk: makeDoc([
     normalText(
@@ -59,11 +69,25 @@ export const principleOfHopeDoc: LocalizedTipTapDoc = {
   ])
 };
 
-export const principleOfHopeLinks = [
+export const principleOfHopeButtonLink =
+  'https://next.privat24.ua/payments/form/%7B%22token%22%3A%225f3f8a36-862f-4714-a6e9-90320b0e9923%22%7D';
+
+export const principleOfHopeButtonText: LocalizedString = {
+  uk: 'Підтримати фонд',
+  en: 'Support the Foundation'
+};
+
+export const principleOfHopeLinks: LocalizedButtonItem[] = [
   {
-    shortText: 'Фонд «Принцип надії»',
-    fullText: 'Благодійний фонд «Принцип надії»',
-    link: 'https://www.facebook.com'
+    shortText: {
+      uk: 'Фонд «Принцип надії»',
+      en: 'Principle of Hope Foundation'
+    },
+    fullText: {
+      uk: 'Благодійний фонд «Принцип надії»',
+      en: 'Principle of Hope Charitable Foundation'
+    },
+    link: 'https://www.facebook.com/principleofhope'
   }
 ];
 
@@ -88,21 +112,39 @@ export const yermolenkoDoc: LocalizedTipTapDoc = {
   ])
 };
 
-export const yermolenkoLinks = [
+export const yermolenkoLinks: LocalizedButtonItem[] = [
   {
-    shortText: 'Kult: Podcast',
-    fullText: 'Kult: Podcast',
-    link: 'https://www.facebook.com'
+    shortText: {
+      uk: 'Kult: Podcast',
+      en: 'Kult: Podcast'
+    },
+    fullText: {
+      uk: 'Kult: Podcast',
+      en: 'Kult: Podcast'
+    },
+    link: 'https://www.facebook.com/kultpodcast'
   },
   {
-    shortText: 'В. Єрмоленка',
-    fullText: 'Володимира Єрмоленка',
-    link: 'https://www.facebook.com'
+    shortText: {
+      uk: 'В. Єрмоленка',
+      en: 'V. Yermolenko'
+    },
+    fullText: {
+      uk: 'Володимира Єрмоленка',
+      en: 'Volodymyr Yermolenko'
+    },
+    link: 'https://www.facebook.com/volodymyr.yermolenko'
   },
   {
-    shortText: 'Т. Огаркової',
-    fullText: 'Тетяни Огаркової',
-    link: 'https://www.facebook.com'
+    shortText: {
+      uk: 'Т. Огаркової',
+      en: 'T. Ogarkova'
+    },
+    fullText: {
+      uk: 'Тетяни Огаркової',
+      en: 'Tetiana Ogarkova'
+    },
+    link: 'https://www.facebook.com/tetyana.ogarkova'
   }
 ];
 

--- a/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.test.tsx
+++ b/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.test.tsx
@@ -12,7 +12,8 @@ jest.mock('~/shared/hooks/use-breakpoints/useBreakpoints', () => ({
 jest.mock('next/image');
 
 jest.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => key
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'uk'
 }));
 
 jest.mock('~/i18n/navigation', () => ({
@@ -30,7 +31,13 @@ jest.mock('~/public/icons/facebook.svg', () => <div />);
 describe('BulletTextWithlinks component', () => {
   const useBreakpointsMock = useBreakpoints as jest.Mock;
 
-  const defaultButtons = [{ shortText: 'FB', fullText: 'Facebook', link: 'https://facebook.com' }];
+  const defaultButtons = [
+    {
+      shortText: { uk: 'FB', en: 'FB' },
+      fullText: { uk: 'Facebook', en: 'Facebook' },
+      link: 'https://facebook.com'
+    }
+  ];
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.tsx
+++ b/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { Box, type BoxProps } from '@mui/material';
 import Image from 'next/image';
+import { useLocale } from 'next-intl';
 import React from 'react';
 
 import Button from '../button/Button';
@@ -15,9 +16,14 @@ import FacebookIcon from '~/public/icons/facebook.svg';
 import { Svg } from '~/shared/components/colored-svg/ColoredSvg';
 import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
 
+type LocalizedString = {
+  uk: string;
+  en: string;
+};
+
 type ButtonItem = {
-  shortText: string;
-  fullText: string;
+  shortText: LocalizedString;
+  fullText: LocalizedString;
   link: string;
 };
 
@@ -26,7 +32,9 @@ type RichContent = string | TipTapDoc;
 type IconButtonContentBlockProps = BoxProps & {
   description?: RichContent;
   buttons: ButtonItem[];
-  buttonText: string;
+  buttonText?: string;
+  buttonLink?: string;
+  showMainButton?: boolean;
 };
 
 const imageSizes = {
@@ -44,10 +52,13 @@ export default function BulletTextWithLinks({
   description,
   buttons,
   buttonText,
+  buttonLink,
+  showMainButton = true,
   sx,
   ...props
 }: Readonly<IconButtonContentBlockProps>) {
   const { isMobile } = useBreakpoints();
+  const locale = useLocale() as 'uk' | 'en';
   const sizesAttribute = generateSizesAttribute(imageSizes);
 
   const imageBox = (
@@ -59,14 +70,15 @@ export default function BulletTextWithLinks({
   return (
     <Box sx={[styles.wrapper, ...sxToArray(sx)]} data-testid="BulletTextWithLinks" {...props}>
       {isMobile && imageBox}
-      <Box sx={styles.buttonBox} data-testid="BulletTextWithLinks-buttonBox">
-        {!isMobile && imageBox}
-        <Button size="medium" variant="contained" sx={{ ...styles.button }}>
-          {buttonText}
-          <Svg Component={ArrowUpRight} alt="icon" color="#fff" width="20px" height="20px" sx={styles.icon} />
-        </Button>
-      </Box>
-
+      {showMainButton && (
+        <Box sx={styles.buttonBox} data-testid="BulletTextWithLinks-buttonBox">
+          {!isMobile && imageBox}
+          <Button size="medium" variant="contained" sx={{ ...styles.button }} link={buttonLink} externalLink={true}>
+            {buttonText}
+            <Svg Component={ArrowUpRight} alt="icon" color="#fff" width="20px" height="20px" sx={styles.icon} />
+          </Button>
+        </Box>
+      )}
       <Box sx={styles.contentBox} data-testid="BulletTextWithLinks-contentBox">
         <ContentBlock
           dataTestId="BulletTextWithLinks-content"
@@ -77,7 +89,7 @@ export default function BulletTextWithLinks({
       <Box sx={styles.buttonsBox} data-testid="BulletTextWithLinks-buttonsBox">
         {buttons.map((button) => (
           <Button
-            key={button.shortText}
+            key={button.link}
             link={button.link}
             externalLink={true}
             variant="outlined"
@@ -94,7 +106,7 @@ export default function BulletTextWithLinks({
               />
             }
           >
-            {isMobile ? button.shortText : button.fullText}
+            {isMobile ? button.shortText[locale] : button.fullText[locale]}
           </Button>
         ))}
       </Box>


### PR DESCRIPTION
## Description

Implemented complete functionality for charity fund buttons on the war-in-ukraine page:

- **Added working links**: All buttons now lead to correct destinations - main donation button opens Privat24 payment form, social media buttons open respective Facebook pages of charitable organizations
- **Added translations**: All button texts now support both Ukrainian and English languages and automatically switch based on user's language selection
- **Made buttons adaptable**: Button texts automatically adjust for different screen sizes - shorter versions display on mobile devices, full versions on desktop
- **Added flexibility**: Main donation button can now be hidden when needed (currently hidden for the second charity block as per requirements)

Technical improvements include type system refactoring for better code maintainability, component architecture enhancements, test coverage updates, and proper separation of data into constants.


### Technical Details:

**Features:**
- Added external links for donation and social media buttons
- Implemented internationalization (i18n) with locale-aware button texts
- Added conditional rendering for main donation button via `showMainButton` prop

**Refactoring:**
- Created generic `Localized<T>` type for reusable translation structure
- Introduced `LocalizedString` and `LocalizedButtonItem` types
- Refactored `ButtonItem` type to support localized strings with `shortText` and `fullText`

**Component Enhancements:**
- Extended `BulletTextWithLinks` component with `buttonLink` and `showMainButton` props
- Integrated `useLocale` hook for dynamic language detection
- Implemented responsive text display (short text on mobile, full text on desktop)

**Bug Fixes:**
- Fixed React `key` prop stability by using `link` instead of locale-dependent `shortText`
- Updated test mocks to include `useLocale` from `next-intl`
- Updated test data structure to match new `LocalizedButtonItem` type

**Data Updates:**
- Added correct URLs for Privat24 donation form and Facebook pages
- Extracted donation button link to `principleOfHopeButtonLink` constant
- Created `principleOfHopeButtonText` with UK/EN translations


## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement

## How to test

1. Navigate to `/war-in-ukraine` page
2. Verify all buttons are clickable and lead to correct URLs:
   - "Підтримати фонд" -> Privat24 payment form
   - Social media buttons -> respective Facebook pages
3. Switch language (UK/EN) using language selector
4. Verify all button texts translate correctly
5. Check responsive design: short text on mobile, full text on desktop
6. Run tests: `npm test BulletTextWithLinks`
 

## Video / Screenshots


https://github.com/user-attachments/assets/f109962a-9c65-4534-8105-29344d83950c


## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
