### PR TITLE
fix(ui): fix war image responsiveness and alt text

### DIFF
--- a/app/[lang]/war-in-ukraine/page.tsx
+++ b/app/[lang]/war-in-ukraine/page.tsx
@@ -73,6 +73,7 @@ export default function WarInUkraine() {
         paymentMethods={carsForAFU}
         imageSrc={carsForAFUData.imageSrc}
         caption={carsForAFUData.caption}
+        imageAlt="Портрет Володимира Єрмоленка з дружиною Тетяною Огарковою"
       />
     </MainLayout>
   );

--- a/app/shared/components/blocks/volunteer-donation/VolunteerDonation.styles.ts
+++ b/app/shared/components/blocks/volunteer-donation/VolunteerDonation.styles.ts
@@ -80,7 +80,6 @@ export const styles = {
       sm: '4 / -1',
       md: '6 / -1',
       lg: '6 / -1'
-      // xl: '6 / -1'
     },
     gridRow: {
       sm: '5 / 7'

--- a/app/shared/components/blocks/volunteer-donation/VolunteerDonation.styles.ts
+++ b/app/shared/components/blocks/volunteer-donation/VolunteerDonation.styles.ts
@@ -97,18 +97,10 @@ export const styles = {
     },
     maxWidth: {
       xs: '100%',
-      sm: '100%',
-      md: '100%',
-      lg: '100%',
-      xl: '100%',
       xxl: '1001px'
     },
     width: {
       xs: '100%',
-      sm: '100%',
-      md: '100%',
-      lg: '100%',
-      xl: '100%',
       xxl: '806px',
       ultra: '1001px'
     }
@@ -130,8 +122,8 @@ export const imageSizes = {
     color: mainHexPallete.blue[300]
   },
   imageSx: {
-    width: { xs: '100%', sm: '100%', md: '100%', lg: '100%', xl: '100%', xxl: '806px', ultra: '1001px' },
-    height: { xs: 'auto', sm: 'auto', md: 'auto' },
+    width: { xs: '100%', xxl: '806px', ultra: '1001px' },
+    height: { xs: 'auto' },
     aspectRatio: { xs: '224 / 138', sm: '457 / 292', md: '569 / 336' }
   }
 };

--- a/app/shared/components/blocks/volunteer-donation/VolunteerDonation.styles.ts
+++ b/app/shared/components/blocks/volunteer-donation/VolunteerDonation.styles.ts
@@ -78,7 +78,9 @@ export const styles = {
     gridColumn: {
       xs: '2 / -1',
       sm: '4 / -1',
-      md: '6 / 12'
+      md: '6 / -1',
+      lg: '6 / -1'
+      // xl: '6 / -1'
     },
     gridRow: {
       sm: '5 / 7'
@@ -94,19 +96,19 @@ export const styles = {
       md: '14px'
     },
     maxWidth: {
-      xs: '224px',
-      sm: '457px',
-      md: '569px',
-      lg: '718px',
-      xl: '816px',
+      xs: '100%',
+      sm: '100%',
+      md: '100%',
+      lg: '100%',
+      xl: '100%',
       xxl: '1001px'
     },
     width: {
-      xs: '200px',
-      sm: '400px',
-      md: '496px',
-      lg: '645px',
-      xl: '744px',
+      xs: '100%',
+      sm: '100%',
+      md: '100%',
+      lg: '100%',
+      xl: '100%',
       xxl: '806px',
       ultra: '1001px'
     }
@@ -128,6 +130,8 @@ export const imageSizes = {
     color: mainHexPallete.blue[300]
   },
   imageSx: {
-    width: { xs: '200px', sm: '400px', md: '496px', lg: '645px', xl: '744px', xxl: '806px', ultra: '1001px' }
+    width: { xs: '100%', sm: '100%', md: '100%', lg: '100%', xl: '100%', xxl: '806px', ultra: '1001px' },
+    height: { xs: 'auto', sm: 'auto', md: 'auto' },
+    aspectRatio: { xs: '224 / 138', sm: '457 / 292', md: '569 / 336' }
   }
 };

--- a/app/shared/components/blocks/volunteer-donation/VolunteerDonation.tsx
+++ b/app/shared/components/blocks/volunteer-donation/VolunteerDonation.tsx
@@ -20,9 +20,10 @@ interface Props {
   paymentMethods: PaymentMethod[];
   imageSrc: string;
   caption?: string;
+  imageAlt?: string;
 }
 
-const VolunteerDonation: React.FC<Props> = ({ title, paymentMethods, imageSrc, caption }) => {
+const VolunteerDonation: React.FC<Props> = ({ title, paymentMethods, imageSrc, caption, imageAlt }) => {
   const t = useTranslations('common');
 
   return (
@@ -42,7 +43,7 @@ const VolunteerDonation: React.FC<Props> = ({ title, paymentMethods, imageSrc, c
 
       <ImageWithCaption
         src={imageSrc}
-        alt={title}
+        alt={imageAlt ?? title}
         caption={caption ?? ''}
         captionSx={styles.captionSx}
         align="right"


### PR DESCRIPTION
## Description

Fixed the image responsiveness bug on the "War in Ukraine" page. Previously, the image had a hardcoded width (200px) on small screens and was not right-aligned on larger viewports. Now, the photo scales correctly and aligns to the right side of the grid across all screen sizes. Also updated the `alt` attribute to the correct description for accessibility.
## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test:
1. Open the "War in Ukraine" page.
2. Open DevTools (Responsive mode).
3. Smoothly resize the screen width from 320px to 1450px (or check standard breakpoints: 767px, 1024px, 1280px, 1440px).
4. **Expected result:** The image is responsive, does not shrink to 200px on mobile, and is always right-aligned within its container on desktop viewports.
5. Inspect the `<img>` element and verify the `alt` attribute (should be: "Портрет Володимира Єрмоленка з дружиною Тетяною Огарковою").

### Actual result:
1. The image is not responsive and is not right-aligned across screen sizes.
2. Incorrect alt for img:
`<img alt="НА АВТІВКИ ДЛЯ ЗСУ:" loading="lazy" decoding="async" data-nimg="fill"...`

### Expected result: 

1. The image is responsive and is right-aligned across screen sizes.
2. Img tag: `<img alt="Портрет Володимира Єрмоленка з дружиною Тетяною Огарковою" loading="lazy" decoding="async" data-nimg="fill"...`

https://github.com/user-attachments/assets/06ca2cae-6666-4727-9e0e-c0602a6d980a



Closes: https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/65