### PR TITLE
fix: fix incorrect position of the button on war-in-ukraine page

### DIFF
--- a/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.styles.ts
+++ b/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.styles.ts
@@ -7,7 +7,7 @@ export const styles = {
       xs: ' "image"  "content" "buttons"',
       sm: '"buttons content" '
     },
-    columnGap: { xs: '20px', sm: '23px', md: '40px' },
+    columnGap: { xs: '16px', sm: '24px', md: '40px' },
     rowGap: { xs: '13px', sm: '17px', md: '20px' },
     alignItems: 'start',
     height: 'fit-content'
@@ -22,13 +22,14 @@ export const styles = {
     gridColumn: { xs: '1/ -1', sm: '1/4', md: '1 / 6' },
     justifyContent: 'space-between',
     width: '100%',
-    height: '100%',
-    marginBottom: { xs: '10px', sm: 0 },
-    marginTop: { xs: '4px', sm: 0 }
+    height: '100%'
+  },
+
+  positionBox: {
+    alignSelf: { xs: 'start', sm: 'end' }
   },
 
   button: {
-    alignSelf: { xs: 'start', sm: 'end' },
     maxWidth: { xs: '200px', sm: '250px' }
   },
 

--- a/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.tsx
+++ b/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.tsx
@@ -73,14 +73,17 @@ export default function BulletTextWithLinks({
       {showMainButton && (
         <Box sx={styles.buttonBox} data-testid="BulletTextWithLinks-buttonBox">
           {!isMobile && imageBox}
-          <Button size="medium" variant="contained" sx={{ ...styles.button }} link={buttonLink} externalLink={true}>
-            {buttonText}
-            <Svg Component={ArrowUpRight} alt="icon" color="#fff" width="20px" height="20px" sx={styles.icon} />
-          </Button>
+          <Box sx={styles.positionBox}>
+            <Button size="medium" variant="contained" sx={{ ...styles.button }} link={buttonLink} externalLink={true}>
+              {buttonText}
+              <Svg Component={ArrowUpRight} alt="icon" color="#fff" width="20px" height="20px" sx={styles.icon} />
+            </Button>
+          </Box>
         </Box>
       )}
       <Box sx={styles.contentBox} data-testid="BulletTextWithLinks-contentBox">
         <ContentBlock
+          containerSx={{ columnGap: { xs: '16px', sm: '24px', md: '40px' } }}
           dataTestId="BulletTextWithLinks-content"
           description={description}
           textSx={{ gridColumn: { xs: '1/ -1', sm: '4/ -1', md: '6/-1' } }}


### PR DESCRIPTION
## Description

In this PR I fixed the incorrect button positioning and adjusted grid gaps for proper spacing and layout consistency.

## Type of change

- [x] Bug fix

## How to test

1. Open the app on `/war-in-ukraine` page
2. Open DevTool and select `Support the Foundation/Підтримати фонд` button
3. Check the position of this button and also grid gaps in whole block on the page

## Video / Screenshots

Before fixing:
<img width="731" height="239" alt="image" src="https://github.com/user-attachments/assets/4de04658-9ee8-44e9-9181-afc53db70b69" />
<img width="939" height="556" alt="image" src="https://github.com/user-attachments/assets/1d7a2d1b-22c3-4d27-bbef-351227f12e29" />

After fixing:
<img width="858" height="352" alt="image" src="https://github.com/user-attachments/assets/14343117-d8c8-486c-b9cf-93bf0567ad67" />
<img width="882" height="366" alt="image" src="https://github.com/user-attachments/assets/604bff75-ac2b-42a8-9ad2-d01d39ab6671" />

## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
