### PR TITLE
feat: implemented News, Events & Media page Layout

### DIFF
--- a/app/[lang]/news/MediaIntroSection/MediaIntroSection.styles.ts
+++ b/app/[lang]/news/MediaIntroSection/MediaIntroSection.styles.ts
@@ -1,0 +1,62 @@
+export const styles = {
+  gridContainer: {
+    mt: '80px',
+    mb: { xs: '64px', sm: '56px', md: '72px' },
+    display: 'grid',
+    gridColumn: '1 / -1',
+    gridTemplateColumns: {
+      xs: 'repeat(4, 1fr)',
+      sm: 'repeat(8, 1fr)',
+      md: 'repeat(12, 1fr)'
+    },
+    columnGap: {
+      xs: '16px',
+      sm: '24px',
+      md: '40px'
+    }
+  },
+  textBlockContainer: {
+    pt: { xs: '40px', sm: '16px', lg: '44px' },
+    gridColumn: {
+      xs: '1 / 5',
+      sm: '4 / -1',
+      md: '6 / -1'
+    }
+  },
+  titleSection: {
+    gridColumn: {
+      xs: '1 / -1',
+      sm: '1 / 4',
+      md: '1 / 6'
+    },
+    height: 'fit-content'
+  },
+  titleText: {
+    fontFamily: 'Oswald, sans-serif',
+    fontWeight: 600,
+    lineHeight: '120%',
+    letterSpacing: '0px',
+    color: 'black',
+    whiteSpace: 'pre-line',
+    // mt: {
+    //   xs: '80px',
+    //   sm: '108px',
+    //   md: '156px'
+    // },
+    // mb: { xs: '44px', sm: '0px' },
+    fontSize: {
+      xs: '40px',
+      md: '64px'
+    }
+    // width: { md: '570px', lg: '560px' }
+  },
+  longText: {
+    textIndent: {
+      xs: 'calc((100vw - 48px) / 4 * 1 + 4px)',
+      sm: 'calc((100vw - 112px) / 8 * 3 - 11px)',
+      md: 'calc((100vw - 144px) / 12 * 3 + 11px)',
+      xxl: 'calc((1728px - 144px) / 12 * 3 + 11px)'
+    },
+    gridColumn: '1 / -1'
+  }
+};

