### PR TITLE
fix: resolve mobile responsiveness in Partnership formats

### DIFF
--- a/app/shared/components/blocks/partnership-formats/PartnershipFormats.test.tsx
+++ b/app/shared/components/blocks/partnership-formats/PartnershipFormats.test.tsx
@@ -347,7 +347,7 @@ describe('PartnershipFormats', () => {
     expect(slider).toBeInTheDocument();
 
     const sliderSlides = within(slider).getAllByTestId('slider-slide');
-    expect(sliderSlides.length).toBe(6);
+    expect(sliderSlides.length).toBe(4);
   });
 
   it('should render mobile slider with cards and images', () => {
@@ -357,7 +357,7 @@ describe('PartnershipFormats', () => {
     expect(slider).toBeInTheDocument();
 
     const sliderSlides = within(slider).getAllByTestId('slider-slide');
-    expect(sliderSlides.length).toBe(6);
+    expect(sliderSlides.length).toBe(4);
 
     let cardCount = 0;
     let imageCount = 0;
@@ -372,7 +372,7 @@ describe('PartnershipFormats', () => {
     }
 
     expect(cardCount).toBe(4);
-    expect(imageCount).toBe(2);
+    expect(imageCount).toBe(0);
   });
 
   it('should not render slider slides when no data is provided', () => {

--- a/app/shared/components/blocks/partnership-formats/PartnershipFormats.tsx
+++ b/app/shared/components/blocks/partnership-formats/PartnershipFormats.tsx
@@ -58,9 +58,7 @@ const PartnershipFormats: React.FC<PartnershipFormatsProps> = ({ data }) => {
 
   const mobileSlides = [
     data.firstRowFirstCard && { type: 'card' as const, card: data.firstRowFirstCard },
-    data.firstRowImage && { type: 'image' as const, image: data.firstRowImage },
     data.firstRowSecondCard && { type: 'card' as const, card: data.firstRowSecondCard },
-    data.secondRowImage && { type: 'image' as const, image: data.secondRowImage },
     data.secondRowFirstCard && { type: 'card' as const, card: data.secondRowFirstCard },
     data.secondRowSecondCard && { type: 'card' as const, card: data.secondRowSecondCard }
   ].filter(Boolean) as Array<{ type: 'card' | 'image'; card?: PartnershipCard; image?: PartnershipImage }>;

--- a/app/shared/components/blocks/partnership-formats/PartnershipSlider.styles.ts
+++ b/app/shared/components/blocks/partnership-formats/PartnershipSlider.styles.ts
@@ -1,6 +1,9 @@
 export const sliderStyles = {
   container: {
-    width: '100%',
+    width: {
+      xs: 'calc(100% + 24px)',
+      sm: '100%'
+    },
     overflow: 'hidden',
     mb: {
       xs: '24px'
@@ -14,26 +17,28 @@ export const sliderStyles = {
   },
   slidesContainer: {
     display: 'flex',
+    gap: '16px',
     transition: 'transform 0.3s ease-in-out',
     willChange: 'transform'
   },
   slide: {
-    minWidth: '100%',
+    flexShrink: 0,
+    maxWidth: 'max-content',
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center'
   },
   cardWrapper: {
     width: {
-      xs: '100%',
+      xs: '272px',
       sm: '294px'
     },
     maxWidth: {
-      xs: '100%',
+      xs: 'max-content',
       sm: '294px'
     },
     minWidth: {
-      xs: '100%',
+      xs: '272px',
       sm: '294px'
     },
     '& > *': {
@@ -44,15 +49,15 @@ export const sliderStyles = {
   imageWrapper: {
     transform: 'skewY(-2deg)',
     width: {
-      xs: '100%',
+      xs: '272px',
       sm: '294px'
     },
     maxWidth: {
-      xs: '100%',
+      xs: '272px',
       sm: '294px'
     },
     minWidth: {
-      xs: '100%',
+      xs: '272px',
       sm: '294px'
     },
     height: '386px',

--- a/app/shared/components/blocks/partnership-formats/PartnershipSlider.tsx
+++ b/app/shared/components/blocks/partnership-formats/PartnershipSlider.tsx
@@ -91,7 +91,10 @@ const PartnershipSlider: React.FC<PartnershipSliderProps> = ({ slides }) => {
         <Box
           sx={{
             ...sliderStyles.slidesContainer,
-            transform: `translateX(-${currentSlide * 100}%)`
+            transform: {
+              xs: `translateX(-${currentSlide * 288}px)`,
+              sm: `translateX(-${currentSlide * 310}px)`
+            }
           }}
         >
           {slides.map((slide) => {


### PR DESCRIPTION
## Description

Fixed mobile responsiveness for the Partnership formats slider by adding a 16px gap and setting a fixed card width to ensure the next card peeks from the right edge. Removed photos from the mobile layout according to the ticket requirements.

## Type of change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Navigate to the Cooperation page and scroll down to the Partnership formats block.
2. Enable mobile view in DevTools with a screen width between 320px and 767px.
3. Verify that the slider displays only cards without any photos.
4. Verify that a portion of the next card is clearly visible on the right side of the screen.
5. Swipe the slider to ensure it scrolls exactly one card at a time without leaving any empty space at the end.

### Actual result:

1. Max-width: 100%
2. Gap between blocks is missing.
3. A next block isn't visible.
4. Photos are present in the Partnership formats block on mobile responsiveness.
<img width="763" height="635" alt="image" src="https://github.com/user-attachments/assets/d073980c-c80d-4eb2-9c82-6c54d7209b34" />

### Exptected result: 

- [X] max-width: max-content;
- [X] gap between blocks: 16px
- [X] Next block is visible fom right side.
- [X] The Partnership formats block doesen't include any photo on mobile responsiveness.

https://github.com/user-attachments/assets/deb6eb92-1cce-4f0d-beb4-36b368bad5df



Closes: https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/109