### PR TITLE
fix: fix all main titles to be as h1 tag

### DIFF
--- a/app/[lang]/contacts/ContactsInfo/ContactsInfo.test.tsx
+++ b/app/[lang]/contacts/ContactsInfo/ContactsInfo.test.tsx
@@ -71,7 +71,7 @@ describe('ContactsInfo', () => {
   it('should render headings and translations', () => {
     render(<ContactsInfo contacts={contacts} socialLinks={socialLinks} />);
 
-    expect(screen.getByRole('heading', { level: 2, name: 'Contacts' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Contacts' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 5, name: 'Contact form' })).toBeInTheDocument();
 
     expect(screen.getByText('We are on social media:')).toBeInTheDocument();

--- a/app/[lang]/contacts/ContactsInfo/ContactsInfo.tsx
+++ b/app/[lang]/contacts/ContactsInfo/ContactsInfo.tsx
@@ -28,11 +28,11 @@ export default function ContactsInfo({ title, formTitle, contacts, socialLinks }
       <Box sx={styles.wrapper}>
         <Box sx={styles.contactsInfoWrapper}>
           {title ? (
-            <Typography sx={styles.title} data-testid="ContactsInfo-title">
+            <Typography variant="h1" sx={styles.title} data-testid="ContactsInfo-title">
               {title}
             </Typography>
           ) : (
-            <Typography sx={styles.titleMain} variant="h2" data-testid="ContactsInfo-title">
+            <Typography sx={styles.titleMain} variant="h1" data-testid="ContactsInfo-title">
               {t('contacts')}
             </Typography>
           )}

--- a/app/shared/components/blocks/HeroSection/HeroSection.tsx
+++ b/app/shared/components/blocks/HeroSection/HeroSection.tsx
@@ -21,7 +21,9 @@ export function HeroSection({ data, years }: Readonly<HeroSectionProps>) {
       <Box sx={heroSectionStyles.topContainer} data-testid="HeroSection-topContainer">
         <Box sx={heroSectionStyles.titleWithQuoteContainer} data-testid="HeroSection-titleWithQuoteContainer">
           <Box data-testid="HeroSection-title">
-            <Typography sx={heroSectionStyles.title}>{t('title')}</Typography>
+            <Typography variant="h1" sx={heroSectionStyles.title}>
+              {t('title')}
+            </Typography>
           </Box>
 
           <QuoteBlock

--- a/app/shared/components/blocks/IntroSection/IntroSection.tsx
+++ b/app/shared/components/blocks/IntroSection/IntroSection.tsx
@@ -12,7 +12,7 @@ export function IntroSection({ data }: { readonly data: IIntroSection }) {
 
   return (
     <Box sx={styles.container} data-testid="IntroSection">
-      <Typography sx={styles.title} data-testid="IntroSection-title">
+      <Typography variant="h1" sx={styles.title} data-testid="IntroSection-title">
         {title}
       </Typography>
       <Box sx={styles.photoContainer} data-testid="IntroSection-photoContainer">

--- a/app/shared/components/blocks/collaboration/collaboration-intro/CollaborationIntro.tsx
+++ b/app/shared/components/blocks/collaboration/collaboration-intro/CollaborationIntro.tsx
@@ -15,7 +15,7 @@ interface CollaborationIntroProps {
 export default function CollaborationIntro({ title, subtitle, content, contentAbove }: CollaborationIntroProps) {
   return (
     <Box sx={styles.container}>
-      <Typography variant="h2" sx={styles.title}>
+      <Typography variant="h1" sx={styles.title}>
         {title}
       </Typography>
       <Box sx={styles.textContainer}>

--- a/app/shared/components/blocks/privacy-policy/intro-section/IntroSection.tsx
+++ b/app/shared/components/blocks/privacy-policy/intro-section/IntroSection.tsx
@@ -18,7 +18,7 @@ export default function IntroSection({ title, trustAndSecurity, agreement, dataT
   return (
     <>
       <Box sx={styles(theme).titleWrapper} data-testid={dataTestId}>
-        <Typography sx={styles(theme).title} data-testid={`${dataTestId}-title`}>
+        <Typography variant="h1" sx={styles(theme).title} data-testid={`${dataTestId}-title`}>
           {title}
         </Typography>
       </Box>

--- a/app/shared/components/blocks/support-foundation/SupportFoundation.test.tsx
+++ b/app/shared/components/blocks/support-foundation/SupportFoundation.test.tsx
@@ -46,7 +46,7 @@ describe('SupportFoundation', () => {
     render(<SupportFoundation />);
 
     const heading = screen.getByRole('heading', {
-      level: 2,
+      level: 1,
       name: 'Support the Foundation'
     });
 

--- a/app/shared/components/blocks/support-foundation/SupportFoundation.tsx
+++ b/app/shared/components/blocks/support-foundation/SupportFoundation.tsx
@@ -15,7 +15,7 @@ function SupportFoundation() {
 
   return (
     <Box sx={styles.wrapper} data-testid="SupportFoundation">
-      <Typography variant="h2" sx={styles.sectionTitle} data-testid="SupportFoundation-title">
+      <Typography variant="h1" sx={styles.sectionTitle} data-testid="SupportFoundation-title">
         {t('title')}
       </Typography>
 

--- a/app/shared/components/blocks/terms-of-use/TermsOfUse.tsx
+++ b/app/shared/components/blocks/terms-of-use/TermsOfUse.tsx
@@ -22,7 +22,7 @@ const TermsOfUse = () => {
     <>
       <Box sx={style.gridContainer} data-testid="TermsOfUse">
         <Box sx={style.titleSection}>
-          <Typography variant="h2" sx={style.titleText} data-testid="TermsOfUse-title">
+          <Typography variant="h1" sx={style.titleText} data-testid="TermsOfUse-title">
             {t('title')}
           </Typography>
         </Box>

--- a/app/shared/components/blocks/war-info/WarInfoSection.tsx
+++ b/app/shared/components/blocks/war-info/WarInfoSection.tsx
@@ -18,7 +18,7 @@ const WarInfoSection: React.FC<WarInfoSectionProps> = ({ sx, ...props }) => {
   return (
     <Box sx={[style.gridContainer, ...sxToArray(sx)]} {...props}>
       <Box sx={style.titleSection}>
-        <Typography variant="h2" sx={style.titleText}>
+        <Typography variant="h1" sx={style.titleText}>
           {t('title')}
         </Typography>
       </Box>

--- a/app/shared/components/title-with-quote/TitleWithQuote.tsx
+++ b/app/shared/components/title-with-quote/TitleWithQuote.tsx
@@ -29,7 +29,7 @@ const TitleWithQuote = ({
   return (
     <Box sx={styles.mainContainer} data-testid="TitleWithQuote">
       <Box sx={styles.titleSection}>
-        <Typography variant="h2" sx={styles.titleText} data-testid="TitleWithQuote-title">
+        <Typography variant="h1" sx={styles.titleText} data-testid="TitleWithQuote-title">
           {title}
         </Typography>
       </Box>


### PR DESCRIPTION
## Description

According to the requirements, the page must begin with a main title (H1). So fix it and change all main titles to h1 tag

## Type of change

- [x] Bug fix

## How to test

1. Choose any page on our site
2. Open DevTool and check if main title is h1 tag

## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