--- a/app/[lang]/news/MediaIntroSection/MediaIntroSection.test.tsx
+++ b/app/[lang]/news/MediaIntroSection/MediaIntroSection.test.tsx
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import MediaIntroSection from './MediaIntroSection';
+
+// mock next-intl
+jest.mock('next-intl', () => ({
+  useLocale: jest.fn(),
+  useTranslations: jest.fn()
+}));
+
+// mock ContentBlock
+jest.mock('~/shared/components/design-system/all-components/content-block/ContentBlock', () => ({
+  __esModule: true,
+  default: ({ description }: { description: string }) => <div data-testid="ContentBlock">{description}</div>
+}));
+
+// mock media.const
+jest.mock('~/shared/components/blocks/media-center/media.const', () => ({
+  mediaBigDoc: {
+    en: 'Big media text EN',
+    uk: 'Big media text UK'
+  },
+  mediaSmallDoc: {
+    en: 'Small media text EN',
+    uk: 'Small media text UK'
+  }
+}));
+
+import { useLocale, useTranslations } from 'next-intl';
+
+describe('MediaIntroSection', () => {
+  beforeEach(() => {
+    (useLocale as jest.Mock).mockReturnValue('en');
+    (useTranslations as jest.Mock).mockReturnValue((key: string) => {
+      const translations: Record<string, string> = {
+        title: 'Media Center'
+      };
+      return translations[key];
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render translated title', () => {
+    render(<MediaIntroSection />);
+
+    expect(screen.getByRole('heading', { name: 'Media Center' })).toBeInTheDocument();
+  });
+
+  it('should render big and small media content blocks for current locale', () => {
+    render(<MediaIntroSection />);
+
+    const blocks = screen.getAllByTestId('ContentBlock');
+
+    expect(blocks).toHaveLength(2);
+
+    expect(blocks[0]).toHaveTextContent('Big media text EN');
+    expect(blocks[1]).toHaveTextContent('Small media text EN');
+  });
+});

--- a/app/[lang]/news/MediaIntroSection/MediaIntroSection.tsx
+++ b/app/[lang]/news/MediaIntroSection/MediaIntroSection.tsx
@@ -1,0 +1,26 @@
+import { Box, Typography } from '@mui/material';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { styles } from './MediaIntroSection.styles';
+
+import { mediaBigDoc, mediaSmallDoc } from '~/shared/components/blocks/media-center/media.const';
+import ContentBlock from '~/shared/components/design-system/all-components/content-block/ContentBlock';
+
+export default function MediaIntroSection() {
+  const locale = useLocale();
+  const t = useTranslations('media');
+
+  return (
+    <Box sx={styles.gridContainer}>
+      <Box sx={styles.titleSection}>
+        <Typography sx={styles.titleText} variant="h1">
+          {t('title')}
+        </Typography>
+      </Box>
+      <Box sx={styles.textBlockContainer}>
+        <ContentBlock textSx={styles.longText} description={mediaBigDoc[locale]} />
+        <ContentBlock textSx={{ gridColumn: '1 / -1', mt: '16px' }} description={mediaSmallDoc[locale]} />
+      </Box>
+    </Box>
+  );
+}

--- a/app/[lang]/news/page.test.tsx
+++ b/app/[lang]/news/page.test.tsx
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import News from './page';
+
+// mocks
+jest.mock('~/utils/isProductionMode', () => ({
+  isProductionMode: jest.fn()
+}));
+
+jest.mock('~/components/under-development/UnderDevelopment', () => ({
+  __esModule: true,
+  default: () => <div data-testid="UnderDevelopment" />
+}));
+
+jest.mock('~/layouts/main-layout/MainLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="MainLayout">{children}</div>
+}));
+
+jest.mock('./MediaIntroSection/MediaIntroSection', () => ({
+  __esModule: true,
+  default: () => <div data-testid="MediaIntroSection" />
+}));
+
+jest.mock('~/shared/components/blocks/media-center/MediaCenter', () => ({
+  __esModule: true,
+  default: () => <div data-testid="MediaCenter" />
+}));
+
+import { isProductionMode } from '~/utils/isProductionMode';
+
+describe('News page', () => {
+  it('should render UnderDevelopment when production mode is enabled', () => {
+    (isProductionMode as jest.Mock).mockReturnValue(true);
+
+    render(<News />);
+
+    expect(screen.getByTestId('UnderDevelopment')).toBeInTheDocument();
+    expect(screen.queryByTestId('MainLayout')).not.toBeInTheDocument();
+  });
+
+  it('should render MainLayout with MediaIntroSection and MediaCenter when production mode is disabled', () => {
+    (isProductionMode as jest.Mock).mockReturnValue(false);
+
+    render(<News />);
+
+    expect(screen.getByTestId('MainLayout')).toBeInTheDocument();
+    expect(screen.getByTestId('MediaIntroSection')).toBeInTheDocument();
+    expect(screen.getByTestId('MediaCenter')).toBeInTheDocument();
+
+    expect(screen.queryByTestId('UnderDevelopment')).not.toBeInTheDocument();
+  });
+});

--- a/app/[lang]/news/page.tsx
+++ b/app/[lang]/news/page.tsx
@@ -1,11 +1,12 @@
-import { Typography } from '@mui/material';
 import React from 'react';
 
 import UnderDevelopment from '~/components/under-development/UnderDevelopment';
 
+import MediaIntroSection from './MediaIntroSection/MediaIntroSection';
 import { isProductionMode } from '~/utils/isProductionMode';
 
 import MainLayout from '~/layouts/main-layout/MainLayout';
