### PR TITLE
fix(styles): adjust image alignment and sizing in BiographyContent

### DIFF
--- a/app/[lang]/biography/BiographyContent/BiographyContent.styles.ts
+++ b/app/[lang]/biography/BiographyContent/BiographyContent.styles.ts
@@ -96,12 +96,19 @@ export const biographyContentStyles = {
 
   onlyImageRight: {
     position: 'relative',
+    marginLeft: 'auto',
     gridColumn: {
       xs: '2 / -1',
       sm: '4 / -1',
       md: '6 / -1'
     },
-    alignSelf: 'end'
+    alignSelf: 'end',
+    maxWidth: {
+      xs: 250,
+      sm: 560,
+      md: '100%'
+    },
+    width: '100%'
   },
 
   imageContainer: {
@@ -131,7 +138,7 @@ export const biographyContentStyles = {
 
   bigHorizontal: {
     width: { xs: 199, sm: 400, md: 496, lg: 646, xl: 744 },
-    height: { xs: 150, sm: 280, md: 350, lg: 452, xl: 506, xxl: 560 }
+    height: { xs: 160, sm: 280, md: 350, lg: 452, xl: 506, xxl: 560 }
   },
 
   fullWidth: {


### PR DESCRIPTION
## Description

This PR fixes the issue where images on the “Lyatoshynsky’s Life Story” page were cut off on the sides in responsive mode between ~400px and 767px screen widths.

Previously, when reducing the screen size to tablet/mobile breakpoints, images were partially clipped horizontally, causing layout inconsistency and deviation from the Figma design.

Now, images are displayed correctly within the viewport across the affected breakpoints, preserving proportions and matching the intended responsive layout.

Issue:
https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/57

## Type of change

- [x] Bug fix

## How to test

1. Open the If-client.
2. Navigate to the “Lyatoshynsky’s Life Story” page.
3. Open DevTools and enable responsive mode.
4. Set screen width to:
   - 767px
   - ~400px
   - Any width between 400px and 767px
5. Review all images on the page.
6. Verify that images are no longer cut off on the sides.
7. Ensure layout matches the Figma mobile design.

Tested in:
- Chrome (Device Mode)
- Firefox (Responsive Design Mode)

## Video / Screenshots

Before:

<img width="782" height="578" alt="Screenshot 2026-03-03 at 22 18 11" src="https://github.com/user-attachments/assets/f111a740-656c-450d-8417-c98bf3b00e44" />

<img width="680" height="406" alt="Screenshot 2026-03-03 at 22 18 40" src="https://github.com/user-attachments/assets/9f18e20e-fd9b-4516-a1f3-3ec45f34a5f7" />

Current:
<img width="436" height="569" alt="Screenshot 2026-03-03 at 22 08 36" src="https://github.com/user-attachments/assets/78ec05dc-0039-4919-bf89-1faa7df9efe3" />
<img width="704" height="744" alt="Screenshot 2026-03-03 at 22 04 10" src="https://github.com/user-attachments/assets/132ee3ad-006a-4e5e-9bbc-7b9224fab98c" />
<img width="683" height="1106" alt="Screenshot 2026-03-03 at 22 03 47" src="https://github.com/user-attachments/assets/c7c158cb-4267-48e4-8916-509ff550bc94" />
