### PR TITLE
Fix search result order for exact title match

### DIFF
--- a/app/shared/components/search/Search.tsx
+++ b/app/shared/components/search/Search.tsx
@@ -150,11 +150,32 @@ export const Search = <T extends TitleOption>({ search, setSearch, options }: Se
     const trimmedInput = inputValue.trim().toLowerCase();
     if (!trimmedInput) return options;
 
-    const words = trimmedInput.split(/\s+/).filter((w) => w.length > 0);
+    const words = trimmedInput.split(/\s+/).filter(Boolean);
 
-    return options.filter((option) => {
+    const filtered = options.filter((option) => {
       const label = getOptionLabel(option).toLowerCase();
       return words.every((word) => label.includes(word));
+    });
+
+    return filtered.sort((a, b) => {
+      const aLabel = getOptionLabel(a).toLowerCase();
+      const bLabel = getOptionLabel(b).toLowerCase();
+
+      if (aLabel === trimmedInput) return -1;
+      if (bLabel === trimmedInput) return 1;
+
+      if (aLabel.startsWith(trimmedInput) && !bLabel.startsWith(trimmedInput)) return -1;
+      if (!aLabel.startsWith(trimmedInput) && bLabel.startsWith(trimmedInput)) return 1;
+
+      const aIndex = aLabel.indexOf(trimmedInput);
+      const bIndex = bLabel.indexOf(trimmedInput);
+
+      if (aIndex !== bIndex) return aIndex - bIndex;
+
+      return aLabel.localeCompare(bLabel, ['uk', 'en'], {
+        sensitivity: 'base',
+        numeric: true
+      });
     });
   }, []);
 
@@ -173,7 +194,7 @@ export const Search = <T extends TitleOption>({ search, setSearch, options }: Se
       clearIcon={false}
       clearOnBlur={false}
       disableListWrap
-      open={!!opened}
+      open={opened}
       noOptionsText={<Typography>{t('notFound')}</Typography>}
       loadingText={<Typography>{t('loading')}</Typography>}
       slotProps={{


### PR DESCRIPTION
## Description

This PR fixes the search behavior on the **Artistry page** where the exact match was not prioritized in the autocomplete results.

Previously, when partially searching for a composition by its full title, the **exact match did not appear at the top of the results list**. Instead, other compositions with similar starting letters could appear before it.

Now, the search results correctly prioritize the **exact match**, ensuring it appears at the top of the autocomplete dropdown when the full or near-full title is entered.

link:
https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/141

## Type of change

- [x] Bug fix

## How to test

1. Open the **Artistry page**:  
   https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/uk/artistry
2. Click the **search field**.
3. Start typing a composition title (for example: `Е` or `Елегія`).
4. Observe the **autocomplete dropdown results**.
5. Verify that the **exact match appears at the top of the list**.
6. Confirm that the search results are ordered correctly and behave consistently.

## Video / Screenshots

Before:
<img width="366" height="455" alt="Screenshot 2026-03-10 at 10 48 37" src="https://github.com/user-attachments/assets/485498e2-8007-4c3c-ae0a-02398c9ba07e" />

Now:
<img width="220" height="339" alt="Screenshot 2026-03-10 at 10 49 09" src="https://github.com/user-attachments/assets/c48fcd57-9bf2-453d-86da-d1318d9e0b2f" />
