### PR TITLE
style(ui): update year font size to 14px in composition filter

### DIFF
--- a/app/shared/components/design-system/all-components/filtering/numeric/NumericFiltering.tsx
+++ b/app/shared/components/design-system/all-components/filtering/numeric/NumericFiltering.tsx
@@ -118,7 +118,7 @@ const NumericFiltering: React.FC<NumericFilteringProps> = ({
           />
         </Box>
         <DesignSystemSlider
-          size="small"
+          size="big"
           min={minNumber}
           max={maxNumber}
           step={1}

--- a/app/shared/components/design-system/all-components/slider/Slider.styles.ts
+++ b/app/shared/components/design-system/all-components/slider/Slider.styles.ts
@@ -31,7 +31,7 @@ export const sliderStyles = {
     position: 'absolute',
     top: '0',
     transform: 'translateX(-50%)',
-    fontSize: (size: 'small' | 'big') => (size === 'small' ? '10px' : '12px'),
+    fontSize: (size: 'small' | 'big') => (size === 'small' ? '10px' : '14px'),
     fontWeight: 'bold',
     background: commonColors.valueLabelBackground,
     color: '#fff',


### PR DESCRIPTION
## Description

The year values in the "Year of composition" filter had inconsistent and incorrect font sizes. The values in the slider were too small (10px), and the labels below were set to 12px instead of the required 14px.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement

## How to test

1. Open the Artistry page.
2. Click on the Filters button and select the Year of composition filter.
3. Observe the year values (1918 and 1998) in the grey tooltips above the slider.
4. Observe the year values displayed below the slider.
5. Using Browser DevTools, verify that both the tooltips and the bottom labels have a font-size of 14px.

Closes [#122](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/122)
