### PR TITLE
fix(ui): ensure full button label on mobile and tablet views

### DIFF
--- a/app/shared/components/Footer/Footer.tsx
+++ b/app/shared/components/Footer/Footer.tsx
@@ -63,7 +63,7 @@ export default async function Footer() {
             }}
             donation={{
               text: tFooter('donationButton'),
-              shortText: tFooter('donationButtonShort'),
+              shortText: locale === 'en' ? undefined : tFooter('donationButtonShort'),
               link: supportButtonLink
             }}
           />


### PR DESCRIPTION
## Description

The footer button was incorrectly displaying a shortened label "Support" instead of the full "Support the Foundation" text on screen sizes below 1024px (tablets and mobile devices) in the English version of the application. This PR fixes the responsive styling/logic to ensure the full label is displayed consistently across all breakpoints.

## Type of change

- [x] Bug fix

## How to test

1. Open the application and scroll down to the **footer**.
2. Switch the language to **English**.
3. Open **DevTools** and test the following responsive breakpoints:
    * **320px – 767px** (Mobile).
    * **768px – 1023px** (Small Tablet).
4. Verify using the **Inspect tool**:
    * The button label is exactly **"Support the Foundation"**.
    * The text is **fully visible** and not cut off or shortened to "Support".

Closes [#50](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/50)