+import MediaCenter from '~/shared/components/blocks/media-center/MediaCenter';
 
 const News = () => {
   if (isProductionMode()) {
@@ -13,8 +14,9 @@ const News = () => {
   }
 
   return (
-    <MainLayout>
-      <Typography variant="h1">News, Events & Media</Typography>
+    <MainLayout withLines>
+      <MediaIntroSection />
+      <MediaCenter />
     </MainLayout>
   );
 };

--- a/app/shared/components/blocks/event-card/EventItem.fixture.ts
+++ b/app/shared/components/blocks/event-card/EventItem.fixture.ts
@@ -5,7 +5,7 @@ export interface EventItemFixture {
   props: EventItemProps;
 }
 
-export const MOCK_EVENT_ITEMS: Readonly<EventItemFixture[]> = [
+export const MOCK_EVENT_ITEMS: EventItemFixture[] = [
   {
     id: 'festival-weekend-1',
     props: {

--- a/app/shared/components/blocks/media-center/MediaCenter.tsx
+++ b/app/shared/components/blocks/media-center/MediaCenter.tsx
@@ -5,6 +5,8 @@ import { useEffect, useState } from 'react';
 
 import { CustomTabs } from '~/ds-components/tabs/Tabs';
 
+import EventsTab from '../../events-tab/EventsTab';
+import { EventItemFixture, MOCK_EVENT_ITEMS } from '../event-card/EventItem.fixture';
 import { mockNewsList, mockPressList } from './media.const';
 import { styles } from './MediaCenter.styles';
 import { TipTapDoc } from '~/types/types/tiptap.types';
@@ -33,6 +35,7 @@ export type newsPressCardItem = {
 function MediaCenter() {
   const [selectedTab, setSelectedTab] = useState('news');
   const [press, setPress] = useState<newsPressCardItem[] | null>(null);
+  const [events, setEvents] = useState<EventItemFixture[] | null>(null);
   const [news] = useState<newsPressCardItem[]>(() => {
     return [...mockNewsList].sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
   });
@@ -44,7 +47,10 @@ function MediaCenter() {
       );
       setPress(sortedPress);
     }
-  }, [selectedTab, press]);
+    if (selectedTab === 'events' && !events) {
+      setEvents(MOCK_EVENT_ITEMS);
+    }
+  }, [selectedTab, press, events]);
 
   return (
     <Box data-testid="MediaCenter" sx={styles.mediaContainer}>
@@ -60,6 +66,8 @@ function MediaCenter() {
       {selectedTab === 'news' && (
         <MediaList dataTestId={selectedTab[0].toUpperCase()} mediaData={news} variant="news" />
       )}
+
+      {selectedTab === 'events' && events && <EventsTab eventsData={events} />}
 
       {selectedTab === 'press' && press && (
         <MediaList dataTestId={selectedTab[0].toUpperCase()} mediaData={press} variant="press" />

--- a/app/shared/components/blocks/media-center/media.const.ts
+++ b/app/shared/components/blocks/media-center/media.const.ts
@@ -21,92 +21,9 @@ export const mediaBigDoc: LocalizedTipTapDoc = {
   ])
 };
 
-export const mediaSmallDoc: LocalizedTipTapDoc = {
-  uk: makeDoc([
-    normalText(
-      'Слідкуйте за анонсами, повертайтеся до вже пережитого, шукайте натхнення — Лятошинський і сьогодні має що сказати.'
-    )
-  ]),
-  en: makeDoc([
-    normalText(
-      'Follow the announcements, revisit past experiences, seek inspiration — Lyatoshynsky still has something to say today.'
-    )
-  ])
-};
-
 export const mockNewsList = [
   {
     _id: '1',
-    publishedAt: '2024-03-16T14:30:00.000Z',
-    newsDate: '2024-01-15T00:00:00.000Z',
-    title: 'Новини українськлю',
-
-    description: 'Опис новин українськлю',
-
-    content: {
-      type: TipTapNodeTypes.doc as const,
-      content: [
-        {
-          type: TipTapNodeTypes.paragraph as const,
-          content: [
-            {
-              type: TipTapNodeTypes.text as const,
-              text: 'Уся інформацію щодо цієї новини українською'
-            }
-          ]
-        }
-      ]
-    },
-    slug: 'news-title-1',
-    coverImage: {
-      src: '/images/placeholder.png',
-      alt: 'Альтернативний текст для зображення 1',
-
-      caption: 'Підпис до зображення 1',
-      isTmp: false
-    },
-    status: 'published',
-    meta: {
-      views: 1000
-    }
-  },
-  {
-    _id: '2',
-    publishedAt: '2024-03-16T14:30:00.000Z',
-    newsDate: '2024-01-15T00:00:00.000Z',
-    title: 'Новини українськлю',
-
-    description: 'Опис новин українськлю',
-
-    content: {
-      type: TipTapNodeTypes.doc as const,
-      content: [
-        {
-          type: TipTapNodeTypes.paragraph as const,
-          content: [
-            {
-              type: TipTapNodeTypes.text as const,
-              text: 'Уся інформацію щодо цієї новини українською'
-            }
-          ]
-        }
-      ]
-    },
-    slug: 'news-title-1',
-    coverImage: {
-      src: '/images/placeholder.png',
-      alt: 'Альтернативний текст для зображення 1',
-
-      caption: 'Підпис до зображення 1',
-      isTmp: false
-    },
-    status: 'published',
-    meta: {
-      views: 1000
-    }
-  },
-  {
-    _id: '3',
     publishedAt: '2024-03-16T14:30:00.000Z',
     newsDate: '2024-01-15T00:00:00.000Z',
     title: 'Новини українськлю',
@@ -179,3 +96,16 @@ export const mockPressList = [
     }
   }
 ];
+
+export const mediaSmallDoc: LocalizedTipTapDoc = {
+  uk: makeDoc([
+    normalText(
+      'Слідкуйте за анонсами, повертайтеся до вже пережитого, шукайте натхнення — Лятошинський і сьогодні має що сказати.'
+    )
+  ]),
+  en: makeDoc([
+    normalText(
+      'Follow the announcements, revisit past experiences, seek inspiration — Lyatoshynsky still has something to say today.'
+    )
+  ])
+};

--- a/app/shared/components/blocks/media-center/media.const.ts
+++ b/app/shared/components/blocks/media-center/media.const.ts
@@ -1,8 +1,112 @@
 import { TipTapNodeTypes } from '~/types/enums/common.enums';
+import { TipTapDoc } from '~/types/types/tiptap.types';
+
+import { makeDoc, normalText } from '~/lib/utils/tiptapHelpers';
+
+type LocalizedTipTapDoc = {
+  uk: TipTapDoc;
+  en: TipTapDoc;
+};
+
+export const mediaBigDoc: LocalizedTipTapDoc = {
+  uk: makeDoc([
+    normalText(
+      'У цьому розділі ми зібрали все, чим живе Фундація Лятошинського просто зараз. Концерти, лекції, новини, відео й архівні скарби — тут звучить не лише музика, а й події, що формують українську культурну реальність.'
+    )
+  ]),
+  en: makeDoc([
+    normalText(
+      'In this section, we have gathered everything that the Lyatoshynsky Foundation is currently working on. Concerts, lectures, news, videos, and archival treasures — here you will find not only music, but also events that shape Ukrainian cultural reality.'
+    )
+  ])
+};
+
+export const mediaSmallDoc: LocalizedTipTapDoc = {
+  uk: makeDoc([
+    normalText(
+      'Слідкуйте за анонсами, повертайтеся до вже пережитого, шукайте натхнення — Лятошинський і сьогодні має що сказати.'
+    )
+  ]),
+  en: makeDoc([
+    normalText(
+      'Follow the announcements, revisit past experiences, seek inspiration — Lyatoshynsky still has something to say today.'
+    )
+  ])
+};
 
 export const mockNewsList = [
   {
     _id: '1',
+    publishedAt: '2024-03-16T14:30:00.000Z',
+    newsDate: '2024-01-15T00:00:00.000Z',
+    title: 'Новини українськлю',
+
+    description: 'Опис новин українськлю',
+
+    content: {
+      type: TipTapNodeTypes.doc as const,
+      content: [
+        {
+          type: TipTapNodeTypes.paragraph as const,
+          content: [
+            {
+              type: TipTapNodeTypes.text as const,
+              text: 'Уся інформацію щодо цієї новини українською'
+            }
+          ]
+        }
+      ]
+    },
+    slug: 'news-title-1',
+    coverImage: {
+      src: '/images/placeholder.png',
+      alt: 'Альтернативний текст для зображення 1',
+
+      caption: 'Підпис до зображення 1',
+      isTmp: false
+    },
+    status: 'published',
+    meta: {
+      views: 1000
+    }
+  },
+  {
+    _id: '2',
+    publishedAt: '2024-03-16T14:30:00.000Z',
+    newsDate: '2024-01-15T00:00:00.000Z',
+    title: 'Новини українськлю',
+
+    description: 'Опис новин українськлю',
+
+    content: {
+      type: TipTapNodeTypes.doc as const,
+      content: [
+        {
+          type: TipTapNodeTypes.paragraph as const,
+          content: [
+            {
+              type: TipTapNodeTypes.text as const,
+              text: 'Уся інформацію щодо цієї новини українською'
+            }
+          ]
+        }
+      ]
+    },
+    slug: 'news-title-1',
+    coverImage: {
+      src: '/images/placeholder.png',
+      alt: 'Альтернативний текст для зображення 1',
+
+      caption: 'Підпис до зображення 1',
+      isTmp: false
+    },
+    status: 'published',
+    meta: {
+      views: 1000
+    }
+  },
+  {
+    _id: '3',
     publishedAt: '2024-03-16T14:30:00.000Z',
     newsDate: '2024-01-15T00:00:00.000Z',
     title: 'Новини українськлю',

--- a/app/shared/components/events-tab/EventsTab.test.tsx
+++ b/app/shared/components/events-tab/EventsTab.test.tsx
@@ -5,7 +5,7 @@ import EventsTab from './EventsTab';
 import type { EventItemProps } from '~/shared/components/blocks/event-card/EventItem';
 import { EventItemFixture } from '~/shared/components/blocks/event-card/EventItem.fixture';
 
-export const MOCK_EVENTS: ReadonlyArray<EventItemFixture> = [
+export const MOCK_EVENTS: EventItemFixture[] = [
   {
     id: 'upcoming-1',
     props: {

--- a/app/shared/components/events-tab/EventsTab.tsx
+++ b/app/shared/components/events-tab/EventsTab.tsx
@@ -15,7 +15,7 @@ import { EventItemFixture } from '~/shared/components/blocks/event-card/EventIte
 import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
 
 interface EventsTabProps {
-  eventsData: ReadonlyArray<EventItemFixture>;
+  eventsData: EventItemFixture[];
   itemsPerPage?: number;
   tabSx?: object;
 }

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -147,6 +147,9 @@
       "phoneCopiedAlert": "Copied"
     }
   },
+  "media": {
+    "title": "NeWs, EveNtS aNd MeDia"
+  },
   "collaboration": {
     "offerCollaboration": {
       "title": "We are open to collaboration, inquiries, and dialogue:",

--- a/i18n/messages/uk.json
+++ b/i18n/messages/uk.json
@@ -147,6 +147,9 @@
       "phoneCopiedAlert": "Скопійовано"
     }
   },
+  "media": {
+    "title": "НоВинИ, ПоДіЇ тА мЕдіА"
+  },
   "collaboration": {
     "offerCollaboration": {
       "title": "Ми відкриті до співпраці, запитів і діалогу:",


### PR DESCRIPTION
## Description

This PR assembles the "News, Events & Media" page.
A new MediaIntroSection block component was created for the page introduction.
The page uses the MediaCenter component to display tab-based content switching between News, Events, and Media sections.

## Type of change

- [x] New feature

## How to test

1. Add static data to media.const.ts and  EventItem.fixture.ts files
2. After just visit our News, Events and Media page

## Video / Screenshots


https://github.com/user-attachments/assets/1f74fb35-3c11-4e8e-8f47-d3d735c00bcb


## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
