### PR TITLE
fix: adjust rowGap in BiographyContent styles and enhance Quote styles with font properties

### DIFF
--- a/app/[lang]/biography/BiographyContent/BiographyContent.styles.ts
+++ b/app/[lang]/biography/BiographyContent/BiographyContent.styles.ts
@@ -6,7 +6,7 @@ export const biographyContentStyles = {
     display: 'grid',
     gridTemplateColumns: 'subgrid',
     gridColumn: '1 / -1',
-    rowGap: { xs: '48px', sm: '64px', md: '80px' },
+    rowGap: '16px',
     marginBottom: '80px',
     marginTop: { xs: '96px', md: '128px', lg: '144px', ultra: '80px' }
   },

--- a/app/shared/components/Quote/Quote.styles.ts
+++ b/app/shared/components/Quote/Quote.styles.ts
@@ -67,6 +67,8 @@ export const styles = {
   mainText: (color: keyof typeof quoteColors, align: Align) => ({
     ...quoteTextStyles,
     color: quoteColors[color],
+    fontFamily: 'Mulish',
+    fontStyle: 'italic',
     textAlign: alignments[align].textAlign
   }),
   sourceText: (align: Align) => ({

--- a/app/shared/components/blocks/HeroSection/HeroSection.style.ts
+++ b/app/shared/components/blocks/HeroSection/HeroSection.style.ts
@@ -101,6 +101,9 @@ export const heroSectionStyles = {
 
   biographyText: {
     fontWeight: 300,
+    strong: {
+      fontWeight: 600
+    },
     fontStyle: 'normal',
     fontSize: { xs: '18px', md: '24px' },
     lineHeight: '160%',


### PR DESCRIPTION
## Description
Fixed differend Ui bugs on the Liatoshynsky’s Life Story page.
SCENARIO-I
<img width="1466" height="383" alt="image" src="https://github.com/user-attachments/assets/86e02519-ce4f-4320-9d0a-379c3e2d351d" />

Fixed result:
провідних українських композиторів ХХ століття- front-weight:600

"... Сформована Лятошинським композиторська школа є найвпливовішою в Україні в другій половині..."

SCENARIO-II
<img width="1788" height="281" alt="image" src="https://github.com/user-attachments/assets/7d6bbb02-7dc1-4032-a470-625d219f7be0" />

Fixed result:



font-family: Mulish; font-style: Italic;

SCENARIO-III
<img width="1605" height="427" alt="image" src="https://github.com/user-attachments/assets/e57fd32e-8066-4294-b85b-f41faa8b6dc6" />

Fixed result:
row-gap:16px
## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
