### PR TITLE
fix: auto-expand opus groups when search is active

### DIFF
--- a/app/shared/components/enhanced-table/EnhancedTable.tsx
+++ b/app/shared/components/enhanced-table/EnhancedTable.tsx
@@ -60,6 +60,7 @@ interface EnhancedTableProps<T extends RowData> {
   rowSx?: object;
   tableContainerSx?: SxProps<Theme>;
   onRowClick?: (row: T) => void;
+  isSearchActive?: boolean;
 }
 
 export const EnhancedTable = <T extends RowData>({
@@ -79,7 +80,8 @@ export const EnhancedTable = <T extends RowData>({
   noResults,
   rowSx,
   tableContainerSx,
-  onRowClick
+  onRowClick,
+  isSearchActive = false
 }: Readonly<EnhancedTableProps<T>>) => {
   const [sorting, setSorting] = useState<SortingState>(defaultSorting);
   const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({});
@@ -88,10 +90,13 @@ export const EnhancedTable = <T extends RowData>({
   const breakpoint = useBreakpoints();
 
   const toggleGroupCollapse = (groupLabel: string) => {
-    setCollapsedGroups((prev) => ({
-      ...prev,
-      [groupLabel]: !prev[groupLabel]
-    }));
+    setCollapsedGroups((prev) => {
+      const currentState = prev[groupLabel] ?? isSearchActive;
+      return {
+        ...prev,
+        [groupLabel]: !currentState
+      };
+    });
   };
 
   const getGroupColumns = <T extends RowData>(columns: ColumnDef<T>[], groupItems: T[]): ColumnDef<T>[] =>
@@ -212,7 +217,7 @@ export const EnhancedTable = <T extends RowData>({
                     <CollapsibleRow
                       key={`group-${entry.label}`}
                       data={entry.items}
-                      collapsed={collapsedGroups[entry.label] ?? false}
+                      collapsed={collapsedGroups[entry.label] ?? isSearchActive}
                       action={() => toggleGroupCollapse(entry.label)}
                       columns={getGroupColumns(columns, entry.items)}
                     />

--- a/app/shared/components/tables/CompositionTable/MusicTableSection.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableSection.tsx
@@ -258,6 +258,7 @@ export default function MusicTableSection() {
       <EnhancedTable
         key={tableKey}
         data={data}
+        isSearchActive={!!params.search}
         loading={loadingData}
         columns={columns}
         groupByKey="opus"


### PR DESCRIPTION
## Description

This PR fixes the issue where grouped opus rows in the EnhancedTable remained collapsed even when a search query was active.

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Navigate: Go to the Artistry page.
2. Search: Enter a composition title (e.g., "Symphony No. 3") in the search bar.
3. Verify: Ensure the corresponding Opus group is expanded automatically.


### Actual result: 
The opus which contains the searched composition is collapsed
### Expected result:
The composition is displayed in expanded opus

https://github.com/user-attachments/assets/74a69732-0227-4779-9a74-3b9bd8db3513




Closes: https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/155