### PR TITLE
fix: the page scrolls to the correspond section

### DIFF
--- a/app/shared/components/year-tabs/YearTabs.test.tsx
+++ b/app/shared/components/year-tabs/YearTabs.test.tsx
@@ -74,6 +74,7 @@ describe('YearTabs', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     ioInstances = [];
+    globalThis.history.pushState(null, '', '/');
 
     Object.defineProperty(globalThis, 'innerHeight', { value: 800, writable: true });
 

--- a/app/shared/components/year-tabs/YearTabs.tsx
+++ b/app/shared/components/year-tabs/YearTabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Box, Button } from '@mui/material';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { styles } from '~/components/year-tabs/YearTabs.styles';
 import ButtonGroup from '~/ds-components/button-group/ButtonGroup';
@@ -16,7 +16,7 @@ interface Data {
 }
 
 export default function YearTabs({ years }: Readonly<Data>) {
-  const validYears = years.filter((y) => y && y.trim() !== '');
+  const validYears = useMemo(() => years.filter((y) => y && y.trim() !== ''), [years]);
   const { isMobile } = useBreakpoints();
   const [year, setYear] = useState<string>(validYears[0] ?? '');
   const [isVisible, setIsVisible] = useState<boolean>(true);
@@ -130,9 +130,40 @@ export default function YearTabs({ years }: Readonly<Data>) {
     };
   }, [isMobile, validYears]);
 
+  useEffect(() => {
+    const scrollToHash = () => {
+      const hash = globalThis.location?.hash;
+      if (!hash) return;
+
+      const raw = hash.slice(1);
+      const id = raw.endsWith('s') ? raw.slice(0, -1) : raw;
+      if (!id) return;
+
+      const element = document.getElementById(`year-${id}`);
+      if (!element) return;
+
+      const elementPosition = element.getBoundingClientRect().top;
+      const offsetPosition = elementPosition + window.pageYOffset - HEADER_OFFSET;
+
+      window.scrollTo({ top: offsetPosition, behavior: 'smooth' });
+
+      if (validYears.includes(id)) {
+        setYear(id);
+      }
+    };
+
+    scrollToHash();
+    globalThis.addEventListener?.('hashchange', scrollToHash);
+
+    return () => {
+      globalThis.removeEventListener?.('hashchange', scrollToHash);
+    };
+  }, [validYears]);
+
   const handleYearChange = (selectedYear: string) => {
     isClickScrolling.current = true;
     setYear(selectedYear);
+    globalThis.history.pushState(null, '', `#${selectedYear}s`);
     const element = document.getElementById(`year-${selectedYear}`);
 
     if (element) {


### PR DESCRIPTION
## Description
This pull request fixes a behavioral issue on the Biography page. Previously, when a user navigated to a deep link with a hash in the address bar, the page did not scroll to the corresponding section.

## Type of change
- [x] Bug fix
- [ ] 
## Changes 
The page now automatically scrolls to the section specified by the hash in the URL.
Clicking on a year link in the timeline scrolls the page to the corresponding section and updates the URL accordingly.

## How to test
1. Go to Biography page
enter into end of url one of the value (#1910s, #1920s, #1930s, #1940s, #1950s, #1960s)
Result - Page scrolls to the correspond section

2. Click one of the link on link line (#1910s, #1920s, #1930s, #1940s, #1950s, #1960s)
Result - Page scrolls to the correspond section and end of url changes to the correspond hash path section 

## Video / Screenshots

https://github.com/user-attachments/assets/bbb85cd5-5654-4cdb-a8b8-dbe434e0b9a2

Link to card task https://github.com/Liatoshynsky-Foundation/lf-client/issues/998
