### PR TITLE
feature: home page cooperation block

### DIFF
--- a/app/shared/components/blocks/cooperation-section/CooperationSection.data.ts
+++ b/app/shared/components/blocks/cooperation-section/CooperationSection.data.ts
@@ -1,0 +1,36 @@
+import { partnersMock } from '../our-partners/partners.data';
+import { TipTapDoc } from '~/types/types/tiptap.types';
+
+import { makeDoc, normalText } from '~/lib/utils/tiptapHelpers';
+
+type LocalizedTipTapDoc = {
+  uk: TipTapDoc;
+  en: TipTapDoc;
+};
+
+export const cooperationSectionTextContent: LocalizedTipTapDoc = {
+  uk: makeDoc([
+    normalText(
+      'Ми віримо, що великі ідеї народжуються у співпраці. Саме завдяки підтримці партнерів і друзів нам вдається реалізовувати проєкти, що популяризують українську музику у світі. Якщо вам близькі наші цінності — будемо раді знайомству.'
+    )
+  ]),
+  en: makeDoc([
+    normalText(
+      'We believe that great ideas are born in collaboration. It is thanks to the support of partners and friends that we are able to implement projects that popularize Ukrainian music in the world. If our values are close to you — we will be happy to meet you.'
+    )
+  ])
+};
+
+export const cooperationSectionData = {
+  title: {
+    uk: 'НаШі ПаРтнЕрИ',
+    en: 'OuR PaRtNeRs'
+  },
+  textContent: cooperationSectionTextContent,
+  buttonText: {
+    uk: 'Долучитись до співпраці',
+    en: 'Join the Partnership'
+  },
+  buttonLink: '/cooperation',
+  partners: partnersMock
+};

--- a/app/shared/components/blocks/cooperation-section/CooperationSection.styles.ts
+++ b/app/shared/components/blocks/cooperation-section/CooperationSection.styles.ts
@@ -1,0 +1,26 @@
+export const styles = {
+  mainContainer: {
+    display: 'grid',
+    gridColumn: '1 / -1',
+    my: { xs: '80px', sm: '104px', md: '128px', lg: '144px' },
+    gridTemplateColumns: {
+      xs: 'repeat(4, 1fr)',
+      sm: 'repeat(8, 1fr)',
+      md: 'repeat(12, 1fr)'
+    },
+    columnGap: {
+      xs: '16px',
+      sm: '24px',
+      md: '40px'
+    }
+  },
+  textStyle: {
+    textIndent: {
+      xs: 'calc((100vw - 48px) / 4 * 1 + 4px)',
+      sm: 'calc((100vw - 112px) / 8 * 3 - 11px)',
+      md: 'calc((100vw - 144px) / 12 * 3 + 11px)',
+      xxl: 'calc((1728px - 144px) / 12 * 3 + 11px)'
+    },
+    gridColumn: { xs: '1/ -1', sm: '4/ -1', md: '6/-1' }
+  }
+};

