### PR TITLE
fix(ui): update separator in LanguageSwitcher from slash to pipe

### DIFF
--- a/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
+++ b/app/shared/components/design-system/all-components/language-switcher/LanguageSwitcher.tsx
@@ -96,7 +96,7 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ variant, scrollDire
           EN
         </button>
 
-        <span style={styles.item(false)}>/</span>
+        <span style={styles.item(false)}>|</span>
 
         <button
           style={styles.item(currentLocale === 'uk')}


### PR DESCRIPTION
## Description

Fixes the layout of the language switcher in the header to match the design (slash alignment and spacing).

Adjusted typography, spacing, and alignment for the language switcher in the 320–767px viewport range to match the expected design.

Related: Liatoshynsky-Foundation/lf-manual-tests#127

## Type of change

- [x] Bug fix

## How to test

1. Open any app page.
2. Set viewport width between 320px and 767px.
3. Open the header.
4. Check the language switcher (EN / UA).
5. Verify that the slash and spacing match the design.

## Video / Screenshots

Screenshots attached showing:
- Actual result before fix
- Correct layout after fix

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean