### PR TITLE
feat: implemented tab navigation for news page

### DIFF
--- a/app/shared/components/blocks/media-center/MediaCenter.test.tsx
+++ b/app/shared/components/blocks/media-center/MediaCenter.test.tsx
@@ -3,6 +3,18 @@ import React from 'react';
 
 import MediaCenter from './MediaCenter';
 
+let searchParamsValue = new URLSearchParams('');
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: jest.fn((url: string) => {
+      const search = url.split('?')[1];
+      searchParamsValue = new URLSearchParams(search || '');
+    })
+  }),
+  useSearchParams: () => searchParamsValue
+}));
+
 jest.mock('~/shared/components/design-system/all-components/media-list/MediaList', () => {
   return function DummyMediaList({ variant }: { variant: string }) {
     return <div data-testid={`media-list-${variant}`}>List: {variant}</div>;
@@ -10,13 +22,8 @@ jest.mock('~/shared/components/design-system/all-components/media-list/MediaList
 });
 
 jest.mock('~/shared/components/design-system/all-components/empty-state/EmptyState', () => {
-  return function DummyEmptyState({ dataTestId, title, description }: any) {
-    return (
-      <div data-testid={dataTestId}>
-        <div data-testid={`${dataTestId}-title`}>{title}</div>
-        {description && <div data-testid={`${dataTestId}-description`}>{description}</div>}
-      </div>
-    );
+  return function DummyEmptyState({ dataTestId, title }: any) {
+    return <div data-testid={dataTestId}>{title}</div>;
   };
 });
 
@@ -32,83 +39,52 @@ jest.mock('~/ds-components/tabs/Tabs', () => ({
   )
 }));
 
-jest.mock('./media.const', () => ({
-  mockPressList: [{ _id: '2', publishedAt: '2023-01-02', title: 'Press' }]
-}));
-
-const mockNewsData = [
-  {
-    _id: '1',
-    publishedAt: new Date('2023-01-01').toISOString(),
-    newsDate: new Date('2023-01-01').toISOString(),
-    title: 'Test News',
-    description: 'Test Description',
-    slug: 'test-news',
-    coverImage: {
-      src: '/test.jpg',
-      alt: 'Test Alt',
-      caption: 'Test Caption',
-      isTmp: false
-    },
-    meta: {
-      views: 100
-    }
-  }
-];
-
-const mockMediaMentionsData = [
-  {
-    _id: '1',
-    url: 'https://example.com/media-mention',
-    title: 'Test Media Mention',
-    description: 'Test Media Description',
-    slug: 'test-media-mention',
-    coverImage: {
-      src: '/test-media.jpg',
-      alt: 'Test Media Alt'
-    },
-    publishedAt: new Date('2023-01-01').toISOString(),
-    meta: {
-      views: 50
-    }
-  }
-];
+const mockNewsData = [{ _id: '1', title: 'News', publishedAt: '2023-01-01', coverImage: { src: '' } }];
+const mockMediaMentionsData = [{ _id: '1', title: 'Media', publishedAt: '2023-01-01', coverImage: { src: '' } }];
 
 describe('MediaCenter Component', () => {
+  beforeEach(() => {
+    searchParamsValue = new URLSearchParams('');
+    jest.clearAllMocks();
+  });
+
   it('should render news list by default', () => {
-    render(<MediaCenter newsData={mockNewsData} mediaMentionsData={mockMediaMentionsData} />);
+    render(<MediaCenter newsData={mockNewsData as any} mediaMentionsData={mockMediaMentionsData as any} />);
     expect(screen.getByTestId('media-list-news')).toBeInTheDocument();
-    expect(screen.queryByTestId('media-list-press')).not.toBeInTheDocument();
   });
 
   it('should switch to "press" tab and renders press list', async () => {
-    render(<MediaCenter newsData={mockNewsData} mediaMentionsData={mockMediaMentionsData} />);
+    const { rerender } = render(
+      <MediaCenter newsData={mockNewsData as any} mediaMentionsData={mockMediaMentionsData as any} />
+    );
+
     const pressTab = screen.getByText('Ми у ЗМІ');
     fireEvent.click(pressTab);
+
+    rerender(<MediaCenter newsData={mockNewsData as any} mediaMentionsData={mockMediaMentionsData as any} />);
+
     await waitFor(() => {
-      expect(screen.queryByTestId('media-list-news')).not.toBeInTheDocument();
       expect(screen.getByTestId('media-list-press')).toBeInTheDocument();
+      expect(screen.queryByTestId('media-list-news')).not.toBeInTheDocument();
     });
   });
 
   it('should show empty state when news data is empty', () => {
-    render(<MediaCenter newsData={[]} mediaMentionsData={mockMediaMentionsData} />);
+    render(<MediaCenter newsData={[]} mediaMentionsData={mockMediaMentionsData as any} />);
+
     expect(screen.getByTestId('EmptyState-news')).toBeInTheDocument();
-    expect(screen.queryByTestId('media-list-news')).not.toBeInTheDocument();
   });
 
   it('should show empty state when media mentions data is empty', async () => {
-    render(<MediaCenter newsData={mockNewsData} mediaMentionsData={[]} />);
+    const { rerender } = render(<MediaCenter newsData={mockNewsData as any} mediaMentionsData={[]} />);
+
     const pressTab = screen.getByText('Ми у ЗМІ');
     fireEvent.click(pressTab);
+
+    rerender(<MediaCenter newsData={mockNewsData as any} mediaMentionsData={[]} />);
+
     await waitFor(() => {
       expect(screen.getByTestId('EmptyState-press')).toBeInTheDocument();
-      expect(screen.queryByTestId('media-list-press')).not.toBeInTheDocument();
     });
-  });
-
-  it('should show empty state when all data is empty', () => {
-    render(<MediaCenter newsData={[]} mediaMentionsData={[]} />);
-    expect(screen.getByTestId('EmptyState-news')).toBeInTheDocument();
   });
 });

--- a/app/shared/components/blocks/media-center/MediaCenter.tsx
+++ b/app/shared/components/blocks/media-center/MediaCenter.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { Box } from '@mui/material';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { z } from 'zod';
 
 import { CustomTabs } from '~/ds-components/tabs/Tabs';
@@ -56,14 +57,32 @@ interface MediaCenterProps {
 
 function MediaCenter({ newsData, mediaMentionsData }: Readonly<MediaCenterProps>) {
   const t = useTranslations('media.emptyState');
-  const [selectedTab, setSelectedTab] = useState('news');
   const [events, setEvents] = useState<EventItemFixture[] | null>(null);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const activeTab = useMemo(() => {
+    const tab = searchParams.get('tab') ?? 'news';
+    return tab;
+  }, [searchParams]);
+
+  const handleTabChange = useCallback(
+    (value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('tab', value);
+
+      router.replace(`/news?${params.toString()}`, {
+        scroll: false
+      });
+    },
+    [router, searchParams]
+  );
 
   useEffect(() => {
-    if (selectedTab === 'events' && !events) {
+    if (activeTab === 'events' && !events) {
       setEvents(MOCK_EVENT_ITEMS);
     }
-  }, [selectedTab, events]);
+  }, [activeTab, events]);
 
   return (
     <Box data-testid="MediaCenter" sx={styles.mediaContainer}>
@@ -72,26 +91,26 @@ function MediaCenter({ newsData, mediaMentionsData }: Readonly<MediaCenterProps>
           dataTestId="MediaTabsContainer"
           aria-label="Категорії медіа"
           tabs={tabs}
-          activeTab={selectedTab}
-          onTabChange={setSelectedTab}
+          activeTab={activeTab}
+          onTabChange={handleTabChange}
         />
       </Box>
-      {selectedTab === 'news' && (
+      {activeTab === 'news' && (
         <>
           {newsData.length > 0 ? (
-            <MediaList dataTestId={selectedTab[0].toUpperCase()} mediaData={newsData as any} variant="news" />
+            <MediaList dataTestId={activeTab[0].toUpperCase()} mediaData={newsData as any} variant="news" />
           ) : (
             <EmptyState dataTestId="EmptyState-news" title={t('news.title')} description={t('news.description')} />
           )}
         </>
       )}
 
-      {selectedTab === 'events' && events && <EventsTab eventsData={events} />}
+      {activeTab === 'events' && events && <EventsTab eventsData={events} />}
 
-      {selectedTab === 'press' && (
+      {activeTab === 'press' && (
         <>
           {mediaMentionsData.length > 0 ? (
-            <MediaList dataTestId={selectedTab[0].toUpperCase()} mediaData={mediaMentionsData as any} variant="press" />
+            <MediaList dataTestId={activeTab[0].toUpperCase()} mediaData={mediaMentionsData as any} variant="press" />
           ) : (
             <EmptyState dataTestId="EmptyState-press" title={t('press.title')} description={t('press.description')} />
           )}


### PR DESCRIPTION
## Description

Implemented synchronized tab navigation for the News page using URL query parameters.

Users clicking buttons (Events, News, Press) from our future Home page or other pages are redirected to the News page with the corresponding tab pre-selected. The active tab is fully controlled by the tab query parameter, ensuring the state is shareable, bookmarkable, and preserved during browser navigation (back/forward).

Key implementation details:

- Extracted the tab parameter using useSearchParams
- Derived the active tab with a default fallback (news)
- Synced tab state with the URL
- Implemented shallow routing using router.replace with scroll: false to avoid full page reloads or scroll jumps

## Type of change

- [x] New feature

## How to test

1. Open the News page and click on Tab buttons (Events, News, Press).
2. Check that the URL contains the correct query parameter (e.g., /news?tab=events).
3. Open /news without a tab parameter: Ensure the default tab ("News") is selected.

## Video / Screenshots


https://github.com/user-attachments/assets/9cbeae0b-ded4-44c0-882d-f5880342488c


## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
