### PR TITLE
set padding-top to 34px for cards in partnership formats block

### DIFF
--- a/app/shared/components/design-system/all-components/card-with-text/CardWithText.styles.ts
+++ b/app/shared/components/design-system/all-components/card-with-text/CardWithText.styles.ts
@@ -6,7 +6,8 @@ export const styles = {
     height: '386px',
     backgroundColor: mainHexPallete.yellow[200],
     px: '34px',
-    py: '48px',
+    pt: '34px',
+    pb: '48px',
     boxSizing: 'border-box'
   },
   content: {


### PR DESCRIPTION
## Description
Changed padding-top into cards with text into Cooperation page into 34px instead 48px

- [x] Bug fix

## How to test
To see the result you need to go to Cooperation page and scroll down to Partnership Formats block and there you can see 4 cards with text. Every one of these cards has a padding-top 34px

## Video / Screenshots
<img width="1283" height="735" alt="padding34" src="https://github.com/user-attachments/assets/ae3713ce-ca66-4506-b4f4-7d41f2f62c8d" />
<img width="1284" height="735" alt="4cardtexthas34pt" src="https://github.com/user-attachments/assets/fa15123e-d20c-435e-a641-aac898533fa0" />
Link to task https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/176



