### PR TITLE
fix: align image width with grid on xxl screens

### DIFF
--- a/app/shared/components/blocks/volunteer-donation/VolunteerDonation.styles.ts
+++ b/app/shared/components/blocks/volunteer-donation/VolunteerDonation.styles.ts
@@ -100,7 +100,6 @@ export const styles = {
     },
     width: {
       xs: '100%',
-      xxl: '806px',
       ultra: '1001px'
     }
   }
@@ -121,7 +120,7 @@ export const imageSizes = {
     color: mainHexPallete.blue[300]
   },
   imageSx: {
-    width: { xs: '100%', xxl: '806px', ultra: '1001px' },
+    width: { xs: '100%', ultra: '1001px' },
     height: { xs: 'auto' },
     aspectRatio: { xs: '224 / 138', sm: '457 / 292', md: '569 / 336' }
   }


### PR DESCRIPTION
## Description

Fixed the image width constraints on the "War in Ukraine" page for `xxl` screens. The image and its caption now correctly stretch to align with the right edge of the main grid

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test
1. Navigate to the /war-in-ukraine page.
2. Open Developer Tools (F12) and enable Device / Responsive mode.
3. Set the viewport width between 1728px and 1919px (the xxl resolution range).
4. Scroll down to the photo with the caption and verify that its right edge aligns perfectly with the main grid line.

### Actual result: 
<img width="819" height="480" alt="image" src="https://github.com/user-attachments/assets/d499c9b1-4b01-4812-a830-a747553ac812" />

### Expected result: 
<img width="751" height="664" alt="image" src="https://github.com/user-attachments/assets/e7dc6c16-fd38-49a3-b579-bd04e94a8873" />


Closes: https://github.com/Liatoshynsky-Foundation/lf-client/issues/1280
