### PR TITLE
fix(styles): adjust margin and remove height from collaboration form

### DIFF
--- a/app/[lang]/contacts/ContactsInfo/ContactsInfo.styles.ts
+++ b/app/[lang]/contacts/ContactsInfo/ContactsInfo.styles.ts
@@ -3,7 +3,7 @@ import { mainHexPallete } from '~/shared/components/design-system/all-components
 export const styles = {
   root: {
     mt: { xs: '35px', sm: '70px' },
-    mb: { xs: '55px', sm: '100px' },
+    mb: { xs: '55px', sm: '90px', md: '105px' },
     gridColumn: '1 / -1',
     maxWidth: '1728px',
     width: '100%',

--- a/app/shared/components/blocks/collaboration/offer-collaboration/OfferCollaboration.styles.ts
+++ b/app/shared/components/blocks/collaboration/offer-collaboration/OfferCollaboration.styles.ts
@@ -3,8 +3,7 @@ import { mainHexPallete } from '~/ds-components/theme/colors';
 export const styles = {
   mainContainer: {
     position: 'relative',
-    width: '100%',
-    height: { sm: '889px', md: '939px', lg: '921px' }
+    width: '100%'
   },
   paper: {
     position: 'absolute',


### PR DESCRIPTION
## Description

This PR fixes the incorrect spacing between the **Offer collaboration form** and the **footer** on the Cooperation page.

Previously, the gap between these elements did not match the design specifications across multiple responsive breakpoints. This caused inconsistent layout spacing on different screen sizes.

Now, the spacing between the Offer collaboration form and the footer is adjusted to match the design for all supported responsive versions.

link:
https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/135

## Type of change

- [x] Bug fix

## How to test

1. Open the **Cooperation page**.
2. Enable **DevTools → Toggle device toolbar**.
3. Check the page in the following responsive breakpoints:
   - 320–767px (Mobile)
   - 768–1023px (Small tablets)
   - 1024–1279px (Big tablets / Small desktop)
   - 1280–1439px (Desktop)
   - 1440px+ (Large desktop)
4. Scroll to the **Offer collaboration form** section.
5. Verify that the spacing between the form and the **footer** matches the design and is consistent across all breakpoints.

## Video / Screenshots

<img width="808" height="557" alt="Screenshot 2026-03-04 at 15 42 46" src="https://github.com/user-attachments/assets/00713088-b4d1-40a7-a2c0-f6876d38f98c" />

<img width="856" height="511" alt="Screenshot 2026-03-04 at 15 42 57" src="https://github.com/user-attachments/assets/785e49dd-4dbf-422e-810c-e4f4bc4b2586" />
