### PR TITLE
fix(ui): adjust images border width on cooperation page

### DIFF
--- a/app/shared/components/blocks/partnership-formats/PartnershipFormats.styles.ts
+++ b/app/shared/components/blocks/partnership-formats/PartnershipFormats.styles.ts
@@ -446,12 +446,12 @@ const imageByType: Record<PartnershipImageType, ImageConfig> = {
   [PartnershipImageType.FirstRowImage]: {
     container: baseStyles.firstRowImageContainer,
     wrapper: baseStyles.firstRowImageWrapper,
-    borderWidth: 2
+    borderWidth: 8
   },
   [PartnershipImageType.SecondRowImage]: {
     container: baseStyles.secondRowImageContainer,
     wrapper: baseStyles.secondRowImageWrapper,
-    borderWidth: 2
+    borderWidth: 8
   }
 };
 

--- a/app/shared/components/blocks/partnership-formats/PartnershipFormats.test.tsx
+++ b/app/shared/components/blocks/partnership-formats/PartnershipFormats.test.tsx
@@ -65,8 +65,8 @@ jest.mock('next/image', () => ({
 
 jest.mock('./PartnershipSlider', () => {
   const borderByType: Record<string, number> = {
-    firstRowImage: 2,
-    secondRowImage: 2
+    firstRowImage: 8,
+    secondRowImage: 8
   };
 
   return jest.fn(({ slides }: any) => (
@@ -323,7 +323,7 @@ describe('PartnershipFormats', () => {
     expect(imageContainers.length).toBeGreaterThanOrEqual(2);
 
     for (const imageContainer of imageContainers) {
-      expect(imageContainer).toHaveAttribute('data-border-width', '2');
+      expect(imageContainer).toHaveAttribute('data-border-width', '8');
     }
   });
 


### PR DESCRIPTION
## Description

The image border lines in the "Partnership Formats" block on the cooperation page were too thin (2px). Following the requirements for desktop views (>=768px), the border width has been increased to 8px. Unit tests were also updated to match the new design requirements.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to [/cooperation](https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/uk/cooperation)
2. Use the DevTools device toolbar.
3. Go to the Forms of Partnership block.
4. Review the element:

- body > div.MuiBox-root.css-swu6uj > div > div.MuiBox-root.css-p7soqj > div.MuiBox-root.css-yjqr17 > div.MuiBox-root.css-1uf97ux > div.MuiBox-root.css-12wwjpz > div > div > div

- body > div.MuiBox-root.css-swu6uj > div > div.MuiBox-root.css-p7soqj > div.MuiBox-root.css-yjqr17 > div.MuiBox-root.css-pemlmy > div.MuiBox-root.css-1eczo75 > div > div > div

Previous result:
width: 2px
<img width="1003" height="528" alt="1" src="https://github.com/user-attachments/assets/7037eac1-d4d4-473b-87f0-4680754e6881" />
<img width="1547" height="550" alt="2" src="https://github.com/user-attachments/assets/ca287756-f5e2-4c4e-b35b-f6f128134490" />

Actual result:
width: 8px
<img width="1008" height="533" alt="3" src="https://github.com/user-attachments/assets/7c4fa0ba-ea87-497f-8416-f541ac1a2429" />
<img width="1547" height="553" alt="4" src="https://github.com/user-attachments/assets/0cfc35a4-cd49-4d81-a65f-ed3df8df26cf" />

Closes Liatoshynsky-Foundation/lf-manual-tests#165

---

