### PR TITLE
fix: prevent vertical scroll on mobile partners carousel

### DIFF
--- a/app/shared/components/blocks/our-partners/OurPartners.styles.ts
+++ b/app/shared/components/blocks/our-partners/OurPartners.styles.ts
@@ -28,6 +28,8 @@ export const styles = {
     display: { xs: 'flex', sm: 'none' },
     justifyContent: 'flex-start',
     overflowX: 'auto',
+    overflowY: 'hidden',
+    touchAction: 'pan-x',
     scrollbarWidth: 'none',
     msOverflowStyle: 'none',
     alignItems: 'center',


### PR DESCRIPTION
## Description

Fixed a bug on the Cooperation page where the partners' logo carousel allowed vertical scrolling on mobile devices. Added strict vertical overflow hidden and touch-action constraints to ensure the container only responds to horizontal swipes.

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the Cooperation page in responsive mode (up to 767px) or on a mobile device.
2. Scroll down to the "Our Partners" section.
3. Try to scroll the logo carousel vertically (up and down).
4. Verify that the carousel remains completely static vertically and only scrolls horizontally.

### Actual result: Horizontal scroll on mobile devices

### Expected result:

https://github.com/user-attachments/assets/3035ad90-8c6a-4acd-935e-87972a69c81e

Closes: https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/226