--- a/app/shared/components/blocks/cooperation-section/CooperationSection.test.tsx
+++ b/app/shared/components/blocks/cooperation-section/CooperationSection.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+
+import { partnersMock } from '../our-partners/partners.data';
+import { CooperationSection } from './CooperationSection';
+
+import { makeDoc, normalText } from '~/lib/utils/tiptapHelpers';
+
+jest.mock('next-intl', () => ({
+  useLocale: () => 'en'
+}));
+
+jest.mock('../../section-title/SectionTitle', () => {
+  const MockSectionTitle = ({ title }: { title: string }) => <h2 data-testid="section-title">{title}</h2>;
+  MockSectionTitle.displayName = 'SectionTitle';
+  return MockSectionTitle;
+});
+
+jest.mock('../terms-of-use/terms-content/button-content-block/ButtonContentBlock', () => {
+  const MockButtonContentBlock = ({ content, buttonText, link }: any) => (
+    <div data-testid="button-content-block">
+      <div data-testid="content">{JSON.stringify(content)}</div>
+      <a href={link} data-testid="button-link">
+        {buttonText}
+      </a>
+    </div>
+  );
+  MockButtonContentBlock.displayName = 'ButtonContentBlock';
+  return MockButtonContentBlock;
+});
+
+jest.mock('../our-partners-slider', () => {
+  const MockOurPartnersSlider = ({ partners }: any) => (
+    <div data-testid="our-partners-slider" data-partners-count={partners?.length || 0}>
+      {partners?.map((partner: any) => (
+        <div key={partner.id} data-testid="slider-partner">
+          {partner.name}
+        </div>
+      ))}
+    </div>
+  );
+  MockOurPartnersSlider.displayName = 'OurPartnersSlider';
+  return MockOurPartnersSlider;
+});
+
+describe('CooperationSection', () => {
+  const mockProps = {
+    title: {
+      uk: 'Співпраця',
+      en: 'Cooperation'
+    },
+    textContent: {
+      uk: makeDoc([normalText('Текст українською')]),
+      en: makeDoc([normalText('Text in English')])
+    },
+    buttonText: {
+      uk: 'Детальніше',
+      en: 'Learn More'
+    },
+    buttonLink: '/cooperation',
+    partners: partnersMock.slice(0, 3)
+  };
+
+  it('should render section title with correct locale', () => {
+    render(<CooperationSection {...mockProps} />);
+
+    expect(screen.getByTestId('section-title')).toBeInTheDocument();
+    expect(screen.getByTestId('section-title')).toHaveTextContent('Cooperation');
+  });
+
+  it('should render button content block with correct data', () => {
+    render(<CooperationSection {...mockProps} />);
+
+    expect(screen.getByTestId('button-content-block')).toBeInTheDocument();
+    expect(screen.getByTestId('button-link')).toHaveTextContent('Learn More');
+    expect(screen.getByTestId('button-link')).toHaveAttribute('href', '/cooperation');
+  });
+
+  it('should render partners slider with provided partners', () => {
+    render(<CooperationSection {...mockProps} />);
+
+    const slider = screen.getByTestId('our-partners-slider');
+    expect(slider).toBeInTheDocument();
+    expect(slider).toHaveAttribute('data-partners-count', '3');
+
+    const sliderPartners = screen.getAllByTestId('slider-partner');
+    expect(sliderPartners).toHaveLength(3);
+  });
+
+  it('should render partners slider with empty array when no partners provided', () => {
+    const propsWithoutPartners = { ...mockProps, partners: undefined };
+    render(<CooperationSection {...propsWithoutPartners} />);
+
+    const slider = screen.getByTestId('our-partners-slider');
+    expect(slider).toBeInTheDocument();
+    expect(slider).toHaveAttribute('data-partners-count', '0');
+  });
+
+  it('should render all main components', () => {
+    render(<CooperationSection {...mockProps} />);
+
+    const title = screen.getByText('Cooperation');
+    const buttonBlock = screen.getByTestId('button-content-block');
+    const slider = screen.getByTestId('our-partners-slider');
+
+    expect(title).toBeInTheDocument();
+    expect(buttonBlock).toBeInTheDocument();
+    expect(slider).toBeInTheDocument();
+  });
+});

--- a/app/shared/components/blocks/cooperation-section/CooperationSection.tsx
+++ b/app/shared/components/blocks/cooperation-section/CooperationSection.tsx
@@ -58,7 +58,7 @@ export const CooperationSection: React.FC<Props> = ({ title, textContent, button
         link={buttonLink}
       />
 
-      <OurPartnersSlider partners={partners ?? []} autoScroll={true} autoScrollInterval={3000} />
+      <OurPartnersSlider partners={partners ?? []} autoScroll={false} autoScrollInterval={3000} />
     </Box>
   );
 };

--- a/app/shared/components/blocks/cooperation-section/CooperationSection.tsx
+++ b/app/shared/components/blocks/cooperation-section/CooperationSection.tsx
@@ -1,0 +1,64 @@
+import { Box } from '@mui/material';
+import { useLocale } from 'next-intl';
+import React from 'react';
+
+import SectionTitle from '../../section-title/SectionTitle';
+import { Partner } from '../our-partners/partners.data';
+import OurPartnersSlider from '../our-partners-slider';
+import ButtonContentBlock from '../terms-of-use/terms-content/button-content-block/ButtonContentBlock';
+import { styles } from './CooperationSection.styles';
+import { TipTapDoc } from '~/types/types/tiptap.types';
+
+interface Props {
+  title: {
+    uk: string;
+    en: string;
+  };
+  textContent: {
+    uk: TipTapDoc;
+    en: TipTapDoc;
+  };
+  buttonText: {
+    uk: string;
+    en: string;
+  };
+  buttonLink: string;
+  partners?: Partner[];
+}
+
+export const CooperationSection: React.FC<Props> = ({ title, textContent, buttonText, buttonLink, partners }) => {
+  const locale = useLocale();
+  return (
+    <Box sx={styles.mainContainer}>
+      <SectionTitle
+        icon={true}
+        title={title[locale]}
+        gridColumn={{ xs: '1/ -1', sm: '4/ -1', md: '6/-1' }}
+        sx={{
+          mb: { xs: '16px' },
+          gap: {
+            xs: '16px',
+            sm: '24px',
+            md: '40px'
+          },
+          '& h2': {
+            textTransform: 'none'
+          }
+        }}
+      />
+      <ButtonContentBlock
+        content={textContent[locale]}
+        buttonText={buttonText[locale]}
+        buttonColor="tertiary"
+        sx={{ maxWidth: { xs: '246px' }, minWidth: { xs: '246px' } }}
+        containerSx={{ mb: { xs: '64px', md: '80px' } }}
+        textSx={styles.textStyle}
+        textContainerSx={{ marginBottom: { xs: '24px', md: '0px' } }}
+        buttonContainerSx={{ justifyContent: { xs: 'flex-start', md: 'flex-end' } }}
+        link={buttonLink}
+      />
+
+      <OurPartnersSlider partners={partners ?? []} autoScroll={true} autoScrollInterval={3000} />
+    </Box>
+  );
+};

