### PR TITLE
fix(search): implement search normalization to handle spaces

### DIFF
--- a/app/lib/utils/normalizeSearch.test.ts
+++ b/app/lib/utils/normalizeSearch.test.ts
@@ -1,0 +1,19 @@
+import { normalizeSearch } from './normalizeSearch';
+
+describe('normalizeSearch', () => {
+  it('removes leading and trailing spaces', () => {
+    expect(normalizeSearch('  Hello world  ')).toBe('Hello world');
+  });
+
+  it('removes multiple inner spaces', () => {
+    expect(normalizeSearch('Hello    world')).toBe('Hello world');
+  });
+
+  it('returns empty string for spaces only', () => {
+    expect(normalizeSearch('     ')).toBe('');
+  });
+
+  it('handles empty string', () => {
+    expect(normalizeSearch('')).toBe('');
+  });
+});

--- a/app/lib/utils/normalizeSearch.ts
+++ b/app/lib/utils/normalizeSearch.ts
@@ -1,0 +1,1 @@
+export const normalizeSearch = (value: string) => value.trim().replace(/\s+/g, ' ');

--- a/app/shared/components/search/Search.tsx
+++ b/app/shared/components/search/Search.tsx
@@ -14,13 +14,15 @@ import {
 } from '@mui/material';
 import debounce from 'lodash.debounce';
 import { useTranslations } from 'next-intl';
-import React, { SyntheticEvent, useCallback, useMemo, useRef, useState } from 'react';
+import React, { SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { mainHexPallete } from '~/ds-components/theme/colors';
 
 import { SvgImage } from '../svg-image/SvgImage';
 import { VirtualizedListbox } from './LazyListItem';
 import { CustomBorderTextField, iconStyles, SearchStyles } from './SearchStyles';
+
+import { normalizeSearch } from '~/lib/utils/normalizeSearch';
 
 interface SearchProps<T> {
   search: string;
@@ -76,7 +78,6 @@ export const Search = <T extends { title?: string | { en?: string; uk?: string }
       if (!opened) setOpened(true);
 
       setInputValue(v);
-      debouncedInput(v);
     },
     [opened, debouncedInput]
   );
@@ -87,7 +88,7 @@ export const Search = <T extends { title?: string | { en?: string; uk?: string }
 
       const label = typeof v?.title === 'string' ? v.title : v?.title?.en || v?.title?.uk || '';
 
-      setSearch(label);
+      setSearch(normalizeSearch(label));
       setOpened(false);
     },
     [setSearch]
@@ -96,12 +97,16 @@ export const Search = <T extends { title?: string | { en?: string; uk?: string }
   const handleEnter = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') {
-        setSearch(inputValue);
+        setSearch(normalizeSearch(inputValue));
         setOpened(false);
       }
     },
     [inputValue, setSearch]
   );
+
+  useEffect(() => {
+    setInputValue(search);
+  }, [search]);
 
   const renderOption = useCallback((props: React.HTMLAttributes<HTMLLIElement> & { key?: React.Key }, option: T) => {
     const { key, ...rest } = props;


### PR DESCRIPTION
## Description

Fixes search behavior when the input contains leading or multiple extra spaces.

Related: Liatoshynsky-Foundation/lf-manual-tests#154

Added `normalizeSearch` utility to trim and normalize spaces before triggering the search.  
Normalization is applied only before calling `setSearch`, without affecting typing UX.

## Type of change

- [x] Bug fix

## How to test

1. Open `/uk/artistry`.
2. Click **Search**.
3. Enter `(space)Симфонія №3 B-moll`.
4. Press **Enter`.
5. Verify that the composition is found and displayed in the table.

Also check:
- Multiple inner spaces between words.
- Leading/trailing spaces.

## Video / Screenshots

Video attached showing correct search behavior with extra spaces.

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues