### PR TITLE
fix: remove height property from modal content styles

### DIFF
--- a/app/shared/components/design-system/all-components/modal/Modal.styles.ts
+++ b/app/shared/components/design-system/all-components/modal/Modal.styles.ts
@@ -50,8 +50,7 @@ export const style = {
     border: 'none',
     padding: '0',
     display: 'flex',
-    flexDirection: 'column',
-    height: '100%'
+    flexDirection: 'column'
   },
   topSection: {
     display: 'flex',


### PR DESCRIPTION
## Description

This PR fixes the incorrect display of the cookie consent modal on iOS mobile devices.

Previously, on iPhone devices (iOS 18.6.2, Chrome and Safari), only the cookie message title was visible. The description text was not displayed, and some functionality (accept, reject, close, settings, detailed information) was either hidden or not accessible.

Now, the cookie modal:
- Displays both the title and full description text correctly.
- Provides full access to all functionality (accept, reject, close, settings, detailed information).
- Fully matches the design specified in Figma.

Issue:
https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/6

## Type of change

- [x] Bug fix

## How to test

1. Clear cookies for the application.
2. Open the app on:
   - iPhone (iOS 18.6.2)
   - Safari
   - Chrome
3. Verify that the cookie modal appears on first load.
4. Ensure:
   - Title and full description text are visible.
   - Accept, Reject, Close, Settings, and Detailed Information options are displayed and functional.
5. Confirm that the layout matches the Figma design.
6. Ensure no layout breaking occurs on iOS devices.

## Video / Screenshots

Before:
<img width="531" height="529" alt="Screenshot 2026-03-03 at 22 53 06" src="https://github.com/user-attachments/assets/5d1f23b2-adb3-4150-88f3-29472cd30d00" />

Current:
<img width="618" height="472" alt="Screenshot 2026-03-03 at 22 53 27" src="https://github.com/user-attachments/assets/79e481ef-918b-4b44-86ed-d21d2a6a5d68" />
