### PR TITLE
fix: align artistry filter dropdowns to the left

### DIFF
--- a/app/shared/components/design-system/all-components/selector/FilterSelect.tsx
+++ b/app/shared/components/design-system/all-components/selector/FilterSelect.tsx
@@ -144,11 +144,11 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
         onClose={handleCloseMenu}
         anchorOrigin={{
           vertical: PositionEnum.Bottom,
-          horizontal: PositionEnum.Center
+          horizontal: PositionEnum.Left
         }}
         transformOrigin={{
           vertical: PositionEnum.Top,
-          horizontal: PositionEnum.Center
+          horizontal: PositionEnum.Left
         }}
         maxHeight={300}
         menuList={menuList}


### PR DESCRIPTION
### Summary
The drop-down lists for filters on the `/artistry` page were not properly aligned with the left edge of the filter bar.

<!-- Briefly describe the purpose of this PR and what was changed -->

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Navigate to /artistry.
2. Open filters: Category, Genre, and Year.
3. Check alignment: Ensure dropdowns are aligned with the left edge of the buttons.
4. Responsiveness: Verify on 320px+.

**Actual result:**
The filters' drop-down list on the /artistry page isn't aligned with the left side of the filter bar.
<img width="609" height="264" alt="Знімок екрана 2026-03-03 133814" src="https://github.com/user-attachments/assets/cb6c0e29-3206-49dd-92b9-bdcc9112494d" />


**Expected result:**
The filters' drop-down list on the /artistry page is aligned with the left side of the filter bar.
<img width="631" height="293" alt="Знімок екрана 2026-03-03 135924" src="https://github.com/user-attachments/assets/50702321-0e51-4946-a569-f26f68d657bf" />
<img width="629" height="376" alt="Знімок екрана 2026-03-03 135929" src="https://github.com/user-attachments/assets/4a3fbe74-1d14-4d7d-b5de-c919cc491216" />

Closes https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/110
