### PR TITLE
perf: stop redundant network requests on FAQ hover

### DIFF
--- a/app/[lang]/archive/page.test.tsx
+++ b/app/[lang]/archive/page.test.tsx
@@ -10,7 +10,7 @@ const renderWithTheme = (component: React.ReactElement) => {
 };
 
 jest.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => key
+  useLocale: () => 'uk'
 }));
 
 const setParam = jest.fn();
@@ -104,7 +104,7 @@ describe('Archive Page', () => {
     await screen.findByTestId('ArchivePage-fundsGrid');
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/funds');
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/funds?lang=uk');
   });
 
   it('should call setParam when search is triggered', () => {

--- a/app/[lang]/archive/page.test.tsx
+++ b/app/[lang]/archive/page.test.tsx
@@ -104,7 +104,7 @@ describe('Archive Page', () => {
     await screen.findByTestId('ArchivePage-fundsGrid');
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/funds?lang=uk');
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/funds');
   });
 
   it('should call setParam when search is triggered', () => {

--- a/app/shared/components/blocks/FAQ/FAQ.styles.ts
+++ b/app/shared/components/blocks/FAQ/FAQ.styles.ts
@@ -33,6 +33,23 @@ export const styles = {
     gap: '16px',
     mt: '32px'
   },
+  '.icon-wrapper': {
+    position: 'relative',
+    '.hover-icon': {
+      display: 'none',
+      position: 'absolute',
+      top: 0,
+      left: 0
+    }
+  },
+  '&:hover .icon-wrapper': {
+    '.default-icon': {
+      display: 'none'
+    },
+    '.hover-icon': {
+      display: 'block'
+    }
+  },
   contactsItem: {
     display: 'flex',
     gap: '8px',

--- a/app/shared/components/design-system/all-components/faq-accordion/FaqAccordion.test.tsx
+++ b/app/shared/components/design-system/all-components/faq-accordion/FaqAccordion.test.tsx
@@ -21,7 +21,8 @@ describe('FaqAccordion component', () => {
   });
 
   it('should not show plus icon initially', () => {
-    expect(screen.getByAltText('toggle icon')).toBeInTheDocument();
+    const icons = screen.getAllByAltText('toggle icon');
+    expect(icons[0]).toBeInTheDocument();
   });
 
   it('should show minus icon after clicking to expand', () => {

--- a/app/shared/components/design-system/all-components/faq-accordion/FaqAccordion.tsx
+++ b/app/shared/components/design-system/all-components/faq-accordion/FaqAccordion.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Accordion, AccordionDetails, AccordionSummary, Box, Typography } from '@mui/material'; // Добавили Box сюда
+import { Accordion, AccordionDetails, AccordionSummary, Box, Typography } from '@mui/material';
 import React, { useState } from 'react';
 
 import { SvgImage } from '~/shared/components/svg-image/SvgImage';

--- a/app/shared/components/design-system/all-components/faq-accordion/FaqAccordion.tsx
+++ b/app/shared/components/design-system/all-components/faq-accordion/FaqAccordion.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@mui/material';
+import { Accordion, AccordionDetails, AccordionSummary, Box, Typography } from '@mui/material'; // Добавили Box сюда
 import React, { useState } from 'react';
 
 import { SvgImage } from '~/shared/components/svg-image/SvgImage';
@@ -10,37 +10,43 @@ export interface FaqAccordionProps {
 }
 
 export const FaqAccordion: React.FC<FaqAccordionProps> = ({ title, content }) => {
-  const [isHovered, setIsHovered] = useState<boolean>(false);
-
-  const handleMouseEnter = () => {
-    setIsHovered(true);
-  };
-
-  const handleMouseLeave = () => {
-    setIsHovered(false);
-  };
-
   const [expanded, setExpanded] = useState(false);
 
   const handleToggle = () => {
     setExpanded((prev: boolean) => !prev);
   };
 
-  const getIconSrc = () => {
-    if (expanded) {
-      return '/icons/circle-minus.svg';
-    } else {
-      return isHovered ? '/icons/circle-plus-black.svg' : '/icons/circle-plus.svg';
-    }
-  };
   return (
     <Accordion expanded={expanded} onChange={handleToggle} square elevation={0} disableGutters>
       <AccordionSummary
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        expandIcon={<SvgImage src={getIconSrc()} alt="toggle icon" width={28} height={28} />}
+        expandIcon={
+          <Box className="icon-wrapper" sx={{ position: 'relative', width: 28, height: 28 }}>
+            <Box className="default-icon">
+              <SvgImage
+                src={expanded ? '/icons/circle-minus.svg' : '/icons/circle-plus.svg'}
+                alt="toggle icon"
+                width={28}
+                height={28}
+              />
+            </Box>
+
+            {!expanded && (
+              <Box className="hover-icon" sx={{ position: 'absolute', top: 0, left: 0, display: 'none' }}>
+                <SvgImage src="/icons/circle-plus-black.svg" alt="toggle icon" width={28} height={28} />
+              </Box>
+            )}
+          </Box>
+        }
         aria-controls="Faq-content"
         id="Faq-header"
+        sx={{
+          '&:hover .default-icon': {
+            display: expanded ? 'block' : 'none'
+          },
+          '&:hover .hover-icon': {
+            display: expanded ? 'none' : 'block'
+          }
+        }}
       >
         <Typography variant="customSemiBold18">{title}</Typography>
       </AccordionSummary>


### PR DESCRIPTION
## Description

This PR fixes an issue where hovering over FAQ accordion items triggered multiple network requests for SVG icons.

Key Changes:
Optimization: Removed isHovered React state and onMouseEnter/onMouseLeave handlers from FaqAccordion. Hover logic is now handled entirely via CSS selectors within the sx prop of AccordionSummary.

DOM Structure: Both default and hover icons are now rendered simultaneously inside a Box wrapper. Visibility is toggled using display: none/block, ensuring icons are preloaded and no new GET requests are made during interaction.

Bug Fixes: Added missing Box import from @mui/material.

Wrapped SvgImage in a Box to correctly apply className and sx styles without modifying the base component's props.

Testing: Updated FaqAccordion.test.tsx to use getAllByAltText instead of getByAltText to account for multiple icons (default/hover) present in the document.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

Go to the `/support-us` page
Hover the cursour over questions element
Observe that element no longer spams requests

## Video / Screenshots

<img width="1070" height="536" alt="image" src="https://github.com/user-attachments/assets/9629d9db-ae91-43dd-979d-633b2b1c45ab" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
