### PR TITLE
fix: adjust padding-right for actions cell container

### DIFF
--- a/app/shared/components/tables/CompositionTable/MusicTableCells.styles.ts
+++ b/app/shared/components/tables/CompositionTable/MusicTableCells.styles.ts
@@ -27,7 +27,7 @@ export const actionsCellContainerSx: SxProps<Theme> = {
   display: 'flex',
   justifyContent: 'flex-end',
   gap: 2,
-  pr: { xs: 1, sm: 2, md: 5 }
+  pr: { xs: 2, sm: 3, md: '58px' }
 };
 
 export const iconButtonSecondaryOutlinedSx: SxProps<Theme> = {


### PR DESCRIPTION
## Description

This PR fixes the vertical alignment of the ellipsis icon in the composition list on the Artistry page.

Previously, the ellipsis icon displayed next to each composition was vertically misaligned compared to other UI elements, particularly the "Filters" button. This created visual inconsistency in the layout.

Now, the ellipsis icon is properly aligned with the surrounding UI elements, ensuring a consistent and balanced layout in the composition list.

link:
https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/116

## Type of change

- [x] Bug fix

## How to test

1. Open the Artistry page:  
   https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/uk/artistry
2. Observe the **ellipsis icons** displayed next to each composition in the list.
3. Verify that the ellipsis icons are **properly vertically aligned** with other UI elements (e.g., the "Filters" button).
4. Ensure that the layout appears consistent and no visual issues remain.

## Video / Screenshots

Before:
<img width="1399" height="569" alt="Screenshot 2026-03-04 at 14 26 45" src="https://github.com/user-attachments/assets/c6a3c8e3-b5c2-46cd-9423-a042c989ea09" />

After:
<img width="439" height="746" alt="Screenshot 2026-03-04 at 14 26 53" src="https://github.com/user-attachments/assets/22cfdf5a-e078-4d61-9571-ca2c3faa843f" />
