### PR TITLE
fix: update YearTabs to use filtered valid years for state and rendering

### DIFF
--- a/app/shared/components/year-tabs/YearTabs.tsx
+++ b/app/shared/components/year-tabs/YearTabs.tsx
@@ -16,8 +16,9 @@ interface Data {
 }
 
 export default function YearTabs({ years }: Readonly<Data>) {
+  const validYears = years.filter((y) => y && y.trim() !== '');
   const { isMobile } = useBreakpoints();
-  const [year, setYear] = useState<string>(years[0] ?? '');
+  const [year, setYear] = useState<string>(validYears[0] ?? '');
   const [isVisible, setIsVisible] = useState<boolean>(true);
   const isClickScrolling = useRef(false);
 
@@ -112,7 +113,7 @@ export default function YearTabs({ years }: Readonly<Data>) {
       if (closestTarget) {
         const id = closestTarget.id;
         const newYear = id.replace('year-', '');
-        if (newYear) {
+        if (newYear && validYears.includes(newYear)) {
           setYear((prevYear) => (newYear === prevYear ? prevYear : newYear));
         }
       }
@@ -127,7 +128,7 @@ export default function YearTabs({ years }: Readonly<Data>) {
     return () => {
       observer.disconnect();
     };
-  }, [isMobile]);
+  }, [isMobile, validYears]);
 
   const handleYearChange = (selectedYear: string) => {
     isClickScrolling.current = true;
@@ -160,9 +161,9 @@ export default function YearTabs({ years }: Readonly<Data>) {
           transform: isVisible ? 'translate(-50%)' : 'translate(-50%, calc(100% + 5vh))',
           transition: 'transform 0.4s ease'
         }}
-        activeButton={years.indexOf(year)}
+        activeButton={validYears.indexOf(year)}
         defaultActiveButton={0}
-        buttons={years.map((year) => (
+        buttons={validYears.map((year) => (
           <Button sx={styles.yearButton} value={year} key={year} onClick={() => handleYearChange(year)}>
             {year}
           </Button>


### PR DESCRIPTION
## Description

This PR fixes an empty white indicator that was appearing before the first year anchor due to invalid data (empty strings) in the years prop. Implemented data validation within the YearTabs component. The code now filters `years.filter(y => y && y.trim() !== '')` to ensure only valid years are rendered and used for state calculations.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1.Navigate to Biography page.
2.Observe the graphical biography timeline.

## Video / Screenshots

<img width="1818" height="701" alt="image" src="https://github.com/user-attachments/assets/b0d07a00-7bf3-438e-b306-acf1616d7da6" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
