### PR TITLE
fix align filter drop-down

### DIFF
--- a/app/shared/components/design-system/all-components/selector/FilterSelect.tsx
+++ b/app/shared/components/design-system/all-components/selector/FilterSelect.tsx
@@ -144,11 +144,11 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
         onClose={handleCloseMenu}
         anchorOrigin={{
           vertical: PositionEnum.Bottom,
-          horizontal: PositionEnum.Center
+          horizontal: PositionEnum.Left
         }}
         transformOrigin={{
           vertical: PositionEnum.Top,
-          horizontal: PositionEnum.Center
+          horizontal: PositionEnum.Left
         }}
         maxHeight={300}
         menuList={menuList}


### PR DESCRIPTION
## Description

Fixes the alignment of the filters' drop-down list on the `/research` page.

Adjusted the positioning so that each filter's drop-down is aligned with the left side of the filter bar across responsive breakpoints.

Related: Liatoshynsky-Foundation/lf-manual-tests#111

## Type of change

- [x] Bug fix

## How to test

1. Open the `/research` page.
2. Set viewport width to:
   - 768px
   - 1024px
   - 1280px
   - >1440px
3. Click the filter icon.
4. Open each filter drop-down.
5. Verify that the drop-down list is aligned with the left side of the filter bar.

## Video / Screenshots

Screenshots attached showing:
- Misaligned drop-down before fix
- Correct alignment after fix

Before:
<img width="365" height="347" alt="Screenshot 2026-03-03 at 14 07 55" src="https://github.com/user-attachments/assets/c60b7013-d655-4b43-b949-ebb08926ea3e" />

Current:

<img width="364" height="385" alt="Screenshot 2026-03-03 at 14 08 43" src="https://github.com/user-attachments/assets/0deb0380-af96-4960-abfd-0b36348091c0" />
