### PR TITLE
fix email and phone links

### DIFF
--- a/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.test.tsx
+++ b/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.test.tsx
@@ -1,9 +1,7 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import useBreakpoints from '~/hooks/use-breakpoints/useBreakpoints';
-
 import FooterContactInfo from './FooterContactInfo';
 
 jest.mock('~/hooks/use-breakpoints/useBreakpoints');
@@ -11,8 +9,6 @@ jest.mock('~/hooks/use-breakpoints/useBreakpoints');
 jest.mock('~/components/colored-svg/ColoredSvg', () => ({
   Svg: ({ Component, ...props }: { Component: React.ComponentType }) => <Component {...props} />
 }));
-
-jest.mock('~/ds-components/copy-link/CopyLink');
 
 const mockedUseBreakpoints = useBreakpoints as jest.Mock;
 
@@ -30,23 +26,12 @@ const labels = {
 const alertMsg = 'Copied';
 
 describe('FooterContactInfo', () => {
-  beforeAll(() => {
-    jest.spyOn(window, 'alert').mockImplementation(() => {});
-  });
-
-  afterAll(() => {
-    jest.restoreAllMocks();
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   describe('on desktop', () => {
     beforeEach(() => {
-      const { setMockIsMobile } = jest.requireMock('~/ds-components/copy-link/CopyLink');
-      setMockIsMobile(false);
-
       mockedUseBreakpoints.mockReturnValue({ isMobile: false });
       render(<FooterContactInfo labels={labels} contacts={contacts} alertMsg={alertMsg} />);
     });
@@ -59,54 +44,43 @@ describe('FooterContactInfo', () => {
       expect(screen.getByText(/Phone:/i)).toBeInTheDocument();
     });
 
-    it('renders email as copyable element on desktop', () => {
-      const copyLinks = screen.getAllByTestId('mock-copy-link');
-      const emailCopyLink = copyLinks.find((link) => link.textContent === contacts.email);
-      expect(emailCopyLink).toBeInTheDocument();
-      expect(emailCopyLink).toHaveTextContent(contacts.email);
+    it('renders email as mailto link', () => {
+      const emailLink = screen.getByRole('link', {
+        name: contacts.email
+      });
+
+      expect(emailLink).toHaveAttribute('href', `mailto:${contacts.email}`);
     });
 
-    it('copies phone on CopyLink click', async () => {
-      const user = userEvent.setup();
-      const writeSpy = jest.spyOn(navigator.clipboard, 'writeText').mockResolvedValue();
+    it('renders phone as tel link', () => {
+      const phoneLink = screen.getByRole('link', {
+        name: contacts.phone
+      });
 
-      const copyLinks = screen.getAllByTestId('mock-copy-link');
-      const phoneCopyLink = copyLinks.find((link) => link.textContent === contacts.phone);
-
-      expect(phoneCopyLink).toBeDefined();
-      if (phoneCopyLink) {
-        await user.click(phoneCopyLink);
-      }
-
-      expect(writeSpy).toHaveBeenCalledWith(contacts.phone);
-      writeSpy.mockRestore();
+      expect(phoneLink).toHaveAttribute('href', `tel:${contacts.phone}`);
     });
   });
 
   describe('on mobile', () => {
     beforeEach(() => {
-      const { setMockIsMobile } = jest.requireMock('~/ds-components/copy-link/CopyLink');
-      setMockIsMobile(true);
       mockedUseBreakpoints.mockReturnValue({ isMobile: true });
       render(<FooterContactInfo labels={labels} contacts={contacts} alertMsg={alertMsg} />);
     });
 
     it('renders mailto email link with correct href', () => {
-      const emailLink = screen.getByRole('link', { name: contacts.email });
+      const emailLink = screen.getByRole('link', {
+        name: contacts.email
+      });
+
       expect(emailLink).toHaveAttribute('href', `mailto:${contacts.email}`);
     });
 
     it('renders tel phone link with correct href', () => {
-      const phoneLink = screen.getByRole('link', { name: contacts.phone });
-      expect(phoneLink).toHaveAttribute('href', `tel:${contacts.phone}`);
-    });
-
-    it('does not render copy button on mobile', () => {
-      const copyLinks = screen.getAllByTestId('mock-copy-link');
-      expect(copyLinks.length).toBeGreaterThan(0);
-      copyLinks.forEach((link) => {
-        expect(link.tagName).toBe('A');
+      const phoneLink = screen.getByRole('link', {
+        name: contacts.phone
       });
+
+      expect(phoneLink).toHaveAttribute('href', `tel:${contacts.phone}`);
     });
   });
 });

--- a/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.test.tsx
+++ b/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import useBreakpoints from '~/hooks/use-breakpoints/useBreakpoints';
+
 import FooterContactInfo from './FooterContactInfo';
 
 jest.mock('~/hooks/use-breakpoints/useBreakpoints');

--- a/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.tsx
+++ b/app/shared/components/Footer/FooterContactInfo/FooterContactInfo.tsx
@@ -30,8 +30,8 @@ const FooterContactInfo: FC<FooterContactInfoProps> = ({ contacts, labels, alert
         </Box>
       </Box>
       <Box>
-        <ContactLink type="phone" value={contacts.phone} label={labels.phoneLabel} alertMsg={alertMsg} />
-        <ContactLink type="email" value={contacts.email} label="Email" alertMsg={alertMsg} />
+        <ContactLink type="phone" value={contacts.phone} label={labels.phoneLabel} alertMsg={alertMsg} useNativeLink />
+        <ContactLink type="email" value={contacts.email} label="Email" alertMsg={alertMsg} useNativeLink />
       </Box>
     </Box>
   );

--- a/app/shared/components/contact-link/ContactLink.tsx
+++ b/app/shared/components/contact-link/ContactLink.tsx
@@ -32,6 +32,7 @@ interface ContactLinkProps {
   copyLinkSize?: CopyIconSize;
   direction?: ContactLinkDirection;
   dataTestid?: string;
+  useNativeLink?: boolean;
 }
 
 export const ContactLink = ({
@@ -47,11 +48,14 @@ export const ContactLink = ({
   disabled = false,
   direction = 'row',
   iconSize = 'medium',
-  copyLinkSize = 'medium'
+  copyLinkSize = 'medium',
+  useNativeLink = false
 }: ContactLinkProps) => {
   const { isMobile } = useBreakpoints();
 
   const hasLabelOutside = !!label && !isMobile;
+
+  const href = type === 'phone' ? `tel:${value.replace(/\s+/g, '')}` : `mailto:${value}`;
 
   return (
     <Box sx={styles.wrapper} data-testid={dataTestid}>
@@ -89,14 +93,27 @@ export const ContactLink = ({
             </Typography>
           )}
 
-          <CopyLink
-            value={value}
-            hrefType={type}
-            size={copyLinkSize}
-            hint={alertMsg}
-            disabled={disabled}
-            sx={isMobile ? styles.mobileStretchedLink : undefined}
-          />
+          {useNativeLink ? (
+            <Typography
+              component="a"
+              href={disabled ? undefined : href}
+              sx={isMobile ? styles.mobileStretchedLink : styles.link}
+              onClick={(e) => {
+                if (disabled) e.preventDefault();
+              }}
+            >
+              {value}
+            </Typography>
+          ) : (
+            <CopyLink
+              value={value}
+              hrefType={type}
+              size={copyLinkSize}
+              hint={alertMsg}
+              disabled={disabled}
+              sx={isMobile ? styles.mobileStretchedLink : undefined}
+            />
+          )}
         </Box>
       </Box>
     </Box>

--- a/app/shared/components/design-system/all-components/link/NextLink.tsx
+++ b/app/shared/components/design-system/all-components/link/NextLink.tsx
@@ -6,8 +6,7 @@ import { useRouter } from 'next/router';
 import * as React from 'react';
 
 interface NextLinkComposedProps
-  extends
-    Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
+  extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
     Omit<NextLinkProps, 'href' | 'as' | 'passHref' | 'onMouseEnter' | 'onClick' | 'onTouchStart'> {
   to: NextLinkProps['href'];
   linkAs?: NextLinkProps['as'];

--- a/app/shared/components/design-system/all-components/link/NextLink.tsx
+++ b/app/shared/components/design-system/all-components/link/NextLink.tsx
@@ -6,7 +6,8 @@ import { useRouter } from 'next/router';
 import * as React from 'react';
 
 interface NextLinkComposedProps
-  extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
+  extends
+    Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>,
     Omit<NextLinkProps, 'href' | 'as' | 'passHref' | 'onMouseEnter' | 'onClick' | 'onTouchStart'> {
   to: NextLinkProps['href'];
   linkAs?: NextLinkProps['as'];


### PR DESCRIPTION
## Description

This PR fixes the footer email behavior for tablet and smaller responsive breakpoints.

Previously, on devices with widths 1024–1279px (Big Tablet), 768–1023px (Small Tablet), and smaller, pressing the email button copied the email address to the clipboard.

Now, clicking the email opens the default email client (`mailto:`) with the address prefilled, ensuring consistent contact behavior across devices.

This aligns email interaction with expected UX and matches the behavior already implemented for the phone number (opening the call window).

Fixes: [#23](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/23)

## Type of change

- [x] Bug fix

## How to test

1. Open the application.
2. Scroll down to the footer.
3. Switch to responsive mode:
   - 1024–1279px (Big Tablet)
   - 768–1023px (Small Tablet)
   - Smaller breakpoints
4. Click the email link.
5. Verify that the default email client opens with the email address prefilled.
6. Ensure that the phone number still opens the call window (`tel:`).

Tested on:
- iOS (Safari, Chrome)
- Android (Chrome)
- Responsive view (DevTools)

## Video / Screenshots

Before:
<img width="368" height="92" alt="Screenshot 2026-03-03 at 14 12 02" src="https://github.com/user-attachments/assets/6bfef94e-9408-4b8b-85f6-b16ef1391781" />

Current:
<img width="849" height="674" alt="Screenshot 2026-03-03 at 14 15 25" src="https://github.com/user-attachments/assets/dc61b5c1-c1c0-4010-adc6-87b6a596f406" />
<img width="303" height="102" alt="Screenshot 2026-03-03 at 14 15 41" src="https://github.com/user-attachments/assets/8b315f16-c711-4d3d-9034-30c31f6e4087" />


---