### PR TITLE
Fix view archive button alignment on terms of use page

### DIFF
--- a/app/shared/components/blocks/terms-of-use/terms-content/TermsContent.tsx
+++ b/app/shared/components/blocks/terms-of-use/terms-content/TermsContent.tsx
@@ -51,8 +51,7 @@ const TermsContent = () => {
         containerSx={{ marginBottom: { xs: '32px', md: '40px' } }}
         sx={{
           maxWidth: { xs: '220px', sm: '289px' },
-          minWidth: { xs: '220px', sm: '289px' },
-          right: { sm: '16px', md: 0 }
+          minWidth: { xs: '220px', sm: '289px' }
         }}
       />
 


### PR DESCRIPTION
## Summary of change

- Aligned the "View the Archive" button with the text content for tablet screens (768px - 1023px).
- Removed the hardcoded right offset that was causing misalignment.

## How to test:
- Open /terms page and set screen width to 768px - 1023px.
- Verify the "View the Archive" button is aligned with the left edge of the text.


 **Actual result**:
The "View the Archive" button was shifted to the right on resolutions between 768px and 1023px, failing to align with the text content above it.
<img width="622" height="768" alt="image" src="https://github.com/user-attachments/assets/db37022c-e581-4156-bfe7-97462c61ebd4" />

**Expected result**:
The button should follow the responsive grid alignment and stay perfectly aligned with the left edge of the "The Foundation Archive..." text block.
<img width="623" height="854" alt="Знімок екрана 2026-03-02 164447" src="https://github.com/user-attachments/assets/c1b53b97-784b-4346-a79d-7b55f658cee2" />
Closes Liatoshynsky-Foundation/lf-manual-tests#119