### PR TITLE
fix: align padding for clear filter button

### DIFF
--- a/app/shared/components/design-system/all-components/clear-filter-button/ClearFilterButton.styles.ts
+++ b/app/shared/components/design-system/all-components/clear-filter-button/ClearFilterButton.styles.ts
@@ -8,6 +8,8 @@ export const styles = {
     display: 'flex',
     justifyContent: 'flex-start',
     color: rgbaClearFilterButton.defaultTextColor,
+    paddingRight: '14px',
+    paddingLeft: '14px',
 
     '& svg path, & svg circle, & svg line, & svg rect': {
       stroke: 'currentColor'


### PR DESCRIPTION
## Description

This PR fixes the alignment issue in the **Genre filter dropdown** on the Artistry page.

Previously, the **icon and text "Clear filter"** inside the Genre dropdown were not aligned to the left side of the menu, causing visual inconsistency with the expected UI layout.

Now, the icon and text are properly aligned to the left edge of the dropdown menu, matching the expected design.

link:
https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/115

## Type of change

- [x] Bug fix

## How to test

1. Open the Artistry page:
   https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/uk/artistry
2. Click the **Filters** button.
3. Click the **Genre** filter.
4. Verify that the **icon and text "Clear filter"** are aligned to the left side of the dropdown menu.
5. Ensure the layout matches the expected design and no UI issues appear.

## Video / Screenshots

Before:
<img width="240" height="332" alt="Screenshot 2026-03-04 at 13 34 01" src="https://github.com/user-attachments/assets/8953ec97-2b1d-4deb-9c7a-6f3e9f32c824" />

After:
<img width="591" height="813" alt="Screenshot 2026-03-04 at 13 29 07" src="https://github.com/user-attachments/assets/17097a82-70bc-4062-b941-3578965979bd" />

