### PR TITLE
fix: align cards and images to grid in PartnershipFormats

### DIFF
--- a/app/shared/components/blocks/partnership-formats/PartnershipFormats.styles.ts
+++ b/app/shared/components/blocks/partnership-formats/PartnershipFormats.styles.ts
@@ -200,6 +200,7 @@ const baseStyles = {
       xl: 'flex'
     },
     justifySelf: {
+      xl: 'end',
       lg: 'auto',
       xxl: 'end'
     },
@@ -230,7 +231,7 @@ const baseStyles = {
       xl: '12px'
     },
     gridColumn: {
-      lg: '10 / 13',
+      lg: '9 / 13',
       xl: 'span 3',
       xxl: '10 / 13'
     }
@@ -340,11 +341,12 @@ const baseStyles = {
       lg: 'start',
       xl: 'start'
     },
+
     gridColumn: {
       xs: '1 / -1',
       sm: 'span 8',
       md: '4 / 13',
-      lg: '3 / 10',
+      lg: '3 / 9',
       xl: 'span 6',
       xxl: '3 / 7'
     },
@@ -358,10 +360,9 @@ const baseStyles = {
     },
     height: '100%',
     transform: {
-      lg: 'translateX(-37px)',
       xl: 'translateX(0px)'
     },
-    justifySelf: { sm: 'end', md: 'end', lg: 'auto' },
+    justifySelf: { sm: 'end', md: 'end', lg: 'end', xl: 'start' },
     width: {
       sm: '618px',
       md: '618px',


### PR DESCRIPTION
## Description

Fixed the alignment of cards and images in the PartnershipFormats section. Removed hardcoded transform values so the items now perfectly follow the CSS Grid across all screen sizes.

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to the Cooperation page.
2. Scroll down to the Partnership Formats section
3. Open Developer Tools and toggle the device toolbar, or manually resize the browser window.
4. Check the layout across different screen sizes (pay special attention to lg and xl breakpoints).
5. Verify that the bottom image no longer overflows and aligns perfectly with the background grid lines.

### Actual result:
<img width="675" height="310" alt="image" src="https://github.com/user-attachments/assets/3d094591-2f83-405f-b665-f54cf86ec5ac" />
<img width="638" height="285" alt="image" src="https://github.com/user-attachments/assets/16b2c2f9-70c2-4603-8893-d0234a7b1fe7" />

### Expected result: 
<img width="821" height="408" alt="image" src="https://github.com/user-attachments/assets/8a65c113-e9c1-4a2a-ac29-3a5fc248ab70" />
<img width="948" height="588" alt="image" src="https://github.com/user-attachments/assets/1cc4314a-7839-4158-b3eb-b64d599a5edd" />

Closes: https://github.com/Liatoshynsky-Foundation/lf-client/issues/1268