### PR TITLE
fix(ui): update contradictory title font size

### DIFF
--- a/app/constants/typography.ts
+++ b/app/constants/typography.ts
@@ -152,10 +152,10 @@ export const AppTypography: TypographyVariantsOptions = {
     fontStyle: 'italic',
     lineHeight: '140%'
   },
-  customBold25: {
+  customBold24: {
     fontFamily: 'Mulish',
     fontWeight: 700,
-    fontSize: '25px',
+    fontSize: '24px',
     lineHeight: '140%',
     letterSpacing: '0px'
   }

--- a/app/constants/typography.ts
+++ b/app/constants/typography.ts
@@ -152,6 +152,13 @@ export const AppTypography: TypographyVariantsOptions = {
     fontStyle: 'italic',
     lineHeight: '140%'
   },
+  customBold25: {
+    fontFamily: 'Mulish',
+    fontWeight: 700,
+    fontSize: '25px',
+    lineHeight: '140%',
+    letterSpacing: '0px'
+  },
   customBold24: {
     fontFamily: 'Mulish',
     fontWeight: 700,

--- a/app/shared/components/design-system/all-components/theme/Theme.ts
+++ b/app/shared/components/design-system/all-components/theme/Theme.ts
@@ -44,6 +44,7 @@ declare module '@mui/material' {
     customItalic14: true;
     customSemiBold16: true;
     customSemiBold18: true;
+    customBold25: true;
     customBold24: true;
     customBold48: true;
   }
@@ -62,7 +63,8 @@ declare module '@mui/material/styles' {
     customItalic14?: React.CSSProperties;
     customSemiBold16?: React.CSSProperties;
     customSemiBold18?: React.CSSProperties;
-    customBold24?: React.CSSProperties;
+    customBold25: React.CSSProperties;
+    customBold24: React.CSSProperties;
     customBold236?: React.CSSProperties;
     customBold132?: React.CSSProperties;
     customBold114?: React.CSSProperties;

--- a/app/shared/components/design-system/all-components/theme/Theme.ts
+++ b/app/shared/components/design-system/all-components/theme/Theme.ts
@@ -44,7 +44,7 @@ declare module '@mui/material' {
     customItalic14: true;
     customSemiBold16: true;
     customSemiBold18: true;
-    customBold25: true;
+    customBold24: true;
     customBold48: true;
   }
 }
@@ -62,7 +62,7 @@ declare module '@mui/material/styles' {
     customItalic14?: React.CSSProperties;
     customSemiBold16?: React.CSSProperties;
     customSemiBold18?: React.CSSProperties;
-    customBold25: React.CSSProperties;
+    customBold24?: React.CSSProperties;
     customBold236?: React.CSSProperties;
     customBold132?: React.CSSProperties;
     customBold114?: React.CSSProperties;
@@ -81,7 +81,7 @@ declare module '@mui/material/styles' {
     customSemiBold18: React.CSSProperties;
     customSemiBold20: React.CSSProperties;
     customBold16: React.CSSProperties;
-    customBold25: React.CSSProperties;
+    customBold24: React.CSSProperties;
     customBold236: React.CSSProperties;
     customBold132: React.CSSProperties;
     customBold114: React.CSSProperties;
@@ -277,10 +277,10 @@ export const theme = createTheme({
       lineHeight: '140%',
       letterSpacing: '0px'
     },
-    customBold25: {
+    customBold24: {
       fontFamily: mulish.style.fontFamily,
       fontWeight: 700,
-      fontSize: '25px',
+      fontSize: '24px',
       lineHeight: '140%',
       letterSpacing: '0px'
     },

--- a/app/shared/components/design-system/all-components/theme/Theme.ts
+++ b/app/shared/components/design-system/all-components/theme/Theme.ts
@@ -84,6 +84,7 @@ declare module '@mui/material/styles' {
     customSemiBold20: React.CSSProperties;
     customBold16: React.CSSProperties;
     customBold24: React.CSSProperties;
+    customBold25: React.CSSProperties;
     customBold236: React.CSSProperties;
     customBold132: React.CSSProperties;
     customBold114: React.CSSProperties;
@@ -283,6 +284,13 @@ export const theme = createTheme({
       fontFamily: mulish.style.fontFamily,
       fontWeight: 700,
       fontSize: '24px',
+      lineHeight: '140%',
+      letterSpacing: '0px'
+    },
+    customBold25: {
+      fontFamily: mulish.style.fontFamily,
+      fontWeight: 700,
+      fontSize: '25px',
       lineHeight: '140%',
       letterSpacing: '0px'
     },

--- a/app/shared/components/enhanced-table/control-panel/ControlPanel.tsx
+++ b/app/shared/components/enhanced-table/control-panel/ControlPanel.tsx
@@ -117,11 +117,11 @@ export default function ControlPanel({
     <Box sx={{ ...ControlPanelStyles.root, ...sx }} data-testid="ControlPanel">
       <Box sx={ControlPanelStyles.header} data-testid="ControlPanel-header">
         <Typography
-          variant="customBold25"
+          variant="customBold24"
           data-testid="ControlPanel-tableName"
           sx={{
             fontSize: {
-              xs: '25px',
+              xs: '24px',
               md: '32px'
             }
           }}


### PR DESCRIPTION
Closes #66

## Description

Addressed issue: [\[Bug\]\[Artsy\] “Всі композиції” section - layout issue (320–767)#66](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/66)
Updated global custom font named `customBold25` with `customBold24`.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Go to [/artistry](https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/en/artistry).
2. Switch to Ukranian language.
3. Press Shortcut `Shift+F12`.
4. Set `dimensions` to `Responsive`.
5. And set first value to `320`.

## Video / Screenshots

<img width="981" height="488" alt="image" src="https://github.com/user-attachments/assets/4036abec-6631-4210-a191-8d4ab30b1eeb" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
