### PR TITLE
fix: implement localization for funds list in Archive page

### DIFF
--- a/app/[lang]/archive/page.test.tsx
+++ b/app/[lang]/archive/page.test.tsx
@@ -10,6 +10,7 @@ const renderWithTheme = (component: React.ReactElement) => {
 };
 
 jest.mock('next-intl', () => ({
+  useLocale: () => 'uk',
   useTranslations: () => (key: string) => key
 }));
 
@@ -104,7 +105,7 @@ describe('Archive Page', () => {
     await screen.findByTestId('ArchivePage-fundsGrid');
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/funds');
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/funds?lang=uk');
   });
 
   it('should call setParam when search is triggered', () => {

--- a/app/[lang]/archive/page.tsx
+++ b/app/[lang]/archive/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Box, CircularProgress } from '@mui/material';
+import { useLocale } from 'next-intl';
 import { useEffect, useState } from 'react';
 
 import useBreakpoints from '~/hooks/use-breakpoints/useBreakpoints';
@@ -38,6 +39,7 @@ const getColumnPaddingTop = (columnNum: number) => {
 export default function Archive() {
   const { isMobile, isTablet, isLaptop, isDesktop } = useBreakpoints();
   const [error, setError] = useState<string | null>(null);
+  const locale = useLocale();
 
   const [funds, setFunds] = useState<FundDTO[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -46,7 +48,7 @@ export default function Archive() {
   useEffect(() => {
     const loadFunds = async () => {
       try {
-        const response = await fetch('/api/funds');
+        const response = await fetch(`/api/funds?lang=${locale}`);
         if (!response.ok) {
           throw new Error('Failed to fetch funds');
         }
@@ -61,7 +63,7 @@ export default function Archive() {
     };
 
     loadFunds();
-  }, []);
+  }, [locale]);
 
   if (error) {
     throw new Error(error);

--- a/app/api/funds/route.ts
+++ b/app/api/funds/route.ts
@@ -9,8 +9,18 @@ export async function GET(req: NextRequest) {
     const params = req.nextUrl.searchParams;
     const fundId = params.get('id');
     const caseId = params.get('caseId');
+    const lang = params.get('lang') || 'uk';
 
     const fundsService = createRequestContainer().resolve('fundsService');
+    if (!fundId && !caseId) {
+      const funds = await fundsService.getFunds();
+      const translatedFunds = funds.map((fund: any) => ({
+        ...fund,
+        number: typeof fund.number === 'object' ? fund.number[lang] : fund.number,
+        title: typeof fund.title === 'object' ? fund.title[lang] : fund.title
+      }));
+      return NextResponse.json({ success: true, data: translatedFunds });
+    }
 
     if (caseId) {
       const caseDetails = await fundsService.getCaseById(caseId);
@@ -34,8 +44,12 @@ export async function GET(req: NextRequest) {
       if (!fund) {
         return NextResponse.json({ success: false, error: errors.NOT_FOUND }, { status: 404 });
       }
-
-      return NextResponse.json({ success: true, data: fund });
+      const translatedFund = {
+        ...fund,
+        number: typeof fund.number === 'object' ? fund.number[lang] : fund.number,
+        title: typeof fund.title === 'object' ? fund.title[lang] : fund.title
+      };
+      return NextResponse.json({ success: true, data: translatedFund });
     }
 
     const funds = await fundsService.getFunds();

--- a/app/api/funds/route.ts
+++ b/app/api/funds/route.ts
@@ -12,9 +12,14 @@ export async function GET(req: NextRequest) {
     const lang = params.get('lang') || 'uk';
 
     const fundsService = createRequestContainer().resolve('fundsService');
+    type FundData = {
+      number: string | Record<string, string>;
+      title: string | Record<string, string>;
+      [key: string]: unknown;
+    };
     if (!fundId && !caseId) {
       const funds = await fundsService.getFunds();
-      const translatedFunds = funds.map((fund: any) => ({
+      const translatedFunds = funds.map((fund: FundData) => ({
         ...fund,
         number: typeof fund.number === 'object' ? fund.number[lang] : fund.number,
         title: typeof fund.title === 'object' ? fund.title[lang] : fund.title


### PR DESCRIPTION
## Description

This PR enables multi-language support (UK/EN) for the Funds list in the Archive section. Previously, fund titles and numbers were fetched as static strings from the database.

**Key Changes:**
API `(/api/funds):` Updated the `GET` route to accept a lang query parameter. Added logic to map data based on the requested locale, supporting both legacy string formats and new localized objects.

Archive Page: Integrated the useLocale hook from next-intl to detect the current language and pass it to the API request.

Database Schema: Migrated title and number fields from String to Object type (containing uk and en keys) to support translations.

Testing: Updated page.test.tsx to reflect the new API request structure (including the ?lang=uk parameter) and mocked next-intl to prevent test failures.
## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

Switch the site language to English.

Navigate to the Archive page.

Confirm that funds with updated DB records (e.g., "Fund 2") display titles in English (e.g., "PERSONAL DOCUMENTS").


## Video / Screenshots

<img width="1280" height="574" alt="image" src="https://github.com/user-attachments/assets/49a9e681-5bfa-48fc-82dd-699b84f9256e" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
