### PR TITLE
fix(ui): remove placeholder captions from War in Ukraine slider

### DIFF
--- a/app/shared/components/blocks/war-carousel/WarCarouselSection.tsx
+++ b/app/shared/components/blocks/war-carousel/WarCarouselSection.tsx
@@ -9,19 +9,19 @@ const images = [
     id: 1,
     src: '/images/war-in-ukraine-page/carousel/photo-1.png',
     alt: 'Carousel Image 1',
-    description: 'Підпис до фото 1'
+    description: ''
   },
   {
     id: 2,
     src: '/images/war-in-ukraine-page/carousel/photo-2.png',
     alt: 'Carousel Image 2',
-    description: 'Підпис до фото 2'
+    description: ''
   },
   {
     id: 3,
     src: '/images/war-in-ukraine-page/carousel/photo-3.png',
     alt: 'Carousel Image 3',
-    description: 'Підпис до фото 3'
+    description: ''
   }
 ];
 


### PR DESCRIPTION
## Description

This PR addresses a UI issue on the "War in Ukraine" page where technical placeholder captions ("Підпис до фото 1/2/3") were displayed in the image slider. These placeholders have been removed to ensure that only actual, relevant descriptions are shown to the user.

## Type of change

- [x] Bug fix

## How to test

1. Open the application and navigate to the **"War in Ukraine"** page.
2. Scroll down to the **image slider** section.
3. Observe the captions below each photo.

## Screenshots
<img width="1362" height="795" alt="image" src="https://github.com/user-attachments/assets/707dd679-a056-4217-98e7-a6e536dfbd8c" />


closes [#1157](https://github.com/Liatoshynsky-Foundation/lf-client/issues/1157)