### PR TITLE
fix(ui): resolve button-in-anchor semantic error and update global navigation styles

### DIFF
--- a/app/shared/components/Footer/FooterContactAndSupport/FooterContactAndSupport.test.tsx
+++ b/app/shared/components/Footer/FooterContactAndSupport/FooterContactAndSupport.test.tsx
@@ -19,7 +19,7 @@ describe('FooterContactAndSupport', () => {
   it('renders both buttons correctly', () => {
     render(<FooterContactAndSupport contact={contact} donation={donation} />);
 
-    expect(screen.getByRole('button', { name: /contact us/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /contact us/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /donate/i })).toHaveAttribute('href', donation.link);
   });
 });

--- a/app/shared/components/Header/SupportButton/SupportButton.test.tsx
+++ b/app/shared/components/Header/SupportButton/SupportButton.test.tsx
@@ -20,7 +20,7 @@ describe('SupportButton', () => {
   it('should render the button with correct label', () => {
     render(<SupportButton data={mockData} />);
 
-    const button = screen.getByRole('button', { name: /support/i });
+    const button = screen.getByRole('link', { name: /support/i });
     expect(button).toBeInTheDocument();
 
     const icon = screen.queryByAltText(/support button/i);

--- a/app/shared/components/design-system/all-components/button-group/ButtonGroup.styles.ts
+++ b/app/shared/components/design-system/all-components/button-group/ButtonGroup.styles.ts
@@ -64,7 +64,7 @@ export const StyledButtonItem = styled(Box, {
     '&:hover': {
       background: 'rgba(25, 13, 3, 0.12)'
     },
-    '& button': {
+    '& .MuiButtonBase-root, && a, && button': {
       backgroundColor: 'transparent',
       color: 'inherit',
       textDecoration: 'none',

--- a/app/shared/components/design-system/all-components/button/Button.test.tsx
+++ b/app/shared/components/design-system/all-components/button/Button.test.tsx
@@ -47,7 +47,6 @@ describe('Button Component', () => {
     render(<Button link="/test-link" label="Go" />);
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', '/test-link');
-    expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
   it('should open link in new tab when externalLink is true', () => {
@@ -72,7 +71,7 @@ describe('Button Component', () => {
 
   it('should render button content inside link when externalLink is true', () => {
     render(<Button link="/external" externalLink label="Inside" />);
-    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toBeInTheDocument();
   });
 
   it('should display children if label not provided', () => {

--- a/app/shared/components/design-system/all-components/button/Button.tsx
+++ b/app/shared/components/design-system/all-components/button/Button.tsx
@@ -2,7 +2,7 @@
 
 import { Button as MuiButton, ButtonProps as MuiButtonProps, CircularProgress } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { forwardRef, ReactNode } from 'react';
+import { ElementType, forwardRef, ReactNode } from 'react';
 
 import { ButtonLabel } from './ButtonLabel';
 
@@ -10,11 +10,16 @@ import { Link } from '~/i18n/navigation';
 
 const CustomButton = styled(MuiButton)({});
 
-type Size = 'large' | 'medium' | 'small';
-type Variant = 'contained' | 'outlined' | 'text';
+interface ExtraProps {
+  href?: string;
+  target?: string;
+  rel?: string;
+  scroll?: boolean;
+  onClick?: React.MouseEventHandler<HTMLElement>;
+}
 
-type BaseButtonProps = {
-  size?: Size;
+export type ButtonProps = {
+  size?: 'large' | 'medium' | 'small';
   startIcon?: ReactNode;
   endIcon?: ReactNode;
   loading?: boolean;
@@ -22,29 +27,44 @@ type BaseButtonProps = {
   shortLabel?: string;
   link?: string;
   externalLink?: boolean;
-} & (
-  | {
-      color?: 'primary' | 'secondary';
-      variant?: Variant;
-    }
-  | {
-      color: 'tertiary';
-      variant?: 'contained';
-    }
-);
-export type ButtonProps = BaseButtonProps & Omit<MuiButtonProps, keyof BaseButtonProps>;
+} & Omit<MuiButtonProps, 'size'>;
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ label, shortLabel, link, externalLink, disabled, loading, startIcon, endIcon, children, ...props }, ref) => {
+  ({ label, shortLabel, link, externalLink, disabled, loading, startIcon, endIcon, children, sx, ...props }, ref) => {
     const isDisabled = disabled ?? loading;
 
-    const content = (
+    let component: ElementType = 'button';
+
+    if (link && !isDisabled) {
+      component = externalLink ? 'a' : Link;
+    }
+
+    const extraProps: ExtraProps = {};
+
+    if (link && !isDisabled) {
+      extraProps.href = link;
+      if (externalLink) {
+        extraProps.target = '_blank';
+        extraProps.rel = 'noopener noreferrer';
+      } else {
+        extraProps.scroll = true;
+      }
+    }
+
+    return (
       <CustomButton
+        component={component}
         ref={ref}
         disabled={isDisabled}
         startIcon={!loading ? startIcon : undefined}
         endIcon={!loading ? endIcon : undefined}
+        sx={{
+          width: 'fit-content',
+          ...(link && { textDecoration: 'none' }),
+          ...sx
+        }}
         {...props}
+        {...extraProps}
       >
         {loading ? (
           <CircularProgress color="inherit" size={25} data-testid="loader" />
@@ -54,22 +74,6 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           </ButtonLabel>
         )}
       </CustomButton>
-    );
-
-    if (!link) return content;
-
-    if (externalLink) {
-      return (
-        <a href={link} target="_blank" rel="noopener noreferrer">
-          {content}
-        </a>
-      );
-    }
-
-    return (
-      <Link style={{ width: 'fit-content' }} href={link} scroll onClickCapture={() => window.scrollTo({ top: 0 })}>
-        {content}
-      </Link>
     );
   }
 );


### PR DESCRIPTION
## Description

Resolved a semantic validation error where a `<button>` element was incorrectly nested inside an `<a>` tag.
Key changes include:
- Refactored `Button.tsx` to use MUI’s component prop. The component now dynamically renders as either an anchor (`<a>`), a Next.js `Link`, or a `<button>` based on the presence of the link prop;
- Updated `ButtonGroup.styles.ts` related to the main navbar of the site to fix visual bug with its buttons after refactoring `Button.tsx`;
- Updated multiple test files (`Button.test.tsx`, `SupportButton.test.tsx`, `FooterContactAndSupport.test.tsx`) to reflect the new DOM structure. Changed role-based queries from button to link where navigation is intended.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open [the app](https://lf-client-stage-a3ama9eydjfucnbj.polandcentral-01.azurewebsites.net/uk).
2. Open DevTools.
3. Find the following elements:

### Footer
#footer > div.MuiBox-root.css-1jfikaa > div.MuiBox-root.css-eualba > div > a.MuiButtonBase-root.MuiButton-root.MuiButton-contained.MuiButton-containedPrimary.MuiButton-sizeMedium.MuiButton-containedSizeMedium.MuiButton-colorPrimary.MuiButton-root.MuiButton-contained.MuiButton-containedPrimary.MuiButton-sizeMedium.MuiButton-containedSizeMedium.MuiButton-colorPrimary.css-1e0xq2a-MuiButtonBase-root-MuiButton-root

#footer > div.MuiBox-root.css-1jfikaa > div.MuiBox-root.css-eualba > div > a.MuiButtonBase-root.MuiButton-root.MuiButton-outlined.MuiButton-outlinedPrimary.MuiButton-sizeMedium.MuiButton-outlinedSizeMedium.MuiButton-colorPrimary.MuiButton-root.MuiButton-outlined.MuiButton-outlinedPrimary.MuiButton-sizeMedium.MuiButton-outlinedSizeMedium.MuiButton-colorPrimary.css-1t11bwu-MuiButtonBase-root-MuiButton-root

### /war-in-ukraine
body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-taw2c0 > div.MuiBox-root.css-1ionaz4 > div.MuiBox-root.css-1t4go9o > a

body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-taw2c0 > div.MuiBox-root.css-15ucf3a > a

body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1dsz7q1 > div.MuiBox-root.css-15ucf3a > a:nth-child(1)
body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1dsz7q1 > div.MuiBox-root.css-15ucf3a > a:nth-child(2)
body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-1dsz7q1 > div.MuiBox-root.css-15ucf3a > a:nth-child(3)

### /about-us | /biography | /main page
body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-gk2taz > div.MuiBox-root.css-6rh1a3 > div.MuiBox-root.css-14tv6je > a

### /main page
body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-rgwtcn > div.MuiBox-root.css-1ndjaaa > div.MuiBox-root.css-8fsmh > a

body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-l8qw1n > div.MuiBox-root.css-1w1hifu > div.MuiBox-root.css-1ndjaaa > div.MuiBox-root.css-8fsmh > a

body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-6jn0br > div.MuiBox-root.css-5kov77 > div > div > div.MuiBox-root.css-8fsmh > a

body > div.MuiBox-root.css-swu6uj > div > div > section > div.MuiBox-root.css-18b9m5r > div.MuiBox-root.css-8fsmh > a

body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-8eubxt > div.MuiBox-root.css-18b9m5r > div.MuiBox-root.css-8fsmh > a

body > div.MuiBox-root.css-swu6uj > div > div > div.MuiBox-root.css-gugb8s > div.MuiBox-root.css-18b9m5r > div.MuiBox-root.css-8fsmh > a

### /cooperation
body > div.MuiBox-root.css-swu6uj > div > div.MuiBox-root.css-p7soqj > div.MuiBox-root.css-rugix2 > div.MuiBox-root.css-1ndjaaa > div.MuiBox-root.css-8fsmh > a

**Previous result**
Semantic element 'button' implemented inside 'a'.
<img width="669" height="214" alt="image" src="https://github.com/user-attachments/assets/a565326c-83ed-48de-88e7-05ed8e2459e4" />

**Actual result**
The button has the correct HTML structure.
<img width="668" height="293" alt="image" src="https://github.com/user-attachments/assets/0d3057cc-55c6-4468-9e94-cb6c0101936d" />

Closes Liatoshynsky-Foundation/lf-manual-tests#225
---