### PR TITLE
fix: foundation title wrap

### DIFF
--- a/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.styles.ts
+++ b/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.styles.ts
@@ -22,7 +22,8 @@ export const styles = {
     ...commonTextStyle,
     fontWeight: 700,
     fontSize: { xs: '18px', sm: '20px' },
-    lineHeight: '135%'
+    lineHeight: '135%',
+    textWrap: 'balance'
   },
   text: {
     ...commonTextStyle,


### PR DESCRIPTION
## Description

Fixed the incorrect line wrapping of the foundation title in the footer for the English version of the interface. 

Previously, the title "PUBLIC ORGANIZATION 'LIATOSHYNSKY FOUNDATION'" would break incorrectly across lines (e.g., leaving "FOUNDATION" orphaned) on devices with widths from 401px to 1440+px. 

The update ensures that if the full title does not fit on one line, it wraps to the next line as a complete unit or balances the words evenly, matching the expected design behavior.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: 

## How to test

1. Open the application locally.
2. Scroll down to the footer.
3. Switch the interface language to English.
4. Resize the browser window width between 400px and 1440px+ (simulate desktop and tablet views).
5. Observe the title "PUBLIC ORGANIZATION 'LIATOSHYNSKY FOUNDATION'".
6. Verify that the title wraps correctly (the words "LIATOSHYNSKY FOUNDATION" should stay together or balance evenly without awkward breaks).

## Video / Screenshots


https://github.com/user-attachments/assets/e090942c-8507-4eb9-a9e9-4d24413c35a2



## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board
