### PR TITLE
feat(ui): implement infinite loop for image carousel on war-in-ukrain…

### DIFF
--- a/app/shared/components/blocks/war-carousel/WarCarouselSection.tsx
+++ b/app/shared/components/blocks/war-carousel/WarCarouselSection.tsx
@@ -28,7 +28,7 @@ const images = [
 const WarCarouselSection = () => {
   return (
     <Box sx={styles.carouselSectionContainer}>
-      <Carousel images={images} />
+      <Carousel images={images} infiniteLoop={true} />
     </Box>
   );
 };

--- a/app/shared/components/design-system/all-components/carousel/Carousel.test.tsx
+++ b/app/shared/components/design-system/all-components/carousel/Carousel.test.tsx
@@ -102,8 +102,8 @@ describe('Carousel', () => {
   it('should navigate to the next image with swipe', () => {
     render(<Carousel images={mockImages} />);
     const firstImage = screen.getByTestId('carousel-image-0');
-    fireEvent.touchStart(firstImage, { touches: [{ clientX: 300, clientY: 0 }] });
-    fireEvent.touchMove(firstImage, { touches: [{ clientX: 100, clientY: 0 }] });
+    fireEvent.touchStart(firstImage, { targetTouches: [{ clientX: 300, clientY: 0 }] });
+    fireEvent.touchMove(firstImage, { targetTouches: [{ clientX: 100, clientY: 0 }] });
     fireEvent.touchEnd(firstImage);
     expect(screen.getByTestId('carousel-image-1')).toHaveAttribute('data-active', 'true');
   });
@@ -111,8 +111,8 @@ describe('Carousel', () => {
   it('should not navigate to the next image with small swipe', () => {
     render(<Carousel images={mockImages} />);
     const firstImage = screen.getByTestId('carousel-image-0');
-    fireEvent.touchStart(firstImage, { touches: [{ clientX: 300, clientY: 0 }] });
-    fireEvent.touchMove(firstImage, { touches: [{ clientX: 280, clientY: 0 }] });
+    fireEvent.touchStart(firstImage, { targetTouches: [{ clientX: 300, clientY: 0 }] });
+    fireEvent.touchMove(firstImage, { targetTouches: [{ clientX: 280, clientY: 0 }] });
     fireEvent.touchEnd(firstImage);
     expect(screen.getByTestId('carousel-image-1')).toHaveAttribute('data-active', 'false');
   });
@@ -120,8 +120,8 @@ describe('Carousel', () => {
   it('should be no infinite loop when it is not enabled', () => {
     render(<Carousel images={mockImages} />);
     const firstImage = screen.getByTestId('carousel-image-0');
-    fireEvent.touchStart(firstImage, { touches: [{ clientX: 200, clientY: 0 }] });
-    fireEvent.touchMove(firstImage, { touches: [{ clientX: 300, clientY: 0 }] });
+    fireEvent.touchStart(firstImage, { targetTouches: [{ clientX: 200, clientY: 0 }] });
+    fireEvent.touchMove(firstImage, { targetTouches: [{ clientX: 300, clientY: 0 }] });
     fireEvent.touchEnd(firstImage);
     expect(firstImage).toHaveAttribute('data-active', 'true');
   });
@@ -129,8 +129,8 @@ describe('Carousel', () => {
   it('should be infinite loop when it is enabled', () => {
     render(<Carousel images={mockImages} infiniteLoop />);
     const firstImage = screen.getByTestId('carousel-image-0');
-    fireEvent.touchStart(firstImage, { touches: [{ clientX: 200, clientY: 0 }] });
-    fireEvent.touchMove(firstImage, { touches: [{ clientX: 300, clientY: 0 }] });
+    fireEvent.touchStart(firstImage, { targetTouches: [{ clientX: 200, clientY: 0 }] });
+    fireEvent.touchMove(firstImage, { targetTouches: [{ clientX: 300, clientY: 0 }] });
     fireEvent.touchEnd(firstImage);
     expect(screen.getByTestId('carousel-image-2')).toHaveAttribute('data-active', 'true');
   });

--- a/app/shared/components/design-system/all-components/carousel/Carousel.tsx
+++ b/app/shared/components/design-system/all-components/carousel/Carousel.tsx
@@ -24,16 +24,27 @@ const Carousel = ({ images, initialIndex = 0, infiniteLoop = false }: CarouselPr
   const [activeIndex, setActiveIndex] = useState(initialIndex ?? 0);
   const [touchStartX, setTouchStartX] = useState(0);
   const [dragOffset, setDragOffset] = useState(0);
-  const isFirstSlide = activeIndex === 0;
-  const isLastSlide = activeIndex === images.length - 1;
 
   const goToNext = useCallback(() => {
-    setActiveIndex((prev) => (prev + 1) % images.length);
-  }, [images.length]);
+    setActiveIndex((prev) => {
+      if (infiniteLoop) {
+        return (prev + 1) % images.length;
+      }
+      return prev < images.length - 1 ? prev + 1 : prev;
+    });
+  }, [images.length, infiniteLoop]);
 
   const goToPrev = useCallback(() => {
-    setActiveIndex((prev) => (prev - 1 + images.length) % images.length);
-  }, [images.length]);
+    setActiveIndex((prev) => {
+      if (infiniteLoop) {
+        return (prev - 1 + images.length) % images.length;
+      }
+      return prev > 0 ? prev - 1 : prev;
+    });
+  }, [images.length, infiniteLoop]);
+
+  const isFirstSlide = !infiniteLoop && activeIndex === 0;
+  const isLastSlide = !infiniteLoop && activeIndex === images.length - 1;
 
   const goToSlide = useCallback((index: number) => {
     setActiveIndex(index);
@@ -48,25 +59,32 @@ const Carousel = ({ images, initialIndex = 0, infiniteLoop = false }: CarouselPr
     [activeIndex]
   );
 
-  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
-    setTouchStartX(e.touches[0].clientX || 0);
+  const handleTouchStart = (e: React.TouchEvent) => {
+    if (e.targetTouches?.[0]) {
+      setTouchStartX(e.targetTouches[0].clientX);
+    }
   };
 
-  const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
-    const currentX = e.touches[0].clientX || 0;
-    setDragOffset(currentX - touchStartX);
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (touchStartX !== null && e.targetTouches?.[0]) {
+      const currentTouchX = e.targetTouches[0].clientX;
+      setDragOffset(currentTouchX - touchStartX);
+    }
   };
 
   const handleTouchEnd = () => {
-    if (Math.abs(dragOffset) < 50) return;
-    if (dragOffset > 0) {
-      if (infiniteLoop || !isFirstSlide) goToPrev();
-    }
-    if (dragOffset < 0) {
-      if (infiniteLoop || !isLastSlide) goToNext();
+    if (dragOffset > 50) {
+      if (infiniteLoop || activeIndex > 0) {
+        goToPrev();
+      }
+    } else if (dragOffset < -50) {
+      if (infiniteLoop || activeIndex < images.length - 1) {
+        goToNext();
+      }
     }
 
     setDragOffset(0);
+    setTouchStartX(0);
   };
 
   const handleKey = useCallback(


### PR DESCRIPTION
Closes [#136](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/136)

## Description

This PR improves the user experience on the `/war-in-ukraine` page by transforming the standard image carousel into an infinite loop gallery. This ensures that users can scroll through images continuously without reaching a "dead end," following UI/UX best practices.

**Key changes:**
* **Infinite Loop:** Implemented seamless left/right scrolling for the image carousel.
* **Desktop Navigation:** Refined spinner controls for desktop and tablet views (768px and above).
* **Touch Support:** Enabled infinite touch-swipe navigation for mobile devices (767px and below).
* **Test Improvements:** Refactored carousel tests by replacing `touches` with `targetTouches` to ensure more accurate event simulation and better tracking of interactions specifically with the carousel element.

## Type of change

- [x] Bug fix (UX improvement)
- [x] Refactoring (Tests)

## How to test

1. Navigate to the `/war-in-ukraine` page.
2. **Desktop/Tablet Test (>= 768px):**
    * Use the navigation arrows (spinner) to scroll through all images.
    * Verify that after the last image, the carousel seamlessly returns to the first one.
3. **Mobile Test (<= 767px):**
    * Enable mobile emulation in DevTools.
    * Use touch-swipe to scroll through images.
    * Verify that the carousel loops infinitely in both directions.
4. **Automated Tests:**
    * Run `npm test` to ensure that the updated touch event simulations (`targetTouches`) pass correctly.

## Video / Screenshots


https://github.com/user-attachments/assets/14d660fe-8f3b-464f-8134-ce1fb2f983a7

