### PR TITLE
fix(content): update partner redirection links on Cooperation page

### DIFF
--- a/app/shared/components/blocks/our-partners/partners.data.ts
+++ b/app/shared/components/blocks/our-partners/partners.data.ts
@@ -5,20 +5,64 @@ export interface Partner {
   name: string;
 }
 
-const partnerData: Omit<Partner, 'link'>[] = [
-  { id: 'musicHouse', name: 'Національний будинок музики', img: 'national-music-house.png' },
-  { id: 'philharmonic', name: 'Національна філармонія України', img: 'national-philharmonic.png' },
-  { id: 'liatoshynsky', name: 'Liatoshynsky Space', img: 'liatoshynsky-space.png' },
-  { id: 'masterKlass', name: 'Master Klass', img: 'masterklass.png' },
-  { id: 'kolomyia', name: 'Коломийська філармонія', img: 'kolomyia-philharmonic.png' },
-  { id: 'axon', name: 'Axon Partners', img: 'axon-partners.png' },
-  { id: 'espreso', name: 'Еспресо', img: 'espreso.png' },
-  { id: 'softserve', name: 'SoftServe Academy', img: 'softserve.png' },
-  { id: 'opentech', name: 'OpenTech', img: 'opentech.png' }
+const partnerData: Partner[] = [
+  {
+    id: 'musicHouse',
+    name: 'Національний будинок музики',
+    img: 'national-music-house.png',
+    link: 'https://nhm.com.ua/'
+  },
+  {
+    id: 'philharmonic',
+    name: 'Національна філармонія України',
+    img: 'national-philharmonic.png',
+    link: 'https://philarmonia.com.ua/'
+  },
+  {
+    id: 'liatoshynsky',
+    name: 'Liatoshynsky Space',
+    img: 'liatoshynsky-space.png',
+    link: '/'
+  },
+  {
+    id: 'masterKlass',
+    name: 'Master Klass',
+    img: 'masterklass.png',
+    link: 'https://dommk.org/'
+  },
+  {
+    id: 'kolomyia',
+    name: 'Коломийська філармонія',
+    img: 'kolomyia-philharmonic.png',
+    link: 'https://kocult.com/home/philharmonic'
+  },
+  {
+    id: 'axon',
+    name: 'Axon Partners',
+    img: 'axon-partners.png',
+    link: 'https://axon.partners/'
+  },
+  {
+    id: 'espreso',
+    name: 'Еспресо',
+    img: 'espreso.png',
+    link: 'https://espreso.tv/'
+  },
+  {
+    id: 'softserve',
+    name: 'SoftServe Academy',
+    img: 'softserve.png',
+    link: 'https://softserve.academy/'
+  },
+  {
+    id: 'opentech',
+    name: 'OpenTech',
+    img: 'opentech.png',
+    link: 'https://opentech.softserveinc.com/uk'
+  }
 ];
 
 export const partnersMock: Partner[] = partnerData.map((p) => ({
   ...p,
-  link: '/',
   img: `/images/partners/${p.img}`
 }));


### PR DESCRIPTION
## Description

This PR fixes a navigation bug on the `/cooperation` page where clicking on partner icons incorrectly redirected users to the "About the Foundation" page instead of the partners' actual websites.

**Key changes:**
* **Link Correction:** Updated the data objects for all partners to include their correct external URLs.

## Type of change

- [x] Bug fix (Content/Navigation)

## How to test

1. Navigate to the **Cooperation** page (`/cooperation`).
2. Locate the block containing partner icons.
3. Click on each partner icon (e.g., icons 1-3, 5-8, 10-11 as specified in the bug report).
4. **Verify the following:**
    * You are redirected to the external official website of the specific partner.
    * You are **no longer** redirected to the "About the Foundation" page.

Closes [#112](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/112)