### PR TITLE
fix: improve transaltion validation to avoid bug with page appearence

### DIFF
--- a/app/validators/localization.ts
+++ b/app/validators/localization.ts
@@ -32,38 +32,55 @@ function doesTipTapHaveTranslations(root: z.infer<typeof TipTapDocSchema>): bool
   return false;
 }
 
-function validTranslatedField(value: Record<string, unknown>, locale: Locale): boolean {
-  if (typeof value[locale] === 'string') {
-    return value[locale] !== '';
+function validTranslatedField(value: Record<string, unknown>, locale: Locale, path?: string): boolean {
+  if (!(locale in value)) {
+    return false;
   }
-  if (typeof value[locale] === 'object') {
-    return doesTipTapHaveTranslations(value[locale] as TipTapDoc);
+
+  const fieldValue = value[locale];
+
+  if (typeof fieldValue === 'string') {
+    if (fieldValue === '' && path) {
+      const isOptionalField = path.endsWith('.alt') || path.endsWith('.caption');
+      if (isOptionalField) {
+        return true;
+      }
+    }
+    return fieldValue !== '';
+  }
+
+  if (typeof fieldValue === 'object') {
+    return doesTipTapHaveTranslations(fieldValue as TipTapDoc);
   }
 
   return false;
 }
 
-function translationErrorFactory(locale: Locale): Error {
-  return new Error(locale === 'en' ? LocalizationErrors.MISSING_EN_ERROR : LocalizationErrors.MISSING_UK_ERROR);
+function translationErrorFactory(locale: Locale, path?: string): Error {
+  const baseMessage = locale === 'en' ? LocalizationErrors.MISSING_EN_ERROR : LocalizationErrors.MISSING_UK_ERROR;
+  const message = path ? `${baseMessage} at path: ${path}` : baseMessage;
+  return new Error(message);
 }
 
 export function LocalizeSchema<S extends z.ZodTypeAny>(schema: S, locale: Locale) {
-  function localizeValue(value: unknown): unknown {
+  function localizeValue(value: unknown, path: string = 'root'): unknown {
     if (isTranslatedField(value, locale)) {
-      if (!validTranslatedField(value, locale)) {
-        throw translationErrorFactory(locale);
+      if (!validTranslatedField(value, locale, path)) {
+        throw translationErrorFactory(locale, path);
       }
 
       return value[locale];
     }
     if (Array.isArray(value)) {
-      return value.map(localizeValue);
+      return value.map((item, idx) => localizeValue(item, `${path}[${idx}]`));
     }
     if (typeof value === 'object' && value !== null && Object.getPrototypeOf(value) === Object.prototype) {
-      return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, localizeValue(v)]));
+      return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, localizeValue(v, `${path}.${k}`)]));
     }
     return value;
   }
 
-  return z.union([z.array(schema), schema]).transform(localizeValue) as unknown as z.ZodType<Localize<z.infer<S>>>;
+  return z.union([z.array(schema), schema]).transform((val) => localizeValue(val)) as unknown as z.ZodType<
+    Localize<z.infer<S>>
+  >;
 }


### PR DESCRIPTION
## Description
This pull request improves the localization validation logic in `localization.ts`, specifically enhancing how missing translations are detected and reported. The changes add better error messages with path information and handle optional fields more gracefully.

This update allow us to avoid page error when some page element doesn't contains translation.

## Type of change
- [x] Bug fix