### PR TITLE
fix(ui): add animation on opening filters, update tests

### DIFF
--- a/app/shared/components/enhanced-table/control-panel/ControlPanel.test.tsx
+++ b/app/shared/components/enhanced-table/control-panel/ControlPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import ControlPanel from './ControlPanel';
 
@@ -89,7 +89,7 @@ describe('ControlPanel', () => {
       expect(screen.queryByTestId('filters-component')).not.toBeInTheDocument();
     });
 
-    it('should toggle filters visibility on desktop button click', () => {
+    it('should toggle filters visibility on desktop button click', async () => {
       render(<ControlPanel {...defaultProps} />);
 
       expect(screen.queryByTestId('filters-component')).not.toBeInTheDocument();
@@ -101,7 +101,9 @@ describe('ControlPanel', () => {
 
       fireEvent.click(filtersButton);
 
-      expect(screen.queryByTestId('filters-component')).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByTestId('filters-component')).not.toBeInTheDocument();
+      });
     });
 
     it('should not display the badge count when activeFiltersCount is 0 (desktop)', () => {
@@ -123,7 +125,7 @@ describe('ControlPanel', () => {
       mockedUseBreakpoints.mockReturnValue(mobileBreakpoints);
     });
 
-    it('should toggle filters visibility on mobile button click', () => {
+    it('should toggle filters visibility on mobile button click', async () => {
       render(<ControlPanel {...defaultProps} />);
 
       const filtersButton = screen.getByRole('button', { name: 'controls.filters' });
@@ -135,7 +137,10 @@ describe('ControlPanel', () => {
       expect(screen.getByTestId('filters-component')).toBeInTheDocument();
 
       fireEvent.click(filtersButton);
-      expect(screen.queryByTestId('filters-component')).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('filters-component')).not.toBeInTheDocument();
+      });
     });
 
     it('should toggle search visibility on mobile button click', () => {

--- a/app/shared/components/enhanced-table/control-panel/ControlPanel.tsx
+++ b/app/shared/components/enhanced-table/control-panel/ControlPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Badge, Box, Typography } from '@mui/material';
+import { Badge, Box, Collapse, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 
@@ -136,7 +136,16 @@ export default function ControlPanel({
       </Box>
       <Box sx={ControlPanelStyles.controlsColumn} data-testid="ControlPanel-controlsColumn">
         {isMobile && searchActive ? <Box>{Search}</Box> : null}
-        {filtersActive ? <Box sx={ControlPanelStyles.filtersContainer}>{Filters}</Box> : null}
+        <Collapse
+          in={filtersActive}
+          timeout={{ enter: 300, exit: 600 }}
+          sx={{
+            transitionTimingFunction: filtersActive ? 'ease-in' : 'ease-out'
+          }}
+          unmountOnExit
+        >
+          <Box sx={ControlPanelStyles.filtersContainer}>{Filters}</Box>
+        </Collapse>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Description

Smooth animations for opening and closing the filter panel have been added to the /artistry and /research pages for responsives from 768px and above. The tests have also been updated.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other:

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open the /artistry page
2. Open the /research page in another tab
3. Press the 'Search' button on each page. Then press the 'Filters' button also on each page
4. Compare the behavior of fully opening these elements.

Previous result:

Filters open without animation.

https://github.com/user-attachments/assets/6317bb25-2ffb-4401-bc66-f8b6f6984736

Actual result:
The animation is implemented and behaves similar to the 'Search' button opening.


https://github.com/user-attachments/assets/23464660-8239-46c1-81fd-c13d326ea2e6


Closes Liatoshynsky-Foundation/lf-manual-tests#220
---