--- a/app/shared/components/blocks/our-partners-slider/OurPartnersSlider.styles.ts
+++ b/app/shared/components/blocks/our-partners-slider/OurPartnersSlider.styles.ts
@@ -10,27 +10,24 @@ export const styles = {
     width: '100%'
   },
 
-  scrollContainer: {
+  swiperStyle: {
+    width: '100%',
+    height: 'auto'
+  },
+
+  slideStyle: {
     display: 'flex',
-    overflowX: 'auto',
-    scrollBehavior: 'smooth',
-    gap: 0,
-    WebkitOverflowScrolling: 'touch',
-    msOverflowStyle: 'none',
-    scrollbarWidth: 'none',
-    '&::-webkit-scrollbar': {
-      display: 'none'
-    },
-    touchAction: 'pan-x'
+    alignItems: 'center',
+    justifyContent: 'center'
   },
 
   slideItem: {
-    flex: '0 0 20%',
-    minWidth: '20%',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    boxSizing: 'border-box'
+    width: '100%',
+    height: '100%',
+    padding: { xs: '8px', sm: '12px', md: '16px' }
   },
 
   logoImage: {

--- a/app/shared/components/blocks/our-partners-slider/OurPartnersSlider.styles.ts
+++ b/app/shared/components/blocks/our-partners-slider/OurPartnersSlider.styles.ts
@@ -1,0 +1,43 @@
+export const styles = {
+  wrapper: {
+    gridColumn: '1 / -1',
+    mb: { xs: '80px', sm: '104px', md: '128px', lg: '144px' }
+  },
+
+  sliderContainer: {
+    gridColumn: '1 / -1',
+    overflow: 'hidden',
+    width: '100%'
+  },
+
+  scrollContainer: {
+    display: 'flex',
+    overflowX: 'auto',
+    scrollBehavior: 'smooth',
+    gap: 0,
+    WebkitOverflowScrolling: 'touch',
+    msOverflowStyle: 'none',
+    scrollbarWidth: 'none',
+    '&::-webkit-scrollbar': {
+      display: 'none'
+    },
+    touchAction: 'pan-x'
+  },
+
+  slideItem: {
+    flex: '0 0 20%',
+    minWidth: '20%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    boxSizing: 'border-box'
+  },
+
+  logoImage: {
+    objectFit: 'contain',
+    height: 'auto',
+    maxHeight: '112px',
+    width: '100%',
+    maxWidth: '200px'
+  }
+};

--- a/app/shared/components/blocks/our-partners-slider/OurPartnersSlider.test.tsx
+++ b/app/shared/components/blocks/our-partners-slider/OurPartnersSlider.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+
+import { partnersMock } from '../our-partners/partners.data';
+import OurPartnersSlider from './OurPartnersSlider';
+
+jest.mock('swiper/css', () => ({}));
+
+jest.mock('swiper/react', () => ({
+  Swiper: ({ children, breakpoints }: any) => (
+    <div data-testid="swiper-slider" data-breakpoints={JSON.stringify(breakpoints)}>
+      {children}
+    </div>
+  ),
+  SwiperSlide: ({ children }: any) => <div data-testid="swiper-slide">{children}</div>
+}));
+
+jest.mock('swiper/modules', () => ({
+  Autoplay: {}
+}));
+
+jest.mock('../../partner-logo/PartnerLogo', () => {
+  const MockPartnerLogo = ({ image, link }: { image: React.ReactNode; link: string }) => (
+    <a href={link} data-testid="partner-logo">
+      {image}
+    </a>
+  );
+  MockPartnerLogo.displayName = 'PartnerLogo';
+  return MockPartnerLogo;
+});
+
+describe('OurPartnersSlider', () => {
+  const mockPartners = partnersMock.slice(0, 3);
+
+  it('should render slider with partners', () => {
+    render(<OurPartnersSlider partners={mockPartners} />);
+
+    expect(screen.getByTestId('swiper-slider')).toBeInTheDocument();
+    const slides = screen.getAllByTestId('swiper-slide');
+    expect(slides).toHaveLength(mockPartners.length);
+  });
+
+  it('should render partner logos with correct data', () => {
+    render(<OurPartnersSlider partners={mockPartners} />);
+
+    const logos = screen.getAllByTestId('partner-logo');
+    expect(logos).toHaveLength(mockPartners.length);
+
+    logos.forEach((logo, index) => {
+      expect(logo).toHaveAttribute('href', mockPartners[index].link);
+      const img = logo.querySelector('img');
+      expect(img).toHaveAttribute('alt', mockPartners[index].name);
+      expect(img).toHaveAttribute('src', mockPartners[index].img);
+    });
+  });
+
+  it('should render slider with responsive breakpoints', () => {
+    render(<OurPartnersSlider partners={mockPartners} />);
+
+    const slider = screen.getByTestId('swiper-slider');
+    const breakpoints = JSON.parse(slider.getAttribute('data-breakpoints') || '{}');
+
+    expect(breakpoints).toHaveProperty('0');
+    expect(breakpoints).toHaveProperty('600');
+    expect(breakpoints).toHaveProperty('900');
+    expect(breakpoints).toHaveProperty('1200');
+  });
+
+  it('should return null when no partners are provided', () => {
+    const { container } = render(<OurPartnersSlider partners={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should return null when partners is undefined', () => {
+    const { container } = render(<OurPartnersSlider partners={undefined as any} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render with autoScroll disabled by default', () => {
+    render(<OurPartnersSlider partners={mockPartners} />);
+    expect(screen.getByTestId('swiper-slider')).toBeInTheDocument();
+  });
+
+  it('should render with custom autoScrollInterval when provided', () => {
+    render(<OurPartnersSlider partners={mockPartners} autoScroll={true} autoScrollInterval={5000} />);
+    expect(screen.getByTestId('swiper-slider')).toBeInTheDocument();
+  });
+});

--- a/app/shared/components/blocks/our-partners-slider/OurPartnersSlider.tsx
+++ b/app/shared/components/blocks/our-partners-slider/OurPartnersSlider.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { Box } from '@mui/material';
+import React, { useEffect, useRef } from 'react';
+
+import PartnerLogo from '../../partner-logo/PartnerLogo';
+import { Partner } from '../our-partners/partners.data';
+import { styles } from './OurPartnersSlider.styles';
+
+interface OurPartnersSliderProps {
+  partners: Partner[];
+  autoScroll?: boolean;
+  autoScrollInterval?: number;
+}
+
+export default function OurPartnersSlider({
+  partners,
+  autoScroll = false,
+  autoScrollInterval = 3000
+}: OurPartnersSliderProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const autoScrollTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const infinitePartners = [...partners, ...partners, ...partners];
+
+  useEffect(() => {
+    if (!autoScroll || !scrollContainerRef.current) return;
+
+    const scrollContainer = scrollContainerRef.current;
+    const itemWidth = scrollContainer.scrollWidth / infinitePartners.length;
+
+    const startAutoScroll = () => {
+      autoScrollTimerRef.current = setInterval(() => {
+        if (scrollContainer) {
+          const currentScroll = scrollContainer.scrollLeft;
+          const maxScroll = scrollContainer.scrollWidth - scrollContainer.clientWidth;
+          const scrollAmount = itemWidth;
+
+          if (currentScroll >= maxScroll - scrollAmount) {
+            scrollContainer.scrollLeft = scrollAmount * partners.length;
+          } else {
+            scrollContainer.scrollLeft += scrollAmount;
+          }
+        }
+      }, autoScrollInterval);
+    };
+
+    const stopAutoScroll = () => {
+      if (autoScrollTimerRef.current) {
+        clearInterval(autoScrollTimerRef.current);
+        autoScrollTimerRef.current = null;
+      }
+    };
+
+    startAutoScroll();
+
+    scrollContainer.addEventListener('mouseenter', stopAutoScroll);
+    scrollContainer.addEventListener('mouseleave', startAutoScroll);
+
+    return () => {
+      stopAutoScroll();
+      scrollContainer.removeEventListener('mouseenter', stopAutoScroll);
+      scrollContainer.removeEventListener('mouseleave', startAutoScroll);
+    };
+  }, [autoScroll, autoScrollInterval, partners.length, infinitePartners.length]);
+
+  return (
+    <Box sx={styles.wrapper}>
+      <Box sx={styles.sliderContainer}>
+        <Box ref={scrollContainerRef} sx={styles.scrollContainer}>
+          {infinitePartners.map((partner, index) => (
+            <Box key={`${partner.id}-${index}`} sx={styles.slideItem}>
+              <PartnerLogo
+                link={partner.link}
+                image={
+                  <img
+                    src={partner.img}
+                    alt={partner.name}
+                    width={200}
+                    height={100}
+                    style={styles.logoImage as React.CSSProperties}
+                  />
+                }
+              />
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/app/shared/components/blocks/our-partners-slider/OurPartnersSlider.tsx
+++ b/app/shared/components/blocks/our-partners-slider/OurPartnersSlider.tsx
@@ -1,16 +1,19 @@
 'use client';
 
+import 'swiper/css';
 import { Box } from '@mui/material';
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
+import { Autoplay } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
 
 import PartnerLogo from '../../partner-logo/PartnerLogo';
 import { Partner } from '../our-partners/partners.data';
 import { styles } from './OurPartnersSlider.styles';
 
 interface OurPartnersSliderProps {
-  partners: Partner[];
-  autoScroll?: boolean;
-  autoScrollInterval?: number;
+  readonly partners: Partner[];
+  readonly autoScroll?: boolean;
+  readonly autoScrollInterval?: number;
 }
 
 export default function OurPartnersSlider({
@@ -18,73 +21,68 @@ export default function OurPartnersSlider({
   autoScroll = false,
   autoScrollInterval = 3000
 }: OurPartnersSliderProps) {
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const autoScrollTimerRef = useRef<NodeJS.Timeout | null>(null);
+  if (!partners || partners.length === 0) return null;
 
-  const infinitePartners = [...partners, ...partners, ...partners];
-
-  useEffect(() => {
-    if (!autoScroll || !scrollContainerRef.current) return;
-
-    const scrollContainer = scrollContainerRef.current;
-    const itemWidth = scrollContainer.scrollWidth / infinitePartners.length;
-
-    const startAutoScroll = () => {
-      autoScrollTimerRef.current = setInterval(() => {
-        if (scrollContainer) {
-          const currentScroll = scrollContainer.scrollLeft;
-          const maxScroll = scrollContainer.scrollWidth - scrollContainer.clientWidth;
-          const scrollAmount = itemWidth;
-
-          if (currentScroll >= maxScroll - scrollAmount) {
-            scrollContainer.scrollLeft = scrollAmount * partners.length;
-          } else {
-            scrollContainer.scrollLeft += scrollAmount;
-          }
-        }
-      }, autoScrollInterval);
-    };
-
-    const stopAutoScroll = () => {
-      if (autoScrollTimerRef.current) {
-        clearInterval(autoScrollTimerRef.current);
-        autoScrollTimerRef.current = null;
-      }
-    };
-
-    startAutoScroll();
-
-    scrollContainer.addEventListener('mouseenter', stopAutoScroll);
-    scrollContainer.addEventListener('mouseleave', startAutoScroll);
-
-    return () => {
-      stopAutoScroll();
-      scrollContainer.removeEventListener('mouseenter', stopAutoScroll);
-      scrollContainer.removeEventListener('mouseleave', startAutoScroll);
-    };
-  }, [autoScroll, autoScrollInterval, partners.length, infinitePartners.length]);
+  const sliderBreakpoints = {
+    0: {
+      slidesPerView: 2,
+      spaceBetween: 0
+    },
+    600: {
+      slidesPerView: 3,
+      spaceBetween: 0
+    },
+    900: {
+      slidesPerView: 4,
+      spaceBetween: 0
+    },
+    1200: {
+      slidesPerView: 5,
+      spaceBetween: 0
+    }
+  };
 
   return (
     <Box sx={styles.wrapper}>
       <Box sx={styles.sliderContainer}>
-        <Box ref={scrollContainerRef} sx={styles.scrollContainer}>
-          {infinitePartners.map((partner, index) => (
-            <Box key={`${partner.id}-${index}`} sx={styles.slideItem}>
-              <PartnerLogo
-                link={partner.link}
-                image={
-                  <img
-                    src={partner.img}
-                    alt={partner.name}
-                    width={200}
-                    height={100}
-                    style={styles.logoImage as React.CSSProperties}
-                  />
+        <Swiper
+          modules={[Autoplay]}
+          spaceBetween={0}
+          slidesPerView={5}
+          loop={true}
+          speed={800}
+          /* eslint-disable */
+          autoplay={
+            autoScroll
+              ? {
+                  delay: autoScrollInterval,
+                  disableOnInteraction: false,
+                  pauseOnMouseEnter: true
                 }
-              />
-            </Box>
+              : false
+          }
+          breakpoints={sliderBreakpoints}
+          style={styles.swiperStyle as React.CSSProperties}
+        >
+          {partners.map((partner) => (
+            <SwiperSlide key={partner.id} style={styles.slideStyle as React.CSSProperties}>
+              <Box sx={styles.slideItem}>
+                <PartnerLogo
+                  link={partner.link}
+                  image={
+                    <img
+                      src={partner.img}
+                      alt={partner.name}
+                      width={200}
+                      height={100}
+                      style={styles.logoImage as React.CSSProperties}
+                    />
+                  }
+                />
+              </Box>
+            </SwiperSlide>
           ))}
-        </Box>
+        </Swiper>
       </Box>
     </Box>
   );

--- a/app/shared/components/blocks/our-partners-slider/index.ts
+++ b/app/shared/components/blocks/our-partners-slider/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OurPartnersSlider';

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "react-hook-form": "^7.62.0",
         "react-virtualized": "^9.22.6",
         "redoc": "^2.5.2",
+        "swiper": "^12.1.0",
         "uuid": "^13.0.0",
         "winston": "^3.17.0",
         "winston-mongodb": "^6.0.0",
@@ -16139,6 +16140,25 @@
       },
       "funding": {
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.0.tgz",
+      "integrity": "sha512-BD4CpAOOyEvZ2f0CDx362ea+vmOwukVcmbsQx+0BhRIaBUz8wvcCd//E7RFmvBZCrfyqXCHUVqmgUwts6ywlxw==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-hook-form": "^7.62.0",
     "react-virtualized": "^9.22.6",
     "redoc": "^2.5.2",
+    "swiper": "^12.1.0",
     "uuid": "^13.0.0",
     "winston": "^3.17.0",
     "winston-mongodb": "^6.0.0",


### PR DESCRIPTION
## Description
This pull request introduces a new "Cooperation Section" feature and a reusable "Our Partners Slider" component, both with localization and responsive design. It also adds comprehensive unit tests for both components and integrates the Swiper library for slider functionality.

**New Cooperation Section feature:**

* Added `CooperationSection` component

**Reusable Partners Slider:**

* Implemented `OurPartnersSlider` component that displays partner logos in a responsive, optionally auto-scrolling slider, using Swiper and MUI styles.

**Testing:**

* Added unit tests for both `CooperationSection` and `OurPartnersSlider` components, including localization, rendering logic, and slider behavior. [[1]](diffhunk://#diff-85ee8c40d6528a18330623e7ccc46356d6eda25657ee2278e7272b269f052566R1-R109) [[2]](diffhunk://#diff-a8731847df38e4d84532792fc5be8ff771385f5f08120cf3db953918ab00e6acR1-R87)

## Type of change

- [x] New feature

## Screenshots

<img width="1079" height="343" alt="Знімок екрана 2026-01-30 о 21 43 25" src="https://github.com/user-attachments/assets/6361c4aa-25ff-4948-8a94-cc3442de4d91" />

<img width="704" height="302" alt="Знімок екрана 2026-01-30 о 21 43 39" src="https://github.com/user-attachments/assets/f0bc6e62-a86d-489c-b005-564228509a95" />

<img width="562" height="293" alt="Знімок екрана 2026-01-30 о 21 43 50" src="https://github.com/user-attachments/assets/4d439d47-06c4-4311-8690-0f6b9e087983" />

<img width="419" height="286" alt="Знімок екрана 2026-01-30 о 21 43 59" src="https://github.com/user-attachments/assets/ca5d543f-8ebd-477f-ab69-085792a3fc99" />

<img width="178" height="304" alt="Знімок екрана 2026-01-30 о 21 44 34" src="https://github.com/user-attachments/assets/86078688-877d-40b3-9525-54d8d7a9644d" />




