### PR TITLE
fix(ui): allow the CookieModal's content height stretch

### DIFF
--- a/app/shared/components/cookie-modal/modal/CookieModal.styles.ts
+++ b/app/shared/components/cookie-modal/modal/CookieModal.styles.ts
@@ -7,7 +7,7 @@ export const styles = {
     display: 'flex',
     justifyContent: 'space-between',
     flexDirection: 'column',
-    height: '100%'
+    flexGrow: 1
   },
   title: {
     fontWeight: 700,

--- a/app/shared/components/cookie-modal/modal/CookieModal.tsx
+++ b/app/shared/components/cookie-modal/modal/CookieModal.tsx
@@ -35,6 +35,7 @@ export const CookieModal: React.FC<CookieModalProps> = ({ open, onClose, showPre
       handleClose={onClose}
       titleSx={styles.title}
       topSection={styles.topSection}
+      contentBoxSx={{ height: '100%' }}
       childrenBoxSx={styles.childrenBox}
       verticalAlignment={PositionEnum.Bottom}
       horizontalAlignment={PositionEnum.Left}

--- a/app/shared/components/cookie-modal/preferances/CookiePreferencesModal.styles.ts
+++ b/app/shared/components/cookie-modal/preferances/CookiePreferencesModal.styles.ts
@@ -12,7 +12,7 @@ export const styles = {
     height: '100%'
   },
   childrenBox: {
-    height: '100%'
+    flexGrow: 1
   },
   topSection: {
     marginBottom: '15px'

--- a/app/shared/components/cookie-modal/preferances/CookiePreferencesModal.tsx
+++ b/app/shared/components/cookie-modal/preferances/CookiePreferencesModal.tsx
@@ -35,6 +35,7 @@ export const CookiePreferencesModal: React.FC<CookiePreferencesModalProps> = ({
       handleClose={onClose}
       titleSx={styles.title}
       topSection={styles.topSection}
+      contentBoxSx={{ height: '100%' }}
       childrenBoxSx={styles.childrenBox}
       verticalAlignment={PositionEnum.Bottom}
       horizontalAlignment={PositionEnum.Left}


### PR DESCRIPTION
Linked [Issue](https://github.com/orgs/Liatoshynsky-Foundation/projects/1/views/6?pane=issue&itemId=163696729&issue=Liatoshynsky-Foundation%7Clf-client%7C1253).

## Description

This PR solved the problem of CookieModal's and CookiePreferencesModal's heights stretching, setting flexible growing on both target modals, and height of 100%.

## Type of change

- [x] Bug fix

## How to test

1. Go to any page withing the site.
2. Reset cache and cookies pressing `Shift+F5` OR produce right mouse click on site reload icon, and click  Empty cache and Hard reload.
3. Ensure both cookie modal and cookie preferences modal(opens by clicking `Cookie settings` button)  displayed as expected.

## Video / Screenshots

>Before changes: 
 - Cookie modal:
<img width="630" height="382" alt="image" src="https://github.com/user-attachments/assets/fd8a2202-1543-4605-b6e3-158a66ddc064" />

- Cookie preferences:
<img width="764" height="484" alt="image" src="https://github.com/user-attachments/assets/0818aa2f-c3f9-44ca-9c50-5df28da25db7" />

>After changes: 
 - Cookie modal:
<img width="630" height="386" alt="image" src="https://github.com/user-attachments/assets/cb701e94-e6bf-4dcd-923f-ec705282f04e" />

- Cookie preferences:
<img width="768" height="493" alt="image" src="https://github.com/user-attachments/assets/0545669d-a487-4d46-8043-22b366878127" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] All comments and requested changes addressed
- [x] Linked issue/task included
- [x] Task moved to the review column on the board