### PR TITLE
Fix partners logos mobile scrollability

### DIFF
--- a/app/shared/components/blocks/our-partners/OurPartners.styles.ts
+++ b/app/shared/components/blocks/our-partners/OurPartners.styles.ts
@@ -42,14 +42,14 @@ export const styles = {
     justifyContent: 'center',
     alignItems: 'center',
     width: '112px',
-    height: '100%',
+    height: '60px',
     flexShrink: 0
   },
 
   logoImage: {
     objectFit: 'contain',
-    height: 'auto',
-    maxHeight: '112px',
+    height: '100%',
+    maxHeight: '60px',
     width: '100%'
   }
 };

--- a/app/shared/components/blocks/our-partners/OurPartners.styles.ts
+++ b/app/shared/components/blocks/our-partners/OurPartners.styles.ts
@@ -25,16 +25,25 @@ export const styles = {
   },
 
   xsGrid: {
-    display: { xs: 'grid', sm: 'none' },
-    justifyContent: 'center',
+    display: { xs: 'flex', sm: 'none' },
+    justifyContent: 'flex-start',
+    overflowX: 'auto',
+    scrollbarWidth: 'none',
+    msOverflowStyle: 'none',
     alignItems: 'center',
-    gap: '12px',
-    gridTemplateColumns: 'repeat(2, 1fr)'
+    gap: '4px',
+    '&::-webkit-scrollbar': {
+      display: 'none'
+    }
   },
 
   logoWrapper: {
     display: 'flex',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '112px',
+    height: '100%',
+    flexShrink: 0
   },
 
   logoImage: {

--- a/app/shared/components/blocks/our-partners/OurPartners.test.tsx
+++ b/app/shared/components/blocks/our-partners/OurPartners.test.tsx
@@ -54,7 +54,7 @@ describe('OurPartners', () => {
   it('should render the first two xs partners', () => {
     render(<OurPartners />);
     const logos = screen.getAllByTestId('partner-logo');
-    expect(logos.length).toBe(2);
+    expect(logos.length).toBe(partnersMock.length);
 
     const firstPartnerName = partnersMock[0].name;
     const secondPartnerName = partnersMock[1].name;

--- a/app/shared/components/blocks/our-partners/OurPartners.tsx
+++ b/app/shared/components/blocks/our-partners/OurPartners.tsx
@@ -16,7 +16,6 @@ export default function OurPartners() {
   const partners = partnersMock;
 
   const layouts = generateLayouts(partners, patterns);
-  const xsPartners = partners.slice(0, 2);
 
   return (
     <Box sx={styles.wrapper}>
@@ -30,19 +29,11 @@ export default function OurPartners() {
       <ContentBlock textSx={styles.text} description={t('description')} />
 
       <Box sx={styles.xsGrid}>
-        {xsPartners.map((partner) => (
+        {partners.map((partner) => (
           <Box key={partner.id} sx={styles.logoWrapper}>
             <PartnerLogo
               link={partner.link}
-              image={
-                <img
-                  src={partner.img}
-                  alt={partner.name}
-                  width={200}
-                  height={100}
-                  style={styles.logoImage as React.CSSProperties}
-                />
-              }
+              image={<img src={partner.img} alt={partner.name} style={styles.logoImage as React.CSSProperties} />}
             />
           </Box>
         ))}


### PR DESCRIPTION
### Summary
Fixed the mobile responsiveness of the partners' logos on the `/cooperation` page. Converted the layout to a horizontally scrollable flex container and adjusted logo dimensions and gaps to match the design. Also updated the related unit tests.

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test
1. Navigate to the `/cooperation` page.
2. Open DevTools and set the screen resolution between 320px and 767px.
3. Try to scroll the partners' logos from right to left using touch simulation.


## Actual result
Scrolling the partners' logos from right to left is impossible.

## Expected result
The partners' logos scroll smoothly from right to left. The logos are 112x60px with a 4px gap.

https://github.com/user-attachments/assets/349c36da-0548-4296-a15d-7f553c9b0186

Closes https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/108