### PR TITLE
fix: incorrect background color in contacts form

### DIFF
--- a/app/[lang]/contacts/ContactsInfo/ContactsInfo.styles.ts
+++ b/app/[lang]/contacts/ContactsInfo/ContactsInfo.styles.ts
@@ -67,6 +67,7 @@ export const styles = {
     padding: { xs: '40px 24px 80px', sm: '64px 32px', md: '75px 53px', lg: '75px 96px' },
     margin: { xs: '0px -24px', sm: 'unset' },
     maxWidth: { sm: '400px', md: '496px', lg: '646px', xl: '744px' },
-    width: { xs: '100vw', sm: '100%' }
+    width: { xs: '100vw', sm: '100%' },
+    backgroundColor: mainHexPallete.white
   }
 };


### PR DESCRIPTION
## Description

Added explicit background color to form wrapper styles.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Go to `/contacts`.
2. Open DevTools.
3. Check that now there is an explicit background-color (bottom one).

## Video / Screenshots

<img width="213" height="32" alt="image" src="https://github.com/user-attachments/assets/8eb41000-4e91-488a-8e1e-efbc205ddb51" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
