### PR TITLE
fix(ui): implement Swiper carousel for ActionsHelp on mobile devices

### DIFF
--- a/app/shared/components/blocks/actions-help/ActionsHelp.styles.ts
+++ b/app/shared/components/blocks/actions-help/ActionsHelp.styles.ts
@@ -41,8 +41,33 @@ export const styles = {
     justifyContent: { xs: 'center', sm: 'end' },
     mt: { xs: '64px', lg: '80px' }
   },
+  mobileSwiperContainer: {
+    gridColumn: '1 / -1',
+    width: '100vw',
+    marginLeft: '50%',
+    transform: 'translateX(-50%)',
+    mt: '24px',
+    overflow: 'hidden',
+
+    '& .swiper': {
+      width: '100%',
+      paddingLeft: '16px',
+      paddingRight: '0px',
+      overflow: 'visible'
+    },
+    '& .swiper-slide': {
+      width: 'auto',
+      display: 'flex'
+    }
+  },
+
   paper: (index: number) => ({
     position: 'relative',
-    top: `-${index * 12}px`
+    top: { xs: '0px', sm: `-${index * 12}px` },
+    maxWidth: {
+      xs: 'calc(100vw - 16px)',
+      sm: '296px'
+    },
+    Width: '100%'
   })
 };

--- a/app/shared/components/blocks/actions-help/ActionsHelp.test.tsx
+++ b/app/shared/components/blocks/actions-help/ActionsHelp.test.tsx
@@ -3,6 +3,12 @@ import { render, screen } from '@testing-library/react';
 import ActionsHelp from './ActionsHelp';
 import { TipTapNodeTypes } from '~/types/enums/common.enums';
 import { TipTapDoc } from '~/types/types/tiptap.types';
