### PR TITLE
fix: incorrect behavior of the timeline bar on the biography page

### DIFF
--- a/app/[lang]/biography/page.tsx
+++ b/app/[lang]/biography/page.tsx
@@ -42,6 +42,7 @@ export default async function Biography({ params }: Readonly<Language>): Promise
     <MainLayout withLines>
       {blocks.heroSection && <HeroSection data={blocks.heroSection} years={years} />}
       {blocks.biographyContent && <BiographyContent data={blocks.biographyContent} />}
+      <div id="timeline-hide-sentinel" style={{ height: '1px' }} />
       {blocks.LiatoshynskyOffice && <LiatoshynskyOffice data={blocks.LiatoshynskyOffice} t={t} sx={{ mb: '80px' }} />}
     </MainLayout>
   );

--- a/app/shared/components/year-tabs/YearTabs.test.tsx
+++ b/app/shared/components/year-tabs/YearTabs.test.tsx
@@ -75,7 +75,7 @@ describe('YearTabs', () => {
     jest.clearAllMocks();
     ioInstances = [];
 
-    Object.defineProperty(window, 'innerHeight', { value: 800, writable: true });
+    Object.defineProperty(globalThis, 'innerHeight', { value: 800, writable: true });
 
     mockUseBreakpoints.mockReturnValue({ isMobile: false });
     mockUseScrollDirection.mockReturnValue('up');
@@ -152,7 +152,7 @@ describe('YearTabs', () => {
     rerender(<YearTabs years={MOCK_YEARS} />);
 
     act(() => {
-      window.dispatchEvent(new Event('scroll'));
+      globalThis.dispatchEvent(new Event('scroll'));
     });
 
     expect(buttonGroup).toHaveStyle('transform: translate(-50%, calc(100% + 5vh))');
@@ -165,7 +165,7 @@ describe('YearTabs', () => {
     rerender(<YearTabs years={MOCK_YEARS} />);
 
     act(() => {
-      window.dispatchEvent(new Event('scroll'));
+      globalThis.dispatchEvent(new Event('scroll'));
     });
 
     expect(buttonGroup).toHaveStyle('transform: translate(-50%)');
@@ -326,7 +326,7 @@ describe('YearTabs', () => {
     });
 
     act(() => {
-      window.dispatchEvent(new Event('scroll'));
+      globalThis.dispatchEvent(new Event('scroll'));
     });
 
     expect(buttonGroup).toHaveStyle('transform: translate(-50%, calc(100% + 5vh))');

--- a/app/shared/components/year-tabs/YearTabs.test.tsx
+++ b/app/shared/components/year-tabs/YearTabs.test.tsx
@@ -34,20 +34,6 @@ jest.mock('~/ds-components/button-group/ButtonGroup', () => ({
 const mockScrollTo = jest.fn();
 globalThis.scrollTo = mockScrollTo;
 
-let mockIntersectionObserverCallback: IntersectionObserverCallback;
-const mockObserve = jest.fn();
-const mockDisconnect = jest.fn();
-const mockUnobserve = jest.fn();
-
-globalThis.IntersectionObserver = jest.fn((callback) => {
-  mockIntersectionObserverCallback = callback;
-  return {
-    observe: mockObserve,
-    disconnect: mockDisconnect,
-    unobserve: mockUnobserve
-  } as unknown as IntersectionObserver;
-});
-
 const mockGetElementById = jest.fn();
 document.getElementById = mockGetElementById;
 
@@ -56,26 +42,66 @@ document.querySelectorAll = mockQuerySelectorAll;
 
 jest.useFakeTimers();
 
+type MockIOInstance = {
+  callback: IntersectionObserverCallback;
+  observe: jest.Mock;
+  disconnect: jest.Mock;
+  unobserve: jest.Mock;
+  observed: Element[];
+};
+
+let ioInstances: MockIOInstance[] = [];
+
+globalThis.IntersectionObserver = jest.fn((callback: IntersectionObserverCallback) => {
+  const instance: MockIOInstance = {
+    callback,
+    observed: [],
+    observe: jest.fn((el: Element) => {
+      instance.observed.push(el);
+    }),
+    disconnect: jest.fn(),
+    unobserve: jest.fn()
+  };
+
+  ioInstances.push(instance);
+  return instance as unknown as IntersectionObserver;
+});
+
 describe('YearTabs', () => {
-  let mockElements: HTMLElement[];
+  let mockYearElements: HTMLElement[];
+  let sentinel: HTMLElement;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    ioInstances = [];
+
+    Object.defineProperty(window, 'innerHeight', { value: 800, writable: true });
 
     mockUseBreakpoints.mockReturnValue({ isMobile: false });
     mockUseScrollDirection.mockReturnValue('up');
     globalThis.scrollY = 0;
     globalThis.pageYOffset = 0;
 
-    mockElements = MOCK_YEARS.map((year) => {
+    mockYearElements = MOCK_YEARS.map((year) => {
       const el = document.createElement('div');
       el.id = `year-${year}`;
       el.getBoundingClientRect = jest.fn(() => ({ top: 150 }) as DOMRect);
       return el;
     });
 
-    mockQuerySelectorAll.mockReturnValue(mockElements);
-    mockGetElementById.mockImplementation((id) => mockElements.find((el) => el.id === id) || null);
+    sentinel = document.createElement('div');
+    sentinel.id = 'timeline-hide-sentinel';
+    sentinel.getBoundingClientRect = jest.fn(() => ({ top: 99999 }) as DOMRect);
+
+    mockQuerySelectorAll.mockImplementation((selector: string) => {
+      if (selector === '[id^="year-"]') return mockYearElements;
+      return [];
+    });
+
+    mockGetElementById.mockImplementation((id: string) => {
+      if (id === 'timeline-hide-sentinel') return sentinel;
+      return mockYearElements.find((el) => el.id === id) || null;
+    });
   });
 
   afterAll(() => {
@@ -104,7 +130,12 @@ describe('YearTabs', () => {
 
     expect(buttonGroup).toHaveAttribute('data-active-index', '0');
     expect(globalThis.IntersectionObserver).toHaveBeenCalled();
-    expect(mockObserve).toHaveBeenCalledTimes(MOCK_YEARS.length);
+
+    const yearObserver = ioInstances.find((inst) =>
+      inst.observed.some((el) => (el as HTMLElement).id.startsWith('year-'))
+    );
+    expect(yearObserver).toBeTruthy();
+    expect(yearObserver!.observe).toHaveBeenCalledTimes(MOCK_YEARS.length);
   });
 
   it('should hide on scroll down and show on scroll up', () => {
@@ -120,6 +151,10 @@ describe('YearTabs', () => {
 
     rerender(<YearTabs years={MOCK_YEARS} />);
 
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
     expect(buttonGroup).toHaveStyle('transform: translate(-50%, calc(100% + 5vh))');
 
     act(() => {
@@ -129,12 +164,16 @@ describe('YearTabs', () => {
 
     rerender(<YearTabs years={MOCK_YEARS} />);
 
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
     expect(buttonGroup).toHaveStyle('transform: translate(-50%)');
   });
 
   it('should scroll to the element and update state on year click', () => {
     const targetYear = MOCK_YEARS[1];
-    const targetElement = mockElements[1];
+    const targetElement = mockYearElements[1];
 
     targetElement.getBoundingClientRect = jest.fn(() => ({ top: 500 }) as DOMRect);
     globalThis.pageYOffset = 100;
@@ -176,20 +215,25 @@ describe('YearTabs', () => {
 
     expect(buttonGroup).toHaveAttribute('data-active-index', '0');
 
+    const yearObserver = ioInstances.find((inst) =>
+      inst.observed.some((el) => (el as HTMLElement).id.startsWith('year-'))
+    );
+    expect(yearObserver).toBeTruthy();
+
     const mockEntry = {
       isIntersecting: true,
-      target: mockElements[2],
+      target: mockYearElements[2],
       boundingClientRect: { top: 110 }
     } as unknown as IntersectionObserverEntry;
 
     const mockEntryFar = {
       isIntersecting: true,
-      target: mockElements[1],
+      target: mockYearElements[1],
       boundingClientRect: { top: 300 }
     } as unknown as IntersectionObserverEntry;
 
     act(() => {
-      mockIntersectionObserverCallback([mockEntry, mockEntryFar], null as any);
+      yearObserver!.callback([mockEntry, mockEntryFar], null as any);
     });
 
     expect(buttonGroup).toHaveAttribute('data-active-index', '2');
@@ -202,14 +246,19 @@ describe('YearTabs', () => {
     fireEvent.click(screen.getByText(MOCK_YEARS[1]));
     expect(buttonGroup).toHaveAttribute('data-active-index', '1');
 
+    const yearObserver = ioInstances.find((inst) =>
+      inst.observed.some((el) => (el as HTMLElement).id.startsWith('year-'))
+    );
+    expect(yearObserver).toBeTruthy();
+
     const mockEntry = {
       isIntersecting: true,
-      target: mockElements[2],
+      target: mockYearElements[2],
       boundingClientRect: { top: 110 }
     } as unknown as IntersectionObserverEntry;
 
     act(() => {
-      mockIntersectionObserverCallback([mockEntry], null as any);
+      yearObserver!.callback([mockEntry], null as any);
     });
 
     expect(buttonGroup).toHaveAttribute('data-active-index', '1');
@@ -219,17 +268,20 @@ describe('YearTabs', () => {
     });
 
     act(() => {
-      mockIntersectionObserverCallback([mockEntry], null as any);
+      yearObserver!.callback([mockEntry], null as any);
     });
 
     expect(buttonGroup).toHaveAttribute('data-active-index', '2');
   });
 
-  it('should not create IntersectionObserver if no elements are found', () => {
+  it('should not create year IntersectionObserver if no elements are found', () => {
     mockQuerySelectorAll.mockReturnValue([]);
     render(<YearTabs years={MOCK_YEARS} />);
 
-    expect(globalThis.IntersectionObserver).not.toHaveBeenCalled();
+    const hasYearObserver = ioInstances.some((inst) =>
+      inst.observed.some((el) => (el as HTMLElement).id.startsWith('year-'))
+    );
+    expect(hasYearObserver).toBe(false);
   });
 
   it('should remove scroll event listener on unmount', () => {
@@ -245,10 +297,38 @@ describe('YearTabs', () => {
   it('should disconnect IntersectionObserver on unmount', () => {
     const { unmount } = render(<YearTabs years={MOCK_YEARS} />);
 
-    expect(globalThis.IntersectionObserver).toHaveBeenCalled();
-
     unmount();
 
-    expect(mockDisconnect).toHaveBeenCalled();
+    const disconnectCalls = ioInstances.reduce((acc, inst) => acc + inst.disconnect.mock.calls.length, 0);
+    expect(disconnectCalls).toBeGreaterThan(0);
+  });
+
+  it('should hide when sentinel passes the bottom threshold (forceHidden)', () => {
+    render(<YearTabs years={MOCK_YEARS} />);
+    const buttonGroup = screen.getByTestId('YearTabs-yearsGroup');
+
+    const sentinelObserver = ioInstances.find((inst) =>
+      inst.observed.some((el) => (el as HTMLElement).id === 'timeline-hide-sentinel')
+    );
+    expect(sentinelObserver).toBeTruthy();
+
+    act(() => {
+      sentinelObserver!.callback(
+        [
+          {
+            target: sentinel,
+            boundingClientRect: { top: 0 },
+            rootBounds: { bottom: 800 } as any
+          } as unknown as IntersectionObserverEntry
+        ],
+        null as any
+      );
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(buttonGroup).toHaveStyle('transform: translate(-50%, calc(100% + 5vh))');
   });
 });

--- a/app/shared/components/year-tabs/YearTabs.tsx
+++ b/app/shared/components/year-tabs/YearTabs.tsx
@@ -8,6 +8,8 @@ import useBreakpoints from '~/hooks/use-breakpoints/useBreakpoints';
 import { useScrollDirection } from '~/hooks/use-scroll-direction/useScrollDirection';
 
 const HEADER_OFFSET = 100;
+const HIDE_SENTINEL_SELECTOR = 'timeline-hide-sentinel';
+const OFFSET = 50;
 
 interface Data {
   years: string[];
@@ -18,13 +20,55 @@ export default function YearTabs({ years }: Readonly<Data>) {
   const [year, setYear] = useState<string>(years[0] ?? '');
   const [isVisible, setIsVisible] = useState<boolean>(true);
   const isClickScrolling = useRef(false);
+
   const scrollDirection = useScrollDirection(100);
+  const scrollDirectionRef = useRef(scrollDirection);
+  useEffect(() => {
+    scrollDirectionRef.current = scrollDirection;
+  }, [scrollDirection]);
+
+  const [forceHidden, setForceHidden] = useState(false);
+  const forceHiddenRef = useRef(forceHidden);
+  useEffect(() => {
+    forceHiddenRef.current = forceHidden;
+  }, [forceHidden]);
+
+  useEffect(() => {
+    if (isMobile) return;
+
+    const el = document.getElementById(HIDE_SENTINEL_SELECTOR);
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const bottom = entry.rootBounds?.bottom ?? window.innerHeight;
+        const top = entry.boundingClientRect.top;
+
+        setForceHidden(top <= bottom);
+      },
+      {
+        threshold: 0,
+        rootMargin: `0px 0px -${OFFSET}px 0px`
+      }
+    );
+
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [isMobile]);
 
   useEffect(() => {
     if (isMobile) return;
 
     const handleVisibility = () => {
-      const isScrollingDown = scrollDirection === 'down';
+      if (forceHiddenRef.current) {
+        setIsVisible(false);
+        return;
+      }
+
+      const isScrollingDown = scrollDirectionRef.current === 'down';
       const isBelowHeader = window.scrollY > HEADER_OFFSET;
       const shouldHideOnScroll = isScrollingDown && isBelowHeader;
       setIsVisible(!shouldHideOnScroll);
@@ -34,7 +78,7 @@ export default function YearTabs({ years }: Readonly<Data>) {
 
     window.addEventListener('scroll', handleVisibility, { passive: true });
     return () => window.removeEventListener('scroll', handleVisibility);
-  }, [scrollDirection, isMobile]);
+  }, [isMobile]);
 
   useEffect(() => {
     if (isMobile) return;


### PR DESCRIPTION
## Description

Added sentinel-based logic to control the YearTabs component visibility after the BiographyContent section, ensuring the timeline bar does not reappear on the LiatoshynskyOffice section or in the footer.
Updated and stabilized unit tests to properly handle IntersectionObserver behavior and scroll-driven visibility changes.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open the `/biography` page
2. Check the timeline bar behavior with different viewport sizes
3. Run tests

## Video / Screenshots

https://github.com/user-attachments/assets/8dd65791-d7c9-4929-ab19-8b02949f1a5d

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
