### PR TITLE
fix(ui): implement redirection for view sheet music library button

### DIFF
--- a/app/shared/components/blocks/terms-of-use/terms-content/TermsContent.tsx
+++ b/app/shared/components/blocks/terms-of-use/terms-content/TermsContent.tsx
@@ -37,6 +37,7 @@ const TermsContent = () => {
       <ButtonContentBlock
         buttonText={isMobile ? t('buttons.library.short') : t('buttons.library.full')}
         buttonColor="tertiary"
+        link={'/artistry'}
         content={testDoc[locale]}
         containerSx={{ marginBottom: { xs: '32px', md: '40px' } }}
         sx={{ maxWidth: { xs: '258px', sm: '308px' }, minWidth: { xs: '258px', sm: '308px' } }}


### PR DESCRIPTION
## Description

The 'View the sheet music library' button on the /terms page was non-functional, as it did not performrequireed navigation. This PR implements the missing redirection logic to ensure users are correctly navigated to the artistry page.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to the /terms page in your local environment.
2. Open the Network tab in DevTools.
3. Scroll down and click the 'View the sheet music library' button.
4. Verify that the application redirects you to the /artistry page.
5. Confirm in the Network tab that the navigation request is processed correctly.

Closes: [#120](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/120)