### PR TITLE
fix: incorrect scroll position on navigation from Liatoshynsky Office section

### DIFF
--- a/app/shared/components/design-system/all-components/button/Button.tsx
+++ b/app/shared/components/design-system/all-components/button/Button.tsx
@@ -67,7 +67,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     }
 
     return (
-      <Link style={{ width: 'fit-content' }} href={link}>
+      <Link style={{ width: 'fit-content' }} href={link} scroll onClickCapture={() => window.scrollTo({ top: 0 })}>
         {content}
       </Link>
     );


### PR DESCRIPTION
## Description

Explicitly enforced scroll-to-top behavior on navigation triggered from the Liatoshynsky Office button.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open `/about-us` page.
2. Scroll to `LiatoshynskyOffice` section.
3. Click on the CTA button and check that you see the start of the 404 page.

## Video / Screenshots

https://github.com/user-attachments/assets/700505d0-c365-4378-9256-bfd9d462c93b

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
