### PR TITLE
fix(ui): show copy button for IBAN on mobile devices

### DIFF
--- a/app/shared/components/blocks/payment-details/PaymentDetails.tsx
+++ b/app/shared/components/blocks/payment-details/PaymentDetails.tsx
@@ -53,7 +53,12 @@ function PaymentDetails() {
             </Typography>
 
             {isIban ? (
-              <CopyLink hint="IBAN is copied" size="large" value={selectedPaymentDetails[key]} />
+              <CopyLink
+                hint="IBAN is copied"
+                size="large"
+                value={selectedPaymentDetails[key]}
+                forceShowCopyIcon={true}
+              />
             ) : (
               <Typography variant="customSemiBold20">{selectedPaymentDetails[key]}</Typography>
             )}

--- a/app/shared/components/design-system/all-components/copy-link/CopyLink.tsx
+++ b/app/shared/components/design-system/all-components/copy-link/CopyLink.tsx
@@ -24,10 +24,12 @@ interface CopyLinkProps {
   hint?: string;
   delay?: number;
   sx?: SxProps<Theme>;
+  forceShowCopyIcon?: boolean;
 }
 
 function CopyLink({
   value,
+  forceShowCopyIcon = false,
   size = 'medium',
   type = 'primary',
   hint,
@@ -43,7 +45,7 @@ function CopyLink({
   const finalHint = hint || t('copied');
 
   const handleCopy = async () => {
-    if (isMobile || disabled) return;
+    if ((isMobile && !forceShowCopyIcon) || disabled) return;
 
     try {
       await navigator.clipboard.writeText(String(value));
@@ -64,7 +66,7 @@ function CopyLink({
   const copyIconSize = iconSizes[size];
   const copyLinkStyles = getCopyLinkStyles(type);
 
-  if (isMobile) {
+  if (isMobile && !forceShowCopyIcon) {
     let href = '';
     if (hrefType === 'phone') {
       href = `tel:${value}`;


### PR DESCRIPTION
## Description

On mobile devices (320px - 767px), the copy button for IBAN was missing on the "Support the Foundation" page. This happened because the `CopyLink` component was globally configured to hide the copy icon and disable clipboard functionality on mobile viewports to favor native `tel:` and `mailto:` links.

I have introduced a new `forceShowCopyIcon` prop to the `CopyLink` component. This allows specific instances (like IBAN) to retain copy-to-clipboard functionality regardless of the device type, while keeping the default behavior for other types of data.

**Key changes:**
* Added `forceShowCopyIcon` boolean prop to `CopyLinkProps`.
* Updated `handleCopy` logic to allow execution on mobile if `forceShowCopyIcon` is enabled.
* Modified the component's render logic to display the button with the copy icon on mobile when requested.
* Applied this prop to the IBAN field on the Support page.

## Type of change

- [x] Bug fix
- [x] New feature (component enhancement)

## How to test

1. Open the **Support the Foundation** page.
2. Open **DevTools** and switch to a mobile view (e.g., **iPhone 14**, **375px width**).
3. Locate the **IBAN** section.
4. Verify using the **Inspect tool**:
    * The **Copy icon** is now visible next to the IBAN.
    * Clicking the IBAN/icon triggers the **"Copied" tooltip**.
    * The IBAN value is successfully added to your **clipboard**.
5. **Regression check**: Verify that phone numbers or emails in other parts of the app (where `forceShowCopyIcon` is NOT used) still behave as standard links without the copy icon on mobile.

Closes [#103](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/103)