### PR TITLE
fix(ui): align header dropdown menu positioning

### DIFF
--- a/app/shared/components/design-system/all-components/dropdown-menu/DropdownMenu.tsx
+++ b/app/shared/components/design-system/all-components/dropdown-menu/DropdownMenu.tsx
@@ -15,11 +15,11 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   sx,
   anchorOrigin = {
     vertical: PositionEnum.Bottom,
-    horizontal: PositionEnum.Center
+    horizontal: PositionEnum.Left
   },
   transformOrigin = {
     vertical: PositionEnum.Top,
-    horizontal: PositionEnum.Center
+    horizontal: PositionEnum.Left
   },
   ...props
 }) => {

--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.styles.ts
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.styles.ts
@@ -19,7 +19,8 @@ export const styles = {
     alignItems: 'center'
   },
   dropdownMenu: {
-    marginTop: '8px'
+    marginTop: '8px',
+    marginLeft: '-16px'
   },
   buttonGroup: {
     height: '40px',

--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.styles.ts
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.styles.ts
@@ -20,7 +20,7 @@ export const styles = {
   },
   dropdownMenu: {
     marginTop: '8px',
-    marginLeft: '-16px'
+    transform: 'translateX(-16px)'
   },
   buttonGroup: {
     height: '40px',


### PR DESCRIPTION
## Description

This PR fixes the alignment issue of the header drop-down menus on desktop (1280px and above).

Previously, the drop-down lists ("Foundation" and "Borys Liatoshynsky") were not aligned correctly to the left relative to their parent menu items, causing visual inconsistency.

Now, the drop-down menus are properly aligned to the left edge of their corresponding header items, ensuring consistent layout behavior.

Issue:
https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/129

## Type of change

- [x] Bug fix

## How to test

1. Open any application page.
2. Set screen width to 1280px or above.
3. Click on the "Foundation" drop-down menu in the header.
4. Click on the "Borys Liatoshynsky" drop-down menu.
5. Verify that the drop-down list is aligned to the left edge of its parent menu item.
6. Ensure there are no layout shifts or visual glitches.

## Video / Screenshots

Before:
<img width="750" height="572" alt="Screenshot 2026-03-03 at 17 55 58" src="https://github.com/user-attachments/assets/d3e48d2d-e5e2-4c20-af8c-d550fb96a246" />

After:
<img width="271" height="224" alt="Screenshot 2026-03-03 at 17 41 23" src="https://github.com/user-attachments/assets/ed6abffa-b0cf-4348-b30a-4dbc30b43365" />
<img width="263" height="235" alt="Screenshot 2026-03-03 at 17 41 18" src="https://github.com/user-attachments/assets/8d16e4b0-dbc9-4102-9ffe-46add32540e7" />

