### PR TITLE
fix(ui): ensure language synchronization across all pages on desktop

### DIFF
--- a/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
+++ b/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
@@ -22,6 +22,10 @@ export interface LanguageSwitcherProps {
   scrollDirection?: ScrollDirection;
 }
 
+const setLocaleCookie = (locale: string) => {
+  document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=31536000; SameSite=Lax`;
+};
+
 const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ variant, scrollDirection }) => {
   const router = useRouter();
   const pathname = usePathname();
@@ -43,6 +47,7 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ variant, scrollDire
 
   const handleLanguageChange = (newLocale: Locale) => {
     if (newLocale === currentLocale) return;
+    setLocaleCookie(newLocale);
     router.replace(pathname, { locale: newLocale, scroll: false });
     handleClose();
   };
@@ -50,6 +55,7 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ variant, scrollDire
   const toggleLocale = () => {
     const newLocale = currentLocale === 'uk' ? 'en' : 'uk';
     if (newLocale === currentLocale) return;
+    setLocaleCookie(newLocale);
     router.replace(pathname, { locale: newLocale, scroll: false });
   };
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the selected language was not consistently applied across all pages on desktop resolutions (1280px to 1440px and above). The issue occurred when navigating via header dropdown menus, which occasionally caused the application to revert to the default locale for certain pages.

**Key changes:**
* **Cookie-based Persistence:** Implemented manual setting of the `NEXT_LOCALE` cookie upon language change. This ensures that the chosen locale is persisted and correctly recognized by the Next.js middleware during client-side navigation.

## Type of change

- [x] Bug fix

## How to test

1. Open the application on a desktop screen (resolution **1280px or higher**).
2. **change the language** (e.g., from Ukrainian to English).
3. Use the header menu to navigate to **ТвоРчіСТь ЛЯтоШиНськогО** (Artistry).
4. **Verify the following:**
    * The Artistry page is fully translated into the selected language (English).
    * Navigate through other pages (Research, Cooperation, Foundation, Contacts, Biography) — the language must remain consistent.
5. **Check DevTools:**
    * Open **Application** -> **Cookies**.
    * Confirm that the `NEXT_LOCALE` cookie value matches the selected language code (e.g., `en` or `uk`).

## Video / Screenshots
**Before**: language is inconsistent

https://github.com/user-attachments/assets/e1a37d19-f6fc-4e72-adb8-48d3d4d18b69

**After**: consistent language 

https://github.com/user-attachments/assets/5bcbdce3-a7c2-4568-8d34-6771d7b5d39b


Closes [#49](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/49)