### PR TITLE
fix(ui): update wrong translation occurrences

### DIFF
--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -14,7 +14,7 @@
   "header": {
     "supportButton": "Support",
     "navLabels": {
-      "liatoshynsky": "Borys Lyatoshynskyi",
+      "liatoshynsky": "Borys Liatoshynskyi",
       "biography": "Biography",
       "artistry": "Artistry",
       "research": "Research and scientific works",
@@ -82,7 +82,7 @@
   },
   "quote": {
     "mainText": "There will, of course, be a lot of interesting things, but you won't hear everything, because two concerts or operas will be held in different theaters and halls in one evening.",
-    "sourceText": "Letter from Boris Lyatoshynsky to Margarita Tsarevich, 29 September 1957, Berlin"
+    "sourceText": "Letter from Boris Liatoshynsky to Margarita Tsarevich, 29 September 1957, Berlin"
   },
   "research": {
     "title-with-quote": {
@@ -105,7 +105,7 @@
     "paidNotes": "Some of the sheet music may be paid for. In such cases, there will be a button on the page of the relevant work to request access.",
     "copyrightRespect": "We urge you to be careful about copyright. If you use materials from this site in publications or other projects, please indicate the source with a hyperlink to the Foundation's website.",
     "behaviorIntro": "Our site does not allow for user comments or content posting. However, we ask that you:",
-    "respectAuthorsIntro": "We sincerely thank you for your interest in Ukrainian music and the figure of Borys Lyatoshynsky. Please be careful with the works you use. Respect for copyright is not only a legal issue, but also an ethical norm.",
+    "respectAuthorsIntro": "We sincerely thank you for your interest in Ukrainian music and the figure of Borys Liatoshynsky. Please be careful with the works you use. Respect for copyright is not only a legal issue, but also an ethical norm.",
     "respectAuthorsOutro": "By preserving and distributing them responsibly, we, together with you, support the culture of memory and the modern sound of Ukrainian classics.",
     "libraryAccessTitle": "Access to the music library and archive:",
     "generalProvisionsTitle": "General provisions:",
@@ -114,7 +114,7 @@
     "behaviorTitle": "Behavior on the site:",
     "supportTitle": "Technical questions and support:",
     "respectAuthorsTitle": "Respect to the authors:",
-    "concertLicense": "If you are the organizer of a concert or are planning to broadcast Lyatoshynsky's works, contact the UAASP to obtain the appropriate license by email.",
+    "concertLicense": "If you are the organizer of a concert or are planning to broadcast Liatoshynsky's works, contact the UAASP to obtain the appropriate license by email.",
     "downloadNotes": "download available sheet music;",
     "saveNotes": "save selected works",
     "subscribeNews": "subscribe to the Foundation's newsletter (concerts, updates, events, etc.).",
@@ -311,12 +311,12 @@
     "title": "RUSSIA'S WAR AGAINST UKRAINIANS",
     "ourPartners": {
       "title": "OUR PARTNERS:",
-      "description": "The Lyatoshynsky Foundation is sincerely open to partnership and appreciates any support. We believe that cooperation based on trust and mutual respect will help us develop Ukrainian musical culture together. We invite those who share our mission and seek to participate in preserving the legacy of Borys Lyatoshynsky and supporting contemporary musical initiatives to partner with us."
+      "description": "The Liatoshynsky Foundation is sincerely open to partnership and appreciates any support. We believe that cooperation based on trust and mutual respect will help us develop Ukrainian musical culture together. We invite those who share our mission and seek to participate in preserving the legacy of Borys Liatoshynsky and supporting contemporary musical initiatives to partner with us."
     }
   },
   "archivePage": {
     "title": "ArcHive",
-    "description": "Original documents are stored in the private archive of the Borys Lyatoshynsky Cabinet-Museum (Kyiv, Ukraine)",
+    "description": "Original documents are stored in the private archive of the Borys Liatoshynsky Cabinet-Museum (Kyiv, Ukraine)",
     "searchPlaceholder": "Search"
   },
   "archiveCase": {
@@ -339,7 +339,7 @@
   },
   "biography": {
     "heroSection": {
-      "title": "Lyatoshynsky’s Life Story"
+      "title": "Liatoshynsky’s Life Story"
     }
   },
   "news": {


### PR DESCRIPTION
## Description

Addressed issue: [\[Bug\] The title of the /biography page doesn't match the English page title in the DB.](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/96)
Replace all `Lyatoshynsky` words with `Liatoshynsky`.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: 

## How to test

1. Go to [/biography](https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/en/biography).
2. Make sure that title not is not `Lyatoshynsky ...`, but `Liatoshynsky...`.

## Video / Screenshots


<img width="1438" height="568" alt="correct-biography-title" src="https://github.com/user-attachments/assets/71811565-4956-4426-b2f0-6af3723cdffb" />


## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board