### PR TITLE
fix: correct mobile overlay height and clipPath for better display on…

### DIFF
--- a/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/mobile-overlay/MobileOverlay.styles.ts
+++ b/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/mobile-overlay/MobileOverlay.styles.ts
@@ -20,11 +20,11 @@ export const styles = {
     top: { xs: '-30px', md: '-48px' },
     left: 0,
     width: '100vw',
-    height: '107vh',
+    height: '100vh',
     backgroundColor: mainHexPallete.yellow[500],
     zIndex: 900,
     clipPath: {
-      xs: 'polygon(0 0, 100% 0, 100% 98%, 0 100%)',
+      xs: 'polygon(0 0, 100% 0, 100% 100%, 0 100%)',
       sm: 'polygon(0 0, 100% 0, 100% 94%, 0 100%)'
     }
   },


### PR DESCRIPTION
## Description

This PR fixes an issue with the header behavior on mobile devices (responsive 320–767px).

Previously, when opening the header menu on mobile devices, the behavior/layout was incorrect in responsive mode. The issue was reproducible on both iOS and Android devices.

The header now works correctly on mobile breakpoints and behaves consistently across supported devices and browsers.

link:
https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/125

## Type of change

- [x] Bug fix

## How to test

1. Open any application page.
2. Open DevTools and enable **Toggle device toolbar**.
3. Select one of the following devices:
   - iPhone 14 Pro Max
   - Samsung Galaxy S20 Ultra
4. Ensure the screen width is within **320–767px**.
5. Open the **header menu**.
6. Verify that the header displays and functions correctly without layout issues.

## Video / Screenshots

Before:
![550858853-85976dec-a858-49e8-afcf-b799047a301e](https://github.com/user-attachments/assets/b33dc6ab-b4fe-46d1-a97d-696ec7a976d3)
![550858854-3c0eabe3-5faa-4631-9ec2-7c5e48db2e2e](https://github.com/user-attachments/assets/a43f593c-3c1f-4148-9324-c726f3f09cee)

Current:
<img width="428" height="838" alt="Screenshot 2026-03-04 at 11 43 21" src="https://github.com/user-attachments/assets/94bad3f5-8456-4990-b98c-8bcfb973774e" />

