### PR TITLE
fix(ui): comprehensive UI bugfix on Support Page

### DIFF
--- a/app/shared/components/blocks/payment-details/PaymentDetails.styles.ts
+++ b/app/shared/components/blocks/payment-details/PaymentDetails.styles.ts
@@ -4,6 +4,7 @@ export const styles = {
   buttonGroup: {
     backgroundColor: mainHexPallete.brown[50],
     p: '4px',
+    height: '36px',
     width: { xs: '100%', sm: 'fit-content' },
 
     div: {
@@ -42,7 +43,7 @@ export const styles = {
     '& h6.MuiTypography-root': {
       lineHeight: '150%',
       color: mainHexPallete.brown[500],
-      width: { xs: '100%', sm: '150px', lg: '180px' },
+      width: { xs: '100%', sm: '115px' },
       flexShrink: 0
     },
 
@@ -57,16 +58,13 @@ export const styles = {
     flexDirection: { xs: 'column', sm: 'row' },
     justifyContent: 'flex-start',
     alignItems: { xs: 'flex-start', sm: 'flex-start' },
-    gap: { xs: '4px', sm: '25px' },
+    gap: { xs: '4px', sm: '24px' },
     width: '100%',
     py: '4px'
   },
 
   iban: {
-    display: 'flex',
     gap: '8px',
-    width: '100%',
-    justifyContent: 'flex-start',
     alignItems: { xs: 'flex-start', sm: 'center' }
   },
 

--- a/app/shared/components/blocks/support-foundation/SupportFoundation.styles.ts
+++ b/app/shared/components/blocks/support-foundation/SupportFoundation.styles.ts
@@ -34,8 +34,8 @@ export const styles = {
   sectionSubtitle: {
     width: '100%',
     mb: { xs: '32px', sm: '64px' },
-    textAlign: { xs: 'left', lg: 'justify' },
-    textIndent: { xs: '26%', sm: '15%', md: '14%', lg: '60%' },
+    textAlign: { xs: 'left', lg: 'left' },
+    textIndent: { xs: '26%', sm: '15%', md: '14%', lg: '60%', xl: '35%' },
     lineHeight: '160%',
     color: mainHexPallete.brown[700]
   }

--- a/app/shared/components/blocks/support-foundation/SupportFoundation.styles.ts
+++ b/app/shared/components/blocks/support-foundation/SupportFoundation.styles.ts
@@ -34,7 +34,7 @@ export const styles = {
   sectionSubtitle: {
     width: '100%',
     mb: { xs: '32px', sm: '64px' },
-    textAlign: { xs: 'left', lg: 'left' },
+    textAlign: 'left',
     textIndent: { xs: '26%', sm: '15%', md: '14%', lg: '60%', xl: '35%' },
     lineHeight: '160%',
     color: mainHexPallete.brown[700]

--- a/app/shared/components/forms/donation-form/DonationForm.styles.ts
+++ b/app/shared/components/forms/donation-form/DonationForm.styles.ts
@@ -82,8 +82,15 @@ export const style = {
   },
   currencyInput: {
     minWidth: '90px',
-    verticalAlign: 'bottom',
-    marginBottom: '16px'
+    marginBottom: '16px',
+    '& .MuiSelect-select': {
+      paddingBottom: '0px'
+    },
+    '& .MuiSelect-select .MuiTypography-root': {
+      fontWeight: 700,
+      WebkitTextFillColor: mainHexPallete.black,
+      lineHeight: 2
+    }
   },
   currencySuggestion: {
     alignSelf: 'center',

--- a/app/shared/components/forms/donation-form/DonationForm.test.tsx
+++ b/app/shared/components/forms/donation-form/DonationForm.test.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 
 import DonationForm from './DonationForm';
 
+jest.mock('~/components/colored-svg/ColoredSvg', () => ({
+  Svg: () => <svg data-testid="mock-chevron" />
+}));
+
 jest.mock('~/ds-components/button/Button', () => {
   const MockButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & { fullWidth?: boolean }> = ({
     children,

--- a/app/shared/components/forms/donation-form/DonationForm.tsx
+++ b/app/shared/components/forms/donation-form/DonationForm.tsx
@@ -3,14 +3,18 @@ import { Box, FormControl, Input, MenuItem, Select, Typography } from '@mui/mate
 import { useLocale, useTranslations } from 'next-intl';
 import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 
+import { Svg } from '~/components/colored-svg/ColoredSvg';
 import PaperComponent from '~/components/paper-component/PaperComponent';
 import TurnstileWidget from '~/components/turnstileWidget/TurnstileWidget';
 import Button from '~/ds-components/button/Button';
+import { mainHexPallete } from '~/ds-components/theme/colors';
 import { useDonation } from '~/hooks/use-donation/useDonation';
 
 import { style } from './DonationForm.styles';
 import { Currency } from '~/types/types/common.types';
 
+import ChevronDown from '~/public/icons/chevron-down.svg';
+import ChevronUp from '~/public/icons/chevron-up.svg';
 import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
 
 const currencies: Currency[] = ['UAH', 'USD', 'EUR', 'GBP'];
@@ -167,6 +171,25 @@ function DonationForm() {
                 value={currency}
                 onChange={handleCurrencySwitch}
                 data-testid="DonationForm-currencySelect"
+                IconComponent={(props) => (
+                  <Box
+                    {...props}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      transform: 'translateY(-1px) !important'
+                    }}
+                  >
+                    <Svg
+                      Component={openDropdown ? ChevronUp : ChevronDown}
+                      alt="chevron"
+                      stroke={mainHexPallete.black}
+                      width="24px"
+                      height="24px"
+                      sx={{ display: 'flex' }}
+                    />
+                  </Box>
+                )}
               >
                 {currencyItems}
               </Select>

--- a/app/shared/components/forms/donation-form/DonationForm.tsx
+++ b/app/shared/components/forms/donation-form/DonationForm.tsx
@@ -28,6 +28,30 @@ const proposedSum: Record<Currency, number[]> = {
 const MIN_DONATION_AMOUNT = 0;
 const isValidDonationAmount = (value: number | ''): boolean => typeof value === 'number' && value > MIN_DONATION_AMOUNT;
 
+const DropdownIcon = (props: React.HTMLAttributes<HTMLDivElement>) => {
+  const isOpen = typeof props.className === 'string' && props.className.includes('iconOpen');
+
+  return (
+    <Box
+      {...props}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        transform: 'translateY(-1px) !important'
+      }}
+    >
+      <Svg
+        Component={isOpen ? ChevronUp : ChevronDown}
+        alt="chevron"
+        stroke={mainHexPallete.black}
+        width="24px"
+        height="24px"
+        sx={{ display: 'flex' }}
+      />
+    </Box>
+  );
+};
+
 function DonationForm() {
   const t = useTranslations('donationForm');
   const lang = useLocale();
@@ -171,25 +195,7 @@ function DonationForm() {
                 value={currency}
                 onChange={handleCurrencySwitch}
                 data-testid="DonationForm-currencySelect"
-                IconComponent={(props) => (
-                  <Box
-                    {...props}
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      transform: 'translateY(-1px) !important'
-                    }}
-                  >
-                    <Svg
-                      Component={openDropdown ? ChevronUp : ChevronDown}
-                      alt="chevron"
-                      stroke={mainHexPallete.black}
-                      width="24px"
-                      height="24px"
-                      sx={{ display: 'flex' }}
-                    />
-                  </Box>
-                )}
+                IconComponent={DropdownIcon}
               >
                 {currencyItems}
               </Select>

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -135,7 +135,7 @@
   },
   "supportUs": {
     "donation": {
-      "title": "SupPorT FoUndaTioN",
+      "title": "SupPorT The FoUndaTioN",
       "subTitle": "All contributions go <b>directly</b> to the Liatoshynsky Foundation account and are used to support its mission. Choose a currency convenient for you - <b>the transfer details are below</b>:"
     },
     "payment": {


### PR DESCRIPTION
## Description

Comprehensive UI bug fixes on the "Support the Foundation" page.

Key changes include:

1. Layout & Typography: Fixed text-align on large screens (1280px+), adjusted line-height to 36px for mobile (320px+), and strictly set the width between elements to 115px across responsive breakpoints (768px and above).
2. Donation Form Select: Updated the dropdown menu styles. Corrected the font color to #190D03 and weight to 700. Implemented a custom SVG chevron marker that switches dynamically on open/close without layout shifts.
3. i18n: Fixed a typo in the English translation (changed "SupPorT FoUndaTioN" to "Support The Foundation").
4. Tests: Added an SVG mock in DonationForm.test.tsx to fix test crashes caused by the new custom chevron component.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the app on the [Support the Foundation](http://localhost:3000/en/support-us) page.
2. Open DevTools and select the Elements.
3. Open the Toggle device toolbar/Responsive.

**SCENARIO-I**
Steps:
1. Go to the element of the page:
  - body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1obf64m > div.MuiBox-root.css-21sfqq > p
2. Change the responsive from 1280px and above.
3. Pay attention to the element alignment

Previous result (res: 1280px):
<img width="1328" height="921" alt="1" src="https://github.com/user-attachments/assets/cc20199a-e896-4bdf-b9e6-92802a899a86" />
<img width="394" height="167" alt="1 1" src="https://github.com/user-attachments/assets/ff952646-13ff-4631-83e1-7d74d0548cd3" />
text-align: justify;

Actual result (res: 1280px):
<img width="1156" height="631" alt="1" src="https://github.com/user-attachments/assets/53750d7a-3731-48e8-a9d6-2777cb317e2e" />
<img width="292" height="120" alt="1 1" src="https://github.com/user-attachments/assets/fa4ccfc7-e44b-4c41-990b-b0d7b6ebca90" />
text-align: left;

############

Previous result (res: 1448px +):
<img width="1195" height="685" alt="2" src="https://github.com/user-attachments/assets/d67eb1e4-6a4f-4a5e-8189-67e1e52f72a1" />
<img width="242" height="112" alt="2 2" src="https://github.com/user-attachments/assets/9c40f9b2-4fae-47ed-abba-f7d1045b7a91" />
text-indent: 60%

Actual result (res: 1448px +):
<img width="1192" height="550" alt="3" src="https://github.com/user-attachments/assets/9a9dbbd6-65e0-4c5f-b511-c752cb834005" />
<img width="280" height="98" alt="3 3" src="https://github.com/user-attachments/assets/57ba829e-fbd8-4dc7-8da7-587fb15f3819" />
text-indent: 35%

**SCENARIO-II**
Steps:
1. Go to the element of the page:
  - body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1obf64m > div.MuiBox-root.css-21sfqq > div > div.MuiButtonGroup-root.MuiButtonGroup-outlined.MuiButtonGroup-horizontal.MuiButtonGroup-colorPrimary.css-1vrr5a-MuiButtonGroup-root
2. Change the responsive to 320px and above
3. Pay attention to the hight of the element

Previous result:
<img width="1196" height="563" alt="4" src="https://github.com/user-attachments/assets/0e5426ca-3468-4508-88ff-eb425f310053" />
Previous result:
line-height: 32px **(not line-height: 24px as listed in the bug report!)**

Actual result:
<img width="996" height="561" alt="image" src="https://github.com/user-attachments/assets/6b55fef1-d293-44e1-bb3c-8084b69e64cd" />
line-height: 36px

**SCENARIO-III**
Steps:
1. Go to any element of the page listed below:
  - body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1obf64m > div.MuiBox-root.css-21sfqq > div > div.MuiBox-root.css-vgw68r > div:nth-child(1) > h6
  - body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1obf64m > div.MuiBox-root.css-21sfqq > div > div.MuiBox-root.css-vgw68r > div:nth-child(2) > h6
  - body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1obf64m > div.MuiBox-root.css-21sfqq > div > div.MuiBox-root.css-vgw68r > div:nth-child(3) > h6
  - body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1obf64m > div.MuiBox-root.css-21sfqq > div > div.MuiBox-root.css-vgw68r > div:nth-child(4) > h6
2. Change the responsive from 768px to 1279px.
3. Pay attention to the width of the element
4. Repeat these steps for 1280px and above
5. Pay attention to the width of the element

Previous result:
<img width="1172" height="617" alt="6" src="https://github.com/user-attachments/assets/2b6253c8-22c6-43a8-ad32-362ae2d61576" />
<img width="1151" height="572" alt="6 1" src="https://github.com/user-attachments/assets/b3025ced-20b2-4478-8064-247c6ed59b53" />
width: 150 for screens between 768px to 1279px
width: 180 for screens 1280px and above

Actual result:
<img width="1193" height="555" alt="7" src="https://github.com/user-attachments/assets/bb4a9f41-a77e-409f-bcb0-9c2ffd13ef67" />
<img width="1157" height="508" alt="7 1" src="https://github.com/user-attachments/assets/6fa8f868-487d-409e-8dad-48ca99fb6cd1" />
width: 115 for both |768px to 1279px| and |1280px and above|

### Drive-by fix
Steps:
1. Go to the element of the page:
  - body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1obf64m > div.MuiBox-root.css-21sfqq > div > div.MuiBox-root.css-p4jt65 > div:nth-child(4) > button > span
2. Switch the responsive to 1480px+
3. Pay attention that the gap between the `UA283510050000026003879189233` text and the copy icon is not fixed. According to the Figma reference, the gap must be 8px and must be fixed for all screen resolutions.

Previous result & Figma reference: 
<img width="1191" height="563" alt="8" src="https://github.com/user-attachments/assets/803a9dad-7515-4f77-92ba-579b2ecaf7fb" />
<img width="1040" height="665" alt="8 1" src="https://github.com/user-attachments/assets/b3ad3967-1ade-4491-8b26-841dd740957a" />
The gap should be 8px

Actual result: 
<img width="1918" height="866" alt="8 2" src="https://github.com/user-attachments/assets/d0720703-4725-4004-9ddb-6ba90bb0aaef" />
The gap is 8px

**SCENARIO-IV**
Steps:
1. Go to the element of the page:
  - body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1obf64m > div.MuiBox-root.css-ojkc1h > div > div > div.MuiBox-root.css-110ito9 > div > div.MuiBox-root.css-1c4l191 > div.MuiFormControl-root.css-f4uxch-MuiFormControl-root > div > div.MuiSelect-select.MuiSelect-standard.MuiInputBase-input.MuiInput-input.css-45tx6x-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input > p
2. Pay attention to the weight and color of the font

Previous result: 
<img width="732" height="674" alt="image" src="https://github.com/user-attachments/assets/78b94d35-5783-47c0-821e-3b06241048d6" />
Color: #52545a
Weight: 400

Actual result:
<img width="1501" height="477" alt="image" src="https://github.com/user-attachments/assets/d4f0cc7b-d042-46e4-b18f-9a3f9c507920" />
font-weight: 700;
Colors: #190D03;

**SCENARIO-V**
Steps:
1. Go to the element of the page:
  - body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1obf64m > div.MuiBox-root.css-ojkc1h > div > div > div.MuiBox-root.css-110ito9 > div > div.MuiBox-root.css-1c4l191 > div.MuiFormControl-root.css-f4uxch-MuiFormControl-root > div > div.MuiSelect-icon.MuiSelect-iconStandard.MuiBox-root.css-1i06sfp-MuiNativeSelect-root-MuiSelect-icon
2. Pay attention that the marker of the drop-down list doesn't match the Figma reference

Previous result & Figma reference:
<img width="520" height="657" alt="image" src="https://github.com/user-attachments/assets/9490f051-d12b-4b61-a9bd-f3dc95aa38b2" />
<img width="596" height="637" alt="image" src="https://github.com/user-attachments/assets/68ac967d-89fe-4bc0-8ee3-98c46e484fdd" />
The marker must have a `chevron` icon

Actual result:

https://github.com/user-attachments/assets/c8f8d324-0b05-4b48-8a21-1d7d3e13a24d

The marker of the drop-down list matches the Figma reference

**SCENARIO-VI**
Steps:
1. Go to the element of the page:
  - body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1obf64m > h1
2. Pay attention that the `h1` must contain the `SupPorT The FoUndaTioN` text instead of the `SupPorT FoUndaTioN`

Previous result:
<img width="490" height="243" alt="image" src="https://github.com/user-attachments/assets/de50a0fb-5708-45e8-8e4a-6ad9baa58980" />

Actual result:
<img width="862" height="372" alt="image" src="https://github.com/user-attachments/assets/26c820aa-b57e-4395-b881-2601df8bc193" />

Closes Liatoshynsky-Foundation/lf-manual-tests#99
---