### PR TITLE
fix: update font sizes for captions to be responsive

### DIFF
--- a/app/[lang]/biography/BiographyContent/BiographyContent.styles.ts
+++ b/app/[lang]/biography/BiographyContent/BiographyContent.styles.ts
@@ -164,14 +164,14 @@ export const biographyContentStyles = {
   leftImageCaption: {
     alignSelf: 'start',
     textAlign: 'left',
-    fontSize: '16px',
+    fontSize: { xs: '14px', sm: '14px', md: '16px', lg: '16px', xl: '16px' },
     fontWeight: 500,
     lineHeight: '140%'
   },
 
   rigthImageCaption: {
     alignSelf: 'end',
-    fontSize: '14px',
+    fontSize: { xs: '14px', sm: '14px', md: '16px', lg: '16px', xl: '16px' },
     fontWeight: 400,
     lineHeight: '140%'
   }


### PR DESCRIPTION
## Description
Font size for photo captions and quotes are standardized on the biography page to font-size 14px in responsive mode across small tablet and mobile screen sizes.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

Review the font-size for photo captions and quotes on the biography page.

## Video / Screenshots

<img width="622" height="279" alt="image" src="https://github.com/user-attachments/assets/fbe0f4b5-92db-4740-9abc-1b2d823e9d5d" />
<img width="359" height="405" alt="image" src="https://github.com/user-attachments/assets/df9c4833-73a2-4fc4-92ac-589962c9c2dd" />
<img width="403" height="369" alt="image" src="https://github.com/user-attachments/assets/3ea53dc6-0318-4c20-89cf-63ce91b0ac2b" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
