### PR TITLE
fix: resolve sticky hover states and align button colors with design system

### DIFF
--- a/app/shared/components/Footer/FooterContactAndSupport/ContactUsButton/ContactUsButton.tsx
+++ b/app/shared/components/Footer/FooterContactAndSupport/ContactUsButton/ContactUsButton.tsx
@@ -16,7 +16,15 @@ const ContactUsButton: React.FC<ContactUsDataProps> = ({ data }) => {
       label={data.text}
       link={data.link}
       startIcon={<SvgImage alt="Contact Us Button" src="/icons/mail-icon.svg" width={20} height={20} />}
-      sx={{ gap: '0px' }}
+      sx={{
+        gap: '0px',
+        '&:hover': {
+          backgroundColor: 'primary.filledHovered'
+        },
+        '&:focus': {
+          backgroundColor: '#190d03'
+        }
+      }}
     />
   );
 };

--- a/app/shared/components/Footer/FooterContactAndSupport/DonationButton/DonationButton.tsx
+++ b/app/shared/components/Footer/FooterContactAndSupport/DonationButton/DonationButton.tsx
@@ -21,7 +21,15 @@ const DonationButton: React.FC<DonationDataProps> = ({ data }) => {
       shortLabel={data.shortText}
       link={data.link}
       startIcon={<SvgImage src="/icons/heart-handshake.svg" alt="Donation Button" width={20} height={20} />}
-      sx={{ gap: '0px' }}
+      sx={{
+        gap: '0px',
+        '&:hover': {
+          backgroundColor: 'primary.outlinedHovered'
+        },
+        '&:focus': {
+          backgroundColor: 'transparent'
+        }
+      }}
     />
   );
 };

--- a/app/shared/components/Footer/footer-social-media/social-media-icon/SocialMediaIcon.styles.ts
+++ b/app/shared/components/Footer/footer-social-media/social-media-icon/SocialMediaIcon.styles.ts
@@ -7,7 +7,7 @@ type SocialMediaIconProps = Partial<Record<SocialMediaTypes, { backgroundColor?:
 const instagramGradient = 'linear-gradient(165deg, #800BFD 10%, #FC01D7 35%, #FF0069 55%, #FF2F2B 75%, #FF8000 100%)';
 
 const baseButtonStyle: SxProps = {
-  backgroundColor: '#1A1008',
+  backgroundColor: '#190d03',
   borderRadius: '50%',
   width: 40,
   height: 40,
@@ -40,6 +40,19 @@ export const iconButtonBase = (type: SocialMediaTypes): SxProps => {
       },
 
       '&:hover::before': { opacity: 1 },
+      '&:focus': {
+        backgroundColor: '#190d03'
+      },
+      '&:focus::before': {
+        opacity: 0
+      },
+
+      '&:focus-visible': {
+        backgroundColor: '#190d03'
+      },
+      '&:focus-visible::before': {
+        opacity: 0
+      },
 
       '& > *': {
         position: 'relative',
@@ -50,8 +63,18 @@ export const iconButtonBase = (type: SocialMediaTypes): SxProps => {
 
   return {
     ...baseButtonStyle,
-    transition: '0.4s ease',
-    '&:hover': socialMediaHoverMap[type]
+    backgroundColor: '#190d03',
+    transition: 'background-color 0.3s ease',
+
+    '&:hover': socialMediaHoverMap[type],
+
+    '&:focus': {
+      backgroundColor: '#190d03'
+    },
+
+    '&:focus-visible': {
+      backgroundColor: '#190d03'
+    }
   };
 };
 


### PR DESCRIPTION
## Description

1. Sticky Hover & Focus Fixes
Fixed a critical issue where buttons (Social Media icons, Contact Us, and Donation buttons) remained in an "active" or "hovered" state after being clicked and returning to the page from an external link.

The Problem: Browsers (especially Chrome on Windows and mobile devices) were retaining focus on the elements, causing the hover background/gradient to persist.

The Solution: Explicitly defined `&:focus` and `&:focus-visible` states to reset the `backgroundColor` (for Facebook/YouTube) or `opacity` (for Instagram's `::before` pseudo-element) to their default states.

Separated hover logic using `&:focus:hover` to ensure visual feedback remains available only when the user is actively interacting with the element again.

2. Design System & Color Alignment
Adjusted the color values to match the project's official design palette.

Contact Us Button: Fixed the background color for both default and focus states. Changed the color to the specific dark shade from the design specs (`#190d03`) instead of a generic black, preventing it from appearing "off-color" on the yellow footer.

Social Media Icons: Updated the base background color from `#1A1008` to `#190d03` to ensure consistency across all components.

Donation Button : Ensured the background remains transparent during focus to avoid the "grey overlay" bug, while maintaining the correct value for the hover state.
## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test
Open the [If-client.](https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/uk/biography) in Chrome on OS Windows.
Open the Toggle device toolbar in DevTool. (Responsive doesn't make sense*)
Scroll down to the footer.
Press on the Instagram icon.
Return to the app after opening a new tab.
Review the Instagram icon.
Click somewhere on the page.
Repeat this step for Facebook and YouTube icons.
Also try for Contact Us and Support the Foundation buttons.

Open the [If-client.](https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/uk/biography) in Chrome on tablet/phone version forAndroid.
Scroll down to the footer.
Press on the Instagram icon.
Return to the app after opening a new tab.
Review the Instagram icon.
Click somewhere on the page.
Repeat this step for Facebook and YouTube icons.
Also try for Contact Us and Support the Foundation buttons.

## Video / Screenshots
<img width="1905" height="774" alt="image" src="https://github.com/user-attachments/assets/02dab3a1-5243-4e92-8e08-2bdf7ba0e68a" />

<img width="428" height="413" alt="image" src="https://github.com/user-attachments/assets/1151d951-ebea-4be9-bb10-56ff813c1be6" />


## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
