### PR TITLE
fix(ui): adjust mobile header paddings and contact field height

### DIFF
--- a/app/shared/components/design-system/all-components/navigation-accordion/NavAccordion.styles.ts
+++ b/app/shared/components/design-system/all-components/navigation-accordion/NavAccordion.styles.ts
@@ -19,8 +19,7 @@ export const styles = {
   container: {
     width: '100%',
     display: 'flex',
-    flexDirection: 'column',
-    gap: { xs: '10px', md: 0 }
+    flexDirection: 'column'
   },
   itemWrapper: {
     display: 'flex',
@@ -32,7 +31,8 @@ export const styles = {
     justifyContent: 'space-between',
     alignItems: 'center',
     cursor: 'pointer',
-    padding: 0,
+    paddingY: { xs: '5px', md: '0' },
+    paddingX: 0,
     color: textStates.default.color,
     transition: 'color 0.2s ease',
 

--- a/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/mobile-overlay/MobileOverlay.styles.ts
+++ b/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/mobile-overlay/MobileOverlay.styles.ts
@@ -64,7 +64,7 @@ export const styles = {
     },
     gap: { xs: '64px', sm: 0 },
     pb: { xs: '24px', sm: 0 },
-    pt: { xs: '6.2rem', sm: 0 },
+    pt: { xs: '86px', sm: 0 },
     justifyContent: { xs: 'space-between', sm: 'unset' }
   },
 

--- a/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/mobile-overlay/nav-contacts/NavContactsSection.styles.ts
+++ b/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/mobile-overlay/nav-contacts/NavContactsSection.styles.ts
@@ -5,7 +5,7 @@ export const styles = {
   links: {
     display: 'flex',
     flexDirection: 'column',
-    gap: { xs: '8px', md: '6px' }
+    gap: { xs: '8px', sm: '16px' }
   },
   mediaTitles: {
     ...AppTypography.mulish18Regular,
@@ -21,13 +21,11 @@ export const styles = {
   },
   contactLabel: {
     fontSize: { sm: '16px', md: '18px' },
-    lineHeight: { sm: '150%', md: '160%' },
-    mb: { sm: '-6px', md: 0 }
+    lineHeight: { sm: '150%', md: '160%' }
   },
   contactLink: {
     fontSize: { xs: '16px', md: '18px' },
-    textDecoration: 'underline',
-    height: { xs: '34px', sm: '20px', md: '24px' },
+    height: { xs: '34px', sm: '44px', md: '24px' },
     display: 'flex',
     alignItems: 'center'
   },

--- a/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/mobile-overlay/nav-contacts/NavContactsSection.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/mobile-overlay/nav-contacts/NavContactsSection.tsx
@@ -24,31 +24,35 @@ export const ContactsSection = ({ contacts, socialLinks, isMobile }: ContactsSec
       {isMobile && <LanguageSwitcher variant="mobile" data-testid="ContactsSection-languageSwitcher" />}
 
       <Box data-testid="ContactsSection-links" sx={styles.links}>
-        <ContactLink
-          data-testid="ContactsSection-phoneLink"
-          type="phone"
-          label={isMobile ? undefined : t('phoneNumber')}
-          value={contacts.phone}
-          direction={isMobile ? 'row' : 'column'}
-          icon={isMobile ? PhoneIcon : undefined}
-          iconSx={styles.icon}
-          labelSx={styles.contactLabel}
-          copyLinkSize="small"
-          iconColor="rgba(65, 43, 33, 0.8)"
-        />
+        <Box sx={styles.contactLink}>
+          <ContactLink
+            data-testid="ContactsSection-phoneLink"
+            type="phone"
+            label={isMobile ? undefined : t('phoneNumber')}
+            value={contacts.phone}
+            direction={isMobile ? 'row' : 'column'}
+            icon={isMobile ? PhoneIcon : undefined}
+            iconSx={styles.icon}
+            labelSx={styles.contactLabel}
+            copyLinkSize="small"
+            iconColor="rgba(65, 43, 33, 0.8)"
+          />
+        </Box>
 
-        <ContactLink
-          data-testid="ContactsSection-emailLink"
-          type="email"
-          label={isMobile ? undefined : t('email')}
-          value={contacts.email}
-          direction={isMobile ? 'row' : 'column'}
-          icon={isMobile ? MailIcon : undefined}
-          iconSx={styles.icon}
-          labelSx={styles.contactLabel}
-          copyLinkSize="small"
-          iconColor="rgba(65, 43, 33, 0.8)"
-        />
+        <Box sx={styles.contactLink}>
+          <ContactLink
+            data-testid="ContactsSection-emailLink"
+            type="email"
+            label={isMobile ? undefined : t('email')}
+            value={contacts.email}
+            direction={isMobile ? 'row' : 'column'}
+            icon={isMobile ? MailIcon : undefined}
+            iconSx={styles.icon}
+            labelSx={styles.contactLabel}
+            copyLinkSize="small"
+            iconColor="rgba(65, 43, 33, 0.8)"
+          />
+        </Box>
       </Box>
 
       <Box data-testid="ContactsSection-socialMedia" sx={styles.socialMediaBox}>


### PR DESCRIPTION
## Description

This PR fixes layout issues in the mobile header for devices with screen widths between 320px and 767px (iOS and Android). The changes ensure that the header and contact fields strictly follow the design specifications for mobile viewports.

- Set the header's padding-top to 86px for mobile screen sizes.
- Adjusted the height of contact fields to 34px.
- Removed incorrect spacing between menu blocks.

## Type of change

- [x] Bug fix

## How to test

1. Open the application in a browser and go to any page.
2. Open DevTools and toggle the Device Toolbar (Ctrl+Shift+M).
3. Select a mobile preset (e.g., iPhone 14 Pro Max or Samsung Galaxy S20 Ultra).
4. Open the header menu.
5. Verify the following using the **Inspect tool**:
    * **Header `padding-top`** is exactly **86px**.
    * **Contact fields** have a **height** of **34px**.
    * There is **no extra spacing or indentation** between menu blocks.


Closes [#126](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/126)