### PR TITLE
Fix: restrict archive block content width on mobile breakpoints

### DIFF
--- a/app/shared/components/blocks/Liatoshynsky-office/LiatoshynskyOffice.styles.ts
+++ b/app/shared/components/blocks/Liatoshynsky-office/LiatoshynskyOffice.styles.ts
@@ -38,6 +38,14 @@ export const styles = {
     transformOrigin: 'top left'
   },
   contentContainer: {
+    maxWidth: {
+      xs: '452px',
+      sm: 'none'
+    },
+    mx: {
+      xs: 'auto',
+      sm: 0
+    },
     p: {
       xs: '39px 0 65px',
       sm: '18px 46px 72px 35px',


### PR DESCRIPTION
## Description

Fixed the layout behavior for the Liatoshynsky Office (Archive) block on mobile devices. The content width is now restricted to a maximum of 452px and centered horizontally on screens wider than 500px, perfectly matching the design specs. The original layout for tablet (sm) and desktop breakpoints remains fully intact.

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the Biography page and scroll to the Liatoshynsky Office block (yellow background).
2. Open DevTools (Responsive Mode) and resize the screen around the 500px mark.
3. Verify that the inner content stops stretching at 452px and centers itself with side margins.
4. Check tablet (sm) and desktop resolutions to ensure the standard layout is not broken.

### Actual result:
<img width="684" height="745" alt="image" src="https://github.com/user-attachments/assets/05f13389-f050-49a4-9e07-1a606f5de376" />


### Expected result:

https://github.com/user-attachments/assets/b794a66c-d42e-4da4-ab06-7e4812ad9c4c


Closes: https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/138