### PR TITLE
fix: implement h2 headings for decades

### DIFF
--- a/app/shared/components/year-with-line/YearWithLine.tsx
+++ b/app/shared/components/year-with-line/YearWithLine.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import { useEffect, useRef, useState } from 'react';
 
@@ -43,7 +44,9 @@ const YearWithLine = ({ year }: { year: number }) => {
     <Box sx={Styles.container} id={`year-${year}`}>
       <Box ref={textRef} sx={Styles.yearBlock}>
         <Box sx={Styles.line(offset)} />
-        <Box sx={Styles.year}>{numberStr}</Box>
+        <Typography variant="h2" sx={Styles.year}>
+          {numberStr}
+        </Typography>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Description

Replaced div elements with h2 headings for each decade section.

## Type of change

- [x] Bug fix

## How to test

1. Go to Biography page
2. Open DerTool and check if decade is implemented as a heading

## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
