### PR TITLE
fix(ui): add link attribute to button component leading to /archive

### DIFF
--- a/app/shared/components/blocks/terms-of-use/terms-content/TermsContent.tsx
+++ b/app/shared/components/blocks/terms-of-use/terms-content/TermsContent.tsx
@@ -45,6 +45,7 @@ const TermsContent = () => {
       <ButtonContentBlock
         buttonText={isMobile ? t('buttons.archive.short') : t('buttons.archive.full')}
         buttonColor="tertiary"
+        link={'/archive'}
         content={archiveDoc[locale]}
         containerSx={{ marginBottom: { xs: '32px', md: '40px' } }}
         sx={{


### PR DESCRIPTION
## Description

Addressed issue: [\[Bug\]\[Terms_of_Use \] The 'View the Archive' button doesn't redirect to the Archive page. #113](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/113)
Added `link` prop to component `ButtonContentBlock` within terms-of-use page.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: 

## How to test

1. Go to [/terms](https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/en/terms).
2. Scroll down to button named `View the Archive`.
3. Click and make sure that it's redirecting to `/archive` page properly.

## Video / Screenshots


https://github.com/user-attachments/assets/0683ec21-7ac5-45c5-8aed-33d8a7c2d90c



## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board
