### PR TITLE
fix(ui): match table background color with page background

### DIFF
--- a/app/shared/components/enhanced-table/EnhancedTable.styles.ts
+++ b/app/shared/components/enhanced-table/EnhancedTable.styles.ts
@@ -10,6 +10,7 @@ export const enhancedTableStyles = {
   container: (theme: Theme) => ({
     boxShadow: 'none',
     border: 'none',
+    backgroundColor: 'transparent',
 
     marginLeft: `-${theme.spacing(2.5)}`,
     marginRight: `-${theme.spacing(2.5)}`,


### PR DESCRIPTION
## Description

The table background color on the artistry page had a darker shade than the page itself. This PR updates the table background to match the page background color (#FCFCFC) to ensure visual consistency.

## Type of change

- [x] Bug fix

## How to test

1. Open the artistry page on the local environment.
2. Verify the table background matches the page background (#FCFCFC).
3. Inspect elements via DevTools to confirm the color value.
4. Ensure no regression in other table components if the style was shared.

## Screenshots

before
<img width="1850" height="581" alt="Screenshot 2026-02-24 152133" src="https://github.com/user-attachments/assets/8a633123-69b9-4e74-b88e-147cc56fbacf" />

after
<img width="1892" height="637" alt="Screenshot 2026-02-24 151402" src="https://github.com/user-attachments/assets/a2671b22-1239-4154-81ba-de53ff59e36b" />


Closes [#123](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/123)
Related to [#337](https://github.com/Liatoshynsky-Foundation/lf-client/issues/337)
