### PR TITLE
fix(ui): update font size to prevent inappropriate word wrapping

### DIFF
--- a/app/shared/components/enhanced-table/control-panel/ControlPanel.tsx
+++ b/app/shared/components/enhanced-table/control-panel/ControlPanel.tsx
@@ -121,7 +121,7 @@ export default function ControlPanel({
           data-testid="ControlPanel-tableName"
           sx={{
             fontSize: {
-              xs: '25px',
+              xs: '24px',
               md: '32px'
             }
           }}


### PR DESCRIPTION
## Description

Addressed issue: [\[Bug\]\[Artsy\] “Всі композиції” section - layout issue (320–767)#66](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/66)
Changed font size to 24px which fixes word wrapping.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: 

## How to test

1. Go to [/artistry](https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/en/artistry).
2. Switch to Ukranian language.
3. Open devtools.
4. Set height to `320`.

## Video / Screenshots

<img width="981" height="488" alt="image" src="https://github.com/user-attachments/assets/4036abec-6631-4210-a191-8d4ab30b1eeb" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