+jest.mock('swiper/react', () => ({
+  Swiper: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-swiper">{children}</div>,
+  SwiperSlide: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-swiper-slide">{children}</div>
+}));
+
+jest.mock('swiper/css', () => ({}));
 
 jest.mock('~/ds-components/text-card/TextCard', () => ({
   __esModule: true,

--- a/app/shared/components/blocks/actions-help/ActionsHelp.tsx
+++ b/app/shared/components/blocks/actions-help/ActionsHelp.tsx
@@ -1,4 +1,8 @@
-import { Box, Typography } from '@mui/material';
+'use client';
+
+import 'swiper/css';
+import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { Swiper, SwiperSlide } from 'swiper/react';
 
 import SectionTitle from '~/components/section-title/SectionTitle';
 import TipTapContent from '~/components/tip-tap-content/TipTapContent';
@@ -23,6 +27,8 @@ interface ActionsHelpProps {
 
 const ActionsHelp = ({ data }: { readonly data: Readonly<ActionsHelpProps> }) => {
   const { title, subtitle, paperItems, paperButton } = data;
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   const renderSubtitle = (children: React.ReactNode) => (
     <Typography variant="body2" sx={styles.typography} data-testid="ActionsHelp-subtitle">
@@ -30,9 +36,46 @@ const ActionsHelp = ({ data }: { readonly data: Readonly<ActionsHelpProps> }) =>
     </Typography>
   );
 
-  const paperComponents = paperItems.map((paper, index) => {
-    return <TextCard sx={styles.paper(index)} key={paper.title} title={paper.title} description={paper.description} />;
-  });
+  const renderCards = () => {
+    const cards = [
+      ...paperItems.map((paper, index) => (
+        <TextCard
+          sx={styles.paper(isMobile ? 0 : index)}
+          key={paper.title}
+          title={paper.title}
+          description={paper.description}
+        />
+      )),
+      <ButtonCard
+        key="button-card"
+        sx={styles.paper(isMobile ? 0 : paperItems.length)}
+        text={paperButton.text}
+        link={paperButton.link}
+        dataTestId="ActionsHelp-buttonCard"
+      />
+    ];
+
+    if (isMobile) {
+      return (
+        <Swiper
+          slidesPerView={'auto'}
+          spaceBetween={16}
+          centeredSlides={false}
+          watchSlidesProgress={true}
+          slidesOffsetAfter={16}
+          style={{ width: '100%', height: '100%' }}
+        >
+          {cards.map((card, index) => (
+            <SwiperSlide key={index} style={{ width: 'auto' }}>
+              {card}
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      );
+    }
+
+    return cards;
+  };
 
   return (
     <Box sx={styles.gridContainer} data-testid="ActionsHelp">
@@ -55,14 +98,11 @@ const ActionsHelp = ({ data }: { readonly data: Readonly<ActionsHelpProps> }) =>
           paragraph: renderSubtitle
         }}
       />
-      <Box sx={styles.papersContainer} data-testid="ActionsHelp-papersContainer">
-        {paperComponents}
-        <ButtonCard
-          sx={styles.paper(paperComponents.length)}
-          text={paperButton.text}
-          link={paperButton.link}
-          dataTestId="ActionsHelp-buttonCard"
-        />
+      <Box
+        sx={isMobile ? styles.mobileSwiperContainer : styles.papersContainer}
+        data-testid="ActionsHelp-papersContainer"
+      >
+        {renderCards()}
       </Box>
     </Box>
   );

--- a/app/shared/components/design-system/all-components/button-card/ButtonCard.styles.ts
+++ b/app/shared/components/design-system/all-components/button-card/ButtonCard.styles.ts
@@ -1,7 +1,7 @@
 export const styles = {
   container: {
     position: 'relative',
-    width: { xs: '270px', sm: '100%', md: '100%', lg: '272px', xl: '296px' },
+    width: { xs: '296px', md: '272px' },
     height: '351px',
     cursor: 'pointer',
     overflow: 'hidden',

--- a/app/shared/components/design-system/all-components/text-card/TextCard.styles.ts
+++ b/app/shared/components/design-system/all-components/text-card/TextCard.styles.ts
@@ -1,10 +1,9 @@
 export const styles = {
   card: {
     position: 'relative',
-    width: { sm: '100%', md: '100%', lg: '272px', xl: '296px' },
+    width: { xs: '296px', md: '272px' },
     height: '351px',
-    overflow: 'hidden',
-    display: { xs: 'none', sm: 'block' }
+    overflow: 'hidden'
   },
   background: {
     position: 'absolute',
@@ -38,6 +37,6 @@ export const styles = {
     fontWeight: 700,
     lineHeight: '130%',
     color: '#190D03',
-    marginTop: { sm: '80px', md: '30px', lg: '50px', xl: '79px' }
+    marginTop: { xs: '80px', md: '30px', lg: '50px' }
   }
 };


### PR DESCRIPTION
## Description

This PR resolves a bug where the carousel in the "Actions Help" section (Support the Foundation page) was unavailable on mobile devices. Previously, only a single static card was displayed, making other information inaccessible on screens between 320px and 767px.

**Key changes:**
* **Carousel Implementation:** Integrated `Swiper.js` into the `ActionsHelp` component to enable horizontal scrolling on mobile devices.
* **Component Refactoring:** * Updated `ActionsHelp.tsx` to conditionally render a `Swiper` carousel when `isMobile` is true.
    * Adjusted `TextCard.styles.ts` and `ButtonCard.styles.ts` to ensure card widths (`296px`) are consistent and fit correctly within the mobile viewport.
* **Style Updates:** Added `mobileSwiperContainer` to `ActionsHelp.styles.ts` to handle `100vw` width and proper alignment on small screens.
* **Test Suite Updates:** * Updated `ActionsHelp.test.tsx` to include mocks for `Swiper` and `SwiperSlide`.
    * Adjusted test assertions to verify correct rendering of cards within the new carousel structure.

## Type of change

- [x] Bug fix (UI/UX)
- [x] Refactoring (Tests)

## How to test

1. Open the "Support the Foundation" page.
2. Open DevTools and switch to the **Device Toolbar**.
3. Set the resolution to **320px** and then to **767px**.
4. **Verify the following:**
    * The cards in the "Actions Help" section are now arranged in a carousel.
    * You can smoothly swipe left and right to view all cards (info blocks and the button card).
    * Cards no longer have layout shifts or incorrect widths.
5. Run `npm test ActionsHelp.test.tsx` to ensure all tests pass with the new Swiper implementation.

## Video / Screenshots

https://github.com/user-attachments/assets/e7c4f311-6986-4956-9343-2cd2b5d602df


Closes: [#102](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/102)
