### PR TITLE
fix(HeroSection): restrict max height of HeroSection component

### DIFF
--- a/app/shared/components/blocks/home-page-hero/HeroSection.styles.ts
+++ b/app/shared/components/blocks/home-page-hero/HeroSection.styles.ts
@@ -47,7 +47,8 @@ export const heroSectionStyles = {
     },
     maxHeight: {
       sm: '60vh',
-      lg: '70vh'
+      md: '600px',
+      xl: '800px'
     },
     width: '100%',
     clipPath: {


### PR DESCRIPTION
## Description

This PR is created to eliminate HeroSection's bust image inconsistent placement for some screen dimension by setting max height for tablets and higher (from 1024px), to adjust tablets breakpoint view conform figma as well. Also fixed xl screens paddle scretch the way it cut upper right corner under header, so displayed innapropriately by setting max height for large desktop breakpoint.

## **Key changes**:

1. Restricted tablet's max height to 600px.
2. Restricted large screen's max hegith to 800px.

## Type of change

- [x] Bug fix

## How to test

1. Go to [Home](https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/) page.
2. Open devtools and set width from 1280px and height from 1050px.
3. Ensure bust image filled height of yellow paddle properly.

## Video / Screenshots

https://github.com/user-attachments/assets/1d81a2b0-c1b5-444f-a42d-f19f8fe070a1

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board