### PR TITLE
fix: add spacing between header and content on contact page

### DIFF
--- a/app/[lang]/contacts/ContactsInfo/ContactsInfo.styles.ts
+++ b/app/[lang]/contacts/ContactsInfo/ContactsInfo.styles.ts
@@ -2,6 +2,8 @@ import { mainHexPallete } from '~/shared/components/design-system/all-components
 
 export const styles = {
   root: {
+    mt: { xs: '35px', sm: '70px' },
+    mb: { xs: '55px', sm: '100px' },
     gridColumn: '1 / -1',
     maxWidth: '1728px',
     width: '100%',


### PR DESCRIPTION
## Description

Fix missing spacing between Header and content on the Contacts page

## Type of change

- [x] Bug fix

## How to test

1. Go to Contacts page
2. Check if there is spacing between content and Header on different screeen sizes

## Video / Screenshots

Before fix:
<img width="1890" height="787" alt="image" src="https://github.com/user-attachments/assets/9a04e221-f797-4e31-b89e-6b63f16842a5" />
<img width="1893" height="728" alt="image" src="https://github.com/user-attachments/assets/c60937fa-0fff-4091-891f-65b6470f1816" />

After fix:
<img width="1901" height="798" alt="image" src="https://github.com/user-attachments/assets/7a34c24b-1a16-403b-b36d-10368d4b1c16" />
<img width="1863" height="871" alt="image" src="https://github.com/user-attachments/assets/5b64932f-89a9-49a4-b999-a0a71256f0d9" />

## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
