### PR TITLE
fix: fix label of buttons to have full persons name

### DIFF
--- a/app/[lang]/war-in-ukraine/page.tsx
+++ b/app/[lang]/war-in-ukraine/page.tsx
@@ -65,6 +65,7 @@ export default function WarInUkraine() {
         buttons={yermolenkoLinks}
         showMainButton={false}
         sx={{ marginBottom: 12 }}
+        showShortButtonsText={false}
       />
 
       <VolunteerDonation

--- a/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.tsx
+++ b/app/shared/components/design-system/all-components/bullet-text-with-links/BulletTextWithLinks.tsx
@@ -35,6 +35,7 @@ type IconButtonContentBlockProps = BoxProps & {
   buttonText?: string;
   buttonLink?: string;
   showMainButton?: boolean;
+  showShortButtonsText?: boolean;
 };
 
 const imageSizes = {
@@ -54,6 +55,7 @@ export default function BulletTextWithLinks({
   buttonText,
   buttonLink,
   showMainButton = true,
+  showShortButtonsText = true,
   sx,
   ...props
 }: Readonly<IconButtonContentBlockProps>) {
@@ -94,7 +96,7 @@ export default function BulletTextWithLinks({
             externalLink={true}
             variant="outlined"
             size="medium"
-            startIcon={
+            endIcon={
               <Svg
                 Component={FacebookIcon}
                 fill="none"
@@ -106,7 +108,7 @@ export default function BulletTextWithLinks({
               />
             }
           >
-            {isMobile ? button.shortText[locale] : button.fullText[locale]}
+            {showShortButtonsText && isMobile ? button.shortText[locale] : button.fullText[locale]}
           </Button>
         ))}
       </Box>


### PR DESCRIPTION
## Description

This PR fixes a bug to ensure the full first and last name are displayed correctly, while also adding the option to show a shortened version on smaller screens for better responsiveness.

## Type of change

- [x] Bug fix

## How to test

1. Open the app on `/war-in-ukraine` page
2. Verify that labels of buttons have to fully person's name for the UK and the EN versions

## Video / Screenshots

Before fixing:
<img width="805" height="185" alt="image" src="https://github.com/user-attachments/assets/20f94ec2-236e-45f8-97e6-32773f381718" />

After fixing:
<img width="681" height="138" alt="image" src="https://github.com/user-attachments/assets/69657931-e9e3-4744-81a7-206169cb341e" />

## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
