### PR TITLE
Fix italic styling for quoted text on multiple pages

### DIFF
--- a/app/shared/components/Quote/Quote.styles.ts
+++ b/app/shared/components/Quote/Quote.styles.ts
@@ -74,7 +74,7 @@ export const styles = {
     ...quoteTextStyles,
     color: quoteColors[color],
     fontFamily: 'Mulish',
-    fontStyle: 'italic',
+    fontStyle: 'normal',
     textAlign: alignments[align].textAlign
   }),
   sourceText: (align: Align) => ({

--- a/app/shared/components/excerpt-block/ExcerptBlock.test.tsx
+++ b/app/shared/components/excerpt-block/ExcerptBlock.test.tsx
@@ -32,25 +32,23 @@ describe('ExcerptBlock', () => {
     expect(screen.getByText('Some source')).toBeInTheDocument();
     expect(screen.getByAltText('Quote icon')).toBeInTheDocument();
   });
-  it('applies correct class for mobile', () => {
+
+  it('applies correct typography variant for mobile quote', () => {
     (useBreakpoints as jest.Mock).mockReturnValue({ isMobile: true });
 
     render(<ExcerptBlock quote="Some quote" source="Some source" />);
     const quote = screen.getByText('Some quote');
-    const source = screen.getByText('Some source');
 
     expect(quote.className).toMatch(/MuiTypography-customItalic18/);
-    expect(source.className).toMatch(/MuiTypography-customItalic14/);
   });
 
-  it('applies correct class for desktop', () => {
+  it('applies correct typography variant for desktop quote', () => {
     (useBreakpoints as jest.Mock).mockReturnValue({ isMobile: false });
 
     render(<ExcerptBlock quote="Some quote" source="Some source" />);
+
     const quote = screen.getByText('Some quote');
-    const source = screen.getByText('Some source');
 
     expect(quote.className).toMatch(/MuiTypography-h5/);
-    expect(source.className).toMatch(/MuiTypography-customItalic14/);
   });
 });

--- a/app/shared/components/excerpt-block/ExcerptBlock.tsx
+++ b/app/shared/components/excerpt-block/ExcerptBlock.tsx
@@ -21,9 +21,7 @@ export default function ExcerptBlock({ quote, source, dataTestId }: ExcerptBlock
       <Typography sx={styles.quoteContainer} variant="customItalic18" fontWeight={700}>
         {quote}
       </Typography>
-      <Typography variant="customItalic14" fontWeight={500}>
-        {source}
-      </Typography>
+      <Typography fontWeight={500}>{source}</Typography>
     </Box>
   ) : (
     <Box sx={styles.desktopView} data-testid={dataTestId}>
@@ -34,7 +32,7 @@ export default function ExcerptBlock({ quote, source, dataTestId }: ExcerptBlock
       <Typography sx={styles.sourceText(isTablet)} variant="customItalic14" fontWeight={500}>
         {source}
       </Typography>
-      <Typography variant="h5" fontStyle={'italic'} sx={styles.quoteText}>
+      <Typography variant="h5" sx={styles.quoteText}>
         {quote}
       </Typography>
     </Box>


### PR DESCRIPTION
## Description

This PR fixes the incorrect styling of quoted text displayed on multiple pages.

Previously, quoted text (red text inside quotation marks) was rendered in *italic* style on several pages, including **Biography, Artistry, Research and Scientific Work, and About Us**. This did not match the expected design.

Now, the quoted text is displayed with the correct font style (not italic), matching the design specifications and ensuring visual consistency across all affected pages.

link:
https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/139

## Type of change

- [x] Bug fix

## How to test

1. Open the **Biography** page:  
   https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/en/biography
2. Observe the **quoted red text** displayed in quotation marks.
3. Verify that the quoted text is **not italic**.
4. Repeat the check on the following pages:
   - Artistry
   - Research and Scientific Work
   - About Us
5. Ensure the quoted text styling matches the design and appears consistently across all pages.

## Video / Screenshots

Before:
<img width="806" height="307" alt="Screenshot 2026-03-09 at 18 55 43" src="https://github.com/user-attachments/assets/f0c026cf-887e-4f5d-aa01-02e75af6fca5" />

Now:
<img width="614" height="410" alt="Screenshot 2026-03-09 at 18 56 08" src="https://github.com/user-attachments/assets/75a4d569-52cd-411b-ae3e-6b5b8a7e910d" />


