### PR TITLE
fix: fix fontSize for span elements on war-in-ukraine page

### DIFF
--- a/app/shared/components/blocks/volunteer-donation/PaymentMethodItem.tsx
+++ b/app/shared/components/blocks/volunteer-donation/PaymentMethodItem.tsx
@@ -17,7 +17,7 @@ export const PaymentMethodItem: React.FC<PaymentMethodItemProps> = ({ method, hi
       <Box sx={styles.paymentMethodContainer}>
         {method.label && <Typography sx={styles.label}>{method.label}:</Typography>}
 
-        <CopyLink hint={hint} size="large" value={method.value} />
+        <CopyLink sx={styles.value} hint={hint} size="large" value={method.value} />
       </Box>
     </Box>
   );

--- a/app/shared/components/design-system/all-components/carousel/Carousel.styles.ts
+++ b/app/shared/components/design-system/all-components/carousel/Carousel.styles.ts
@@ -82,6 +82,9 @@ export const styles = {
     opacity: 0,
     animation: `${fadeIn} 1s ease forwards`
   },
+  exactCaptionStyles: {
+    fontSize: '14px'
+  },
   dotsContainerStyles: {
     display: 'flex',
     justifyContent: 'center',

--- a/app/shared/components/design-system/all-components/carousel/Carousel.tsx
+++ b/app/shared/components/design-system/all-components/carousel/Carousel.tsx
@@ -129,7 +129,9 @@ const Carousel = ({ images, initialIndex = 0, infiniteLoop = false }: CarouselPr
       </Box>
       <Box sx={styles.carouselFooterStyles}>
         <Box key={images[activeIndex].description} sx={styles.captionStyles} data-testid="carousel-caption">
-          <Typography variant="caption">{images[activeIndex]?.description}</Typography>
+          <Typography sx={styles.exactCaptionStyles} variant="caption">
+            {images[activeIndex]?.description}
+          </Typography>
         </Box>
         <Box sx={styles.dotsContainerStyles}>
           {images.map((image, index) => {

--- a/app/shared/components/design-system/all-components/copy-link/CopyLink.tsx
+++ b/app/shared/components/design-system/all-components/copy-link/CopyLink.tsx
@@ -110,7 +110,7 @@ function CopyLink({
       data-testid="CopyLink"
       sx={[styles.wrapper, copyLinkStyles, ...sxToArray(sx)]}
     >
-      <Typography component="span" variant={variant} data-testid="CopyLink-text">
+      <Typography sx={{ ...sx }} component="span" variant={variant} data-testid="CopyLink-text">
         {value}
       </Typography>
       <TooltipCustom title={finalHint} isOpen={isCopied} showArrow>


### PR DESCRIPTION
## Description

This PR updates the font size of span elements to match the Figma design specifications, ensuring consistency with the intended UI layout.

## Type of change

- [x] Bug fix

## How to test

1. Find the element `body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-14vybo9 > div > div.MuiBox-root.css-11vcs2v > div.MuiBox-root.css-l1vh2r > span`
2. Check that fontSize of this element is 14px
3. Select elements: `body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-ymfo2c > div.MuiBox-root.css-ql8660 > div:nth-child(1) > div > button > span`
4. Check that fontSize of this element is 16px in responsive mode from 320px to 1023px and 20px in responsive mode 1024px and above

## Video / Screenshots

Before fixing:
<img width="443" height="133" alt="image" src="https://github.com/user-attachments/assets/b9cd2170-7790-4f66-9c9d-f7912f71f820" />

After fixing: 
<img width="357" height="162" alt="image" src="https://github.com/user-attachments/assets/99d964ba-b8f2-4089-804b-b93709582f72" />


## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---
