### PR TITLE
feature: replace hardcoded routes with ROUTES constants

### DIFF
--- a/app/[lang]/about-us/page.tsx
+++ b/app/[lang]/about-us/page.tsx
@@ -20,6 +20,7 @@ import { isProductionMode } from '~/utils/isProductionMode';
 import MainLayout from '~/layouts/main-layout/MainLayout';
 import { ErrorPageFactory } from '~/lib/utils/errorPageFactory';
 import { resolvePageData } from '~/services/pages-data/resolvePageData';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
   const { lang } = await params;
@@ -30,7 +31,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/',
+    url: ROUTES.HOME,
     locale: lang
   });
 }

--- a/app/[lang]/archive/FundCard/FundCard.tsx
+++ b/app/[lang]/archive/FundCard/FundCard.tsx
@@ -5,6 +5,7 @@ import { Box, Typography } from '@mui/material';
 import { styles } from './FundCard.styles';
 
 import { Link } from '~/i18n/navigation';
+import { getDynamicRoute } from '~/shared/components/constants/routes';
 
 export interface FundCardProps {
   id: number;
@@ -14,7 +15,7 @@ export interface FundCardProps {
 
 export default function FundCard({ id, number, title }: Readonly<FundCardProps>) {
   return (
-    <Link href={`/archive/${id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
+    <Link href={getDynamicRoute.archiveFund(id)} style={{ textDecoration: 'none', color: 'inherit' }}>
       <Box component="article" sx={styles.card} data-testid="FundCard" aria-label={`${number}: ${title}`}>
         <Typography sx={styles.fundNumber} data-testid="FundCard-number">
           {number}

--- a/app/[lang]/archive/[fund]/[case]/page.test.tsx
+++ b/app/[lang]/archive/[fund]/[case]/page.test.tsx
@@ -6,6 +6,7 @@ import ArchiveCasePage, { generateMetadata } from './page';
 import { createSeoMeta } from '~/utils/createSeoMeta';
 
 import type { ArchiveCaseDetailsProps } from '~/shared/components/blocks/archive-case-details/ArchiveCaseDetails';
+import { getDynamicRoute } from '~/shared/components/constants/routes';
 
 const mockGetCaseById = jest.fn();
 
@@ -95,7 +96,7 @@ describe('generateMetadata', () => {
     const expectedConfig = {
       title: `Архівна справа ${mockCaseDetails.cipher} – ${mockCaseDetails.name}`,
       description: `Архівна справа «${mockCaseDetails.name}» (${mockCaseDetails.cipher}). Дати: ${mockCaseDetails.dates}.`,
-      url: '/archive/2/op1-spr3'
+      url: getDynamicRoute.archiveCase(2, 'op1-spr3')
     };
 
     expect(mockGetCaseById).toHaveBeenCalledWith('op1-spr3');
@@ -114,7 +115,7 @@ describe('generateMetadata', () => {
     const expectedConfig = {
       title: 'Архівна справа не знайдена',
       description: 'Запитувану архівну справу не знайдено.',
-      url: '/archive/2/missing-id'
+      url: getDynamicRoute.archiveCase(2, 'missing-id')
     };
 
     expect(mockGetCaseById).toHaveBeenCalledWith('missing-id');
@@ -134,6 +135,7 @@ describe('ArchiveCasePage', () => {
 
   it('renders archive case details inside main layout and maps data correctly', async () => {
     mockGetCaseById.mockResolvedValue(mockCaseDetails);
+    const lang = 'en';
 
     const jsx = await ArchiveCasePage({
       params: Promise.resolve({ lang: 'en', fund: '2', case: 'op1-spr3' })
@@ -156,7 +158,7 @@ describe('ArchiveCasePage', () => {
     expect(props.dateRange).toBe(mockCaseDetails.dates);
     expect(props.sheetsCount).toBe(mockCaseDetails.sheets);
     expect(props.pdfUrl).toBe(mockCaseDetails.pdfUrl);
-    expect(props.fundHref).toBe('/en/archive/2');
+    expect(props.fundHref).toBe(`/${lang}${getDynamicRoute.archiveFund('2')}`);
 
     expect(props.documents).toEqual([
       { id: 'doc-1', title: 'Документ А' },
@@ -164,13 +166,13 @@ describe('ArchiveCasePage', () => {
     ]);
 
     expect(props.prevCase).toEqual({
-      href: '/en/archive/2/prev-id',
+      href: `/${lang}${getDynamicRoute.archiveCase('2', 'prev-id')}`,
       indexLabel: 'Ф. 2, оп. 1, спр. 2',
       title: 'Попередня справа'
     });
 
     expect(props.nextCase).toEqual({
-      href: '/en/archive/2/next-id',
+      href: `/${lang}${getDynamicRoute.archiveCase('2', 'next-id')}`,
       indexLabel: 'Ф. 2, оп. 1, спр. 4',
       title: 'Наступна справа'
     });

--- a/app/[lang]/archive/[fund]/[case]/page.tsx
+++ b/app/[lang]/archive/[fund]/[case]/page.tsx
@@ -13,6 +13,7 @@ import ArchiveCaseDetails, {
   type ArchiveCaseDetailsLabels,
   type ArchiveCaseDocument
 } from '~/shared/components/blocks/archive-case-details/ArchiveCaseDetails';
+import { getDynamicRoute } from '~/shared/components/constants/routes';
 
 type ArchiveCasePageParams = {
   lang: Locale;
@@ -42,7 +43,7 @@ export async function generateMetadata({ params }: Readonly<ArchiveCasePageProps
     return createSeoMeta({
       title: 'Архівна справа не знайдена',
       description: 'Запитувану архівну справу не знайдено.',
-      url: `/archive/${fund}/${caseId}`
+      url: getDynamicRoute.archiveCase(fund, caseId)
     });
   }
 
@@ -52,7 +53,7 @@ export async function generateMetadata({ params }: Readonly<ArchiveCasePageProps
   return createSeoMeta({
     title,
     description,
-    url: `/archive/${fund}/${caseId}`
+    url: getDynamicRoute.archiveCase(fund, caseId)
   });
 }
 
@@ -70,7 +71,7 @@ export default async function ArchiveCasePage({ params }: Readonly<ArchiveCasePa
     notFound();
   }
 
-  const fundHref = `/${lang}/archive/${fund}`;
+  const fundHref = `/${lang}${getDynamicRoute.archiveFund(fund)}`;
 
   const documents: ArchiveCaseDocument[] =
     caseDetails.documents?.map((doc) => ({
@@ -78,7 +79,7 @@ export default async function ArchiveCasePage({ params }: Readonly<ArchiveCasePa
       title: doc.text
     })) ?? [];
 
-  const buildCaseHref = (id: string) => `/${lang}/archive/${fund}/${id}`;
+  const buildCaseHref = (id: string) => `/${lang}${getDynamicRoute.archiveCase(fund, id)}`;
 
   const mapAdjacentCase = (caseItem: CaseDetailsDTO['prevCase']): ArchiveAdjacentCase | undefined => {
     if (!caseItem?._id) {

--- a/app/[lang]/archive/layout.tsx
+++ b/app/[lang]/archive/layout.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react';
 import type { Language } from '~/types/types/language';
 
 import { createSeoMeta } from '~/lib/utils/createSeoMeta';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
   const { lang } = await params;
@@ -15,7 +16,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/archive',
+    url: ROUTES.ARCHIVE,
     locale: lang
   });
 }

--- a/app/[lang]/artistry/page.tsx
+++ b/app/[lang]/artistry/page.tsx
@@ -11,6 +11,7 @@ import { createSeoMeta } from '~/utils/createSeoMeta';
 import { isProductionMode } from '~/utils/isProductionMode';
 
 import MainLayout from '~/layouts/main-layout/MainLayout';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
   const { lang } = await params;
@@ -21,7 +22,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/artistry',
+    url: ROUTES.ARTISTRY,
     locale: lang
   });
 }

--- a/app/[lang]/biography/page.tsx
+++ b/app/[lang]/biography/page.tsx
@@ -16,6 +16,7 @@ import { createSeoMeta } from '~/lib/utils/createSeoMeta';
 import { ErrorPageFactory } from '~/lib/utils/errorPageFactory';
 import { resolvePageData } from '~/services/pages-data/resolvePageData';
 import { HeroSection } from '~/shared/components/blocks/HeroSection/HeroSection';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
   const { lang } = await params;
@@ -26,7 +27,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/biography',
+    url: ROUTES.BIOGRAPHY,
     locale: lang
   });
 }

--- a/app/[lang]/contacts/page.tsx
+++ b/app/[lang]/contacts/page.tsx
@@ -11,6 +11,7 @@ import { isProductionMode } from '~/utils/isProductionMode';
 import { createRequestContainer } from '~/di/container';
 import ColoredLayout from '~/layouts/colored-layout/ColoredLayout';
 import { createSeoMeta } from '~/lib/utils/createSeoMeta';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
   const { lang } = await params;
@@ -21,7 +22,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/contacts',
+    url: ROUTES.CONTACTS,
     locale: lang
   });
 }

--- a/app/[lang]/cooperation/page.tsx
+++ b/app/[lang]/cooperation/page.tsx
@@ -19,6 +19,7 @@ import { collaborationIntroPageData } from '~/shared/components/blocks/collabora
 import OfferCollaboration from '~/shared/components/blocks/collaboration/offer-collaboration/OfferCollaboration';
 import OurPartners from '~/shared/components/blocks/our-partners/OurPartners';
 import PartnershipFormats from '~/shared/components/blocks/partnership-formats/PartnershipFormats';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
   const { lang } = await params;
@@ -29,7 +30,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/cooperation',
+    url: ROUTES.COOPERATION,
     locale: lang
   });
 }

--- a/app/[lang]/news/page.tsx
+++ b/app/[lang]/news/page.tsx
@@ -12,6 +12,7 @@ import { createRequestContainer } from '~/di/container';
 import MainLayout from '~/layouts/main-layout/MainLayout';
 import { createSeoMeta } from '~/lib/utils/createSeoMeta';
 import MediaCenter from '~/shared/components/blocks/media-center/MediaCenter';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
   const { lang } = await params;
@@ -22,7 +23,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/news',
+    url: ROUTES.NEWS,
     locale: lang
   });
 }

--- a/app/[lang]/not-found.test.tsx
+++ b/app/[lang]/not-found.test.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 import { PageNotFound } from './[...unknown-route]/page-not-found/PageNotFound';
 
+import { ROUTES } from '~/shared/components/constants/routes';
+
 jest.mock('~/i18n/navigation', () => ({
   Link: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>
 }));
@@ -28,6 +30,6 @@ describe('NotFound', () => {
     ).toBeInTheDocument();
     const link = screen.getByRole('link', { name: /"Return to home/i });
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('href', '/');
+    expect(link).toHaveAttribute('href', ROUTES.HOME);
   });
 });

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -48,6 +48,7 @@ import MainLayout from '~/layouts/main-layout/MainLayout';
 import { ErrorPageFactory } from '~/lib/utils/errorPageFactory';
 import { resolvePageData } from '~/services/pages-data/resolvePageData';
 import { IntroAnimation } from '~/shared/components/blocks/home-page-hero/animation';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
   const { lang } = await params;
@@ -58,7 +59,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/',
+    url: ROUTES.HOME,
     locale: lang
   });
 }
@@ -132,7 +133,7 @@ export default async function Home({ params }: Readonly<Language>) {
       title: eventsTitle[lang],
       text: eventsMainText[lang],
       ctaLabel: eventsCtaLabel[lang],
-      ctaHref: '/events',
+      ctaHref: `${ROUTES.NEWS}#events`,
       publishDateLabes: eventsPublishDateLabel[lang],
       viewLabel: eventsViewLabel[lang],
       regLabel: eventsRegLabel[lang],

--- a/app/[lang]/privacy-policy/page.tsx
+++ b/app/[lang]/privacy-policy/page.tsx
@@ -15,6 +15,7 @@ import { isProductionMode } from '~/utils/isProductionMode';
 import MainLayout from '~/layouts/main-layout/MainLayout';
 import { ErrorPageFactory } from '~/lib/utils/errorPageFactory';
 import { resolvePageData } from '~/services/pages-data/resolvePageData';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
   const { lang } = await params;
@@ -25,7 +26,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/privacy-policy',
+    url: ROUTES.PRIVACY_POLICY,
     locale: lang
   });
 }

--- a/app/[lang]/research/page.tsx
+++ b/app/[lang]/research/page.tsx
@@ -15,6 +15,7 @@ import { isProductionMode } from '~/utils/isProductionMode';
 import MainLayout from '~/layouts/main-layout/MainLayout';
 import { ErrorPageFactory } from '~/lib/utils/errorPageFactory';
 import { resolvePageData } from '~/services/pages-data/resolvePageData';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
   const { lang } = await params;
@@ -25,7 +26,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/research',
+    url: ROUTES.RESEARCH,
     locale: lang
   });
 }

--- a/app/[lang]/support-us/page.test.tsx
+++ b/app/[lang]/support-us/page.test.tsx
@@ -8,17 +8,21 @@ jest.mock('~/di/container', () => ({
   createRootContainer: jest.fn()
 }));
 
-jest.mock('~/shared/components/blocks/actions-help/ActionsHelp.consts', () => ({
-  getActionsHelpData: jest.fn().mockResolvedValue({
-    title: 'Допомогти справами',
-    subtitle: {},
-    paperItems: [],
-    paperButton: {
-      text: 'Запропонувати допомогу',
-      link: '/cooperation'
-    }
-  })
-}));
+jest.mock('~/shared/components/blocks/actions-help/ActionsHelp.consts', () => {
+  const { ROUTES } = jest.requireActual('~/shared/components/constants/routes');
+
+  return {
+    getActionsHelpData: jest.fn().mockResolvedValue({
+      title: 'Допомогти справами',
+      subtitle: {},
+      paperItems: [],
+      paperButton: {
+        text: 'Запропонувати допомогу',
+        link: ROUTES.COOPERATION
+      }
+    })
+  };
+});
 
 jest.mock('~/shared/components/blocks/actions-help/ActionsHelp', () => {
   const MockActionsHelp = () => <div>Actions Help</div>;

--- a/app/[lang]/support-us/page.tsx
+++ b/app/[lang]/support-us/page.tsx
@@ -15,6 +15,7 @@ import { getActionsHelpData } from '~/shared/components/blocks/actions-help/Acti
 import Faq from '~/shared/components/blocks/FAQ/FAQ';
 import { faqItems } from '~/shared/components/blocks/FAQ/FAQ.consts';
 import SupportFoundation from '~/shared/components/blocks/support-foundation/SupportFoundation';
+import { ROUTES } from '~/shared/components/constants/routes';
 import MainLayout from '~/shared/layouts/main-layout/MainLayout';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
@@ -26,7 +27,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/support-us',
+    url: ROUTES.SUPPORT_US,
     locale: lang
   });
 }

--- a/app/[lang]/terms/page.tsx
+++ b/app/[lang]/terms/page.tsx
@@ -10,6 +10,7 @@ import { createSeoMeta } from '~/utils/createSeoMeta';
 import { isProductionMode } from '~/utils/isProductionMode';
 
 import MainLayout from '~/layouts/main-layout/MainLayout';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
   const { lang } = await params;
@@ -20,7 +21,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/terms',
+    url: ROUTES.TERMS,
     locale: lang
   });
 }

--- a/app/[lang]/war-in-ukraine/page.tsx
+++ b/app/[lang]/war-in-ukraine/page.tsx
@@ -24,6 +24,7 @@ import {
   yermolenkoLinks
 } from '~/[lang]/war-in-ukraine/war.const';
 import MainLayout from '~/layouts/main-layout/MainLayout';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export async function generateMetadata({ params }: Language): Promise<Metadata> {
   const { lang } = await params;
@@ -34,7 +35,7 @@ export async function generateMetadata({ params }: Language): Promise<Metadata> 
   return createSeoMeta({
     title: t('title'),
     description: t('description'),
-    url: '/war-in-ukraine',
+    url: ROUTES.WAR_IN_UKRAINE,
     locale: lang
   });
 }

--- a/app/infrastructure/repositories/foundation-info/foundationInfo.test.ts
+++ b/app/infrastructure/repositories/foundation-info/foundationInfo.test.ts
@@ -3,6 +3,7 @@ import newFoundationInfoRepo from './foundationInfo.repository';
 import { BrandingInfo } from '~/infrastructure/models/foundation-info/foundationInfoBranding';
 import { ContactInfo } from '~/infrastructure/models/foundation-info/foundationInfoContact';
 import { PublicInfo } from '~/infrastructure/models/foundation-info/foundationInfoPublic';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 jest.mock('~/infrastructure/db/connect', () => ({
   __esModule: true,
@@ -58,7 +59,7 @@ const mockPublicData = {
   },
   links: [
     { label: { uk: 'Політика', en: 'Privacy' }, href: '/privacy' },
-    { label: { uk: 'Умови', en: 'Terms' }, href: '/terms' }
+    { label: { uk: 'Умови', en: 'Terms' }, href: ROUTES.TERMS }
   ]
 };
 

--- a/app/infrastructure/repositories/navigation/navigation.test.ts
+++ b/app/infrastructure/repositories/navigation/navigation.test.ts
@@ -1,5 +1,6 @@
 import { Navigation } from '~/infrastructure/models/navigation/navigation';
 import newNavigationRepository from '~/infrastructure/repositories/navigation/navigation.repository';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 jest.mock('~/infrastructure/db/connect', () => ({
   __esModule: true,
@@ -25,7 +26,7 @@ describe('navigationRepository', () => {
       {
         title: { uk: 'Головна', en: 'Main' },
         links: [
-          { label: { uk: 'Дім', en: 'Home' }, href: '/', visibility: true },
+          { label: { uk: 'Дім', en: 'Home' }, href: ROUTES.HOME, visibility: true },
           { label: { uk: 'Про нас', en: 'About' }, href: '/about', visibility: false }
         ],
         order: 1
@@ -54,7 +55,7 @@ describe('navigationRepository', () => {
     const invalidDocs = [
       {
         title: { uk: 'Головна' },
-        links: [{ label: { uk: 'Дім', en: 'Home' }, href: '/', visibility: true }],
+        links: [{ label: { uk: 'Дім', en: 'Home' }, href: ROUTES.HOME, visibility: true }],
         order: 1
       }
     ];

--- a/app/lib/utils/createSeoMeta.test.ts
+++ b/app/lib/utils/createSeoMeta.test.ts
@@ -1,5 +1,7 @@
 import { createSeoMeta } from './createSeoMeta';
 
+import { ROUTES } from '~/shared/components/constants/routes';
+
 const localBaseUrl = 'http://localhost:3000';
 const prodBaseUrl = 'https://lf-client.com';
 
@@ -16,14 +18,14 @@ describe('createSeoMeta', () => {
     const meta = createSeoMeta({
       title: 'Test Title',
       description: 'Test Description',
-      url: '/artistry',
+      url: ROUTES.ARTISTRY,
       imageUrl: '/images/test.jpg',
       locale: 'uk'
     });
 
     expect(meta.title).toBe('Test Title');
     expect(meta.description).toBe('Test Description');
-    expect(meta.openGraph?.url).toBe(`${localBaseUrl}/uk/artistry`);
+    expect(meta.openGraph?.url).toBe(`${localBaseUrl}/uk${ROUTES.ARTISTRY}`);
     expect(meta.openGraph?.locale).toBe('uk_UA');
     expect(meta.openGraph?.alternateLocale).toBe('en_US');
 
@@ -45,7 +47,7 @@ describe('createSeoMeta', () => {
     const meta = createSeoMeta({
       title: 'Prod Title',
       description: 'Prod Description',
-      url: '/',
+      url: ROUTES.HOME,
       locale: 'en'
     });
 

--- a/app/lib/utils/footerNavigationMapper.test.ts
+++ b/app/lib/utils/footerNavigationMapper.test.ts
@@ -1,5 +1,7 @@
 import { type FooterNavSection, mapFooterNavigation } from './footerNavigationMapper';
 
+import { ROUTES } from '~/shared/components/constants/routes';
+
 jest.mock('next-intl/server', () => ({
   getTranslations: jest.fn().mockResolvedValue((key: string) => {
     const mock: Record<string, string> = {
@@ -22,7 +24,7 @@ describe('mapFooterNavigation', () => {
         title: 'Section 1',
         links: [
           { label: 'About', href: '/about' },
-          { label: 'Contact', href: '/contacts' }
+          { label: 'Contact', href: ROUTES.CONTACTS }
         ]
       }
     ];
@@ -39,7 +41,7 @@ describe('mapFooterNavigation', () => {
         title: 'Foundation',
         links: [
           { label: 'About', href: '/about' },
-          { label: 'News', href: '/news' }
+          { label: 'News', href: ROUTES.NEWS }
         ]
       }
     ];
@@ -48,9 +50,9 @@ describe('mapFooterNavigation', () => {
 
     expect(result[0].links).toEqual([
       { label: 'About', href: '/about' },
-      { label: 'News', href: '/news#news' },
-      { label: 'Events', href: '/news#events' },
-      { label: 'Media About Us', href: '/news#media' }
+      { label: 'News', href: `${ROUTES.NEWS}#news` },
+      { label: 'Events', href: `${ROUTES.NEWS}#events` },
+      { label: 'Media About Us', href: `${ROUTES.NEWS}#media` }
     ]);
   });
 
@@ -60,12 +62,12 @@ describe('mapFooterNavigation', () => {
         title: 'Foundation',
         links: [
           { label: 'About', href: '/about' },
-          { label: 'News', href: '/news' }
+          { label: 'News', href: ROUTES.NEWS }
         ]
       },
       {
         title: 'Misc',
-        links: [{ label: 'Archive', href: '/archive' }]
+        links: [{ label: 'Archive', href: ROUTES.ARCHIVE }]
       }
     ];
 
@@ -78,26 +80,26 @@ describe('mapFooterNavigation', () => {
     const sections: FooterNavSection[] = [
       {
         title: 'Foundation',
-        links: [{ label: 'News', href: '/news' }]
+        links: [{ label: 'News', href: ROUTES.NEWS }]
       },
       {
         title: 'Another',
-        links: [{ label: 'News again', href: '/news' }]
+        links: [{ label: 'News again', href: ROUTES.NEWS }]
       }
     ];
 
     const result = await mapFooterNavigation(sections);
 
     expect(result[0].links).toEqual([
-      { label: 'News', href: '/news#news' },
-      { label: 'Events', href: '/news#events' },
-      { label: 'Media About Us', href: '/news#media' }
+      { label: 'News', href: `${ROUTES.NEWS}#news` },
+      { label: 'Events', href: `${ROUTES.NEWS}#events` },
+      { label: 'Media About Us', href: `${ROUTES.NEWS}#media` }
     ]);
 
     expect(result[1].links).toEqual([
-      { label: 'News', href: '/news#news' },
-      { label: 'Events', href: '/news#events' },
-      { label: 'Media About Us', href: '/news#media' }
+      { label: 'News', href: `${ROUTES.NEWS}#news` },
+      { label: 'Events', href: `${ROUTES.NEWS}#events` },
+      { label: 'Media About Us', href: `${ROUTES.NEWS}#media` }
     ]);
   });
 });

--- a/app/lib/utils/footerNavigationMapper.ts
+++ b/app/lib/utils/footerNavigationMapper.ts
@@ -3,7 +3,9 @@ import { getTranslations } from 'next-intl/server';
 export type FooterNavLink = { label: string; href: string };
 export type FooterNavSection = { title: string; links: FooterNavLink[] };
 
-const UNIFIED_NEWS_ROUTE = '/news';
+import { ROUTES } from '~/shared/components/constants/routes';
+
+const UNIFIED_NEWS_ROUTE = ROUTES.NEWS;
 
 export async function mapFooterNavigation(sections: FooterNavSection[]): Promise<FooterNavSection[]> {
   const tNav = await getTranslations('header.navLabels');

--- a/app/lib/utils/navigationHelper.test.ts
+++ b/app/lib/utils/navigationHelper.test.ts
@@ -5,32 +5,33 @@ jest.mock('~/infrastructure/repositories/navigation/navigation.repository', () =
 import { getNavigationLink, getNavigationLinkByHref, getNavigationLinkByLabel } from './navigationHelper';
 
 import newNavigationRepository from '~/infrastructure/repositories/navigation/navigation.repository';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 const mockNavigationData = [
   {
     title: { uk: 'Борис Лятошинський', en: 'Borys Liatoshynskyi' },
     links: [
-      { label: { uk: 'Біографія', en: 'Biography' }, href: '/biography' },
-      { label: { uk: 'Дослідження', en: 'Research' }, href: '/research' },
-      { label: { uk: 'Мистецтво', en: 'Artistry' }, href: '/artistry' }
+      { label: { uk: 'Біографія', en: 'Biography' }, href: ROUTES.BIOGRAPHY },
+      { label: { uk: 'Дослідження', en: 'Research' }, href: ROUTES.RESEARCH },
+      { label: { uk: 'Мистецтво', en: 'Artistry' }, href: ROUTES.ARTISTRY }
     ]
   },
   {
     title: { uk: 'Фундація', en: 'Foundation' },
     links: [
-      { label: { uk: 'Про нас', en: 'About Us' }, href: '/about-us' },
-      { label: { uk: 'Новини', en: 'News' }, href: '/news' },
-      { label: { uk: 'Підтримати нас', en: 'Support Us' }, href: '/support-us' },
-      { label: { uk: 'Контакти', en: 'Contacts' }, href: '/contacts' }
+      { label: { uk: 'Про нас', en: 'About Us' }, href: ROUTES.ABOUT_US },
+      { label: { uk: 'Новини', en: 'News' }, href: ROUTES.NEWS },
+      { label: { uk: 'Підтримати нас', en: 'Support Us' }, href: ROUTES.SUPPORT_US },
+      { label: { uk: 'Контакти', en: 'Contacts' }, href: ROUTES.CONTACTS }
     ]
   },
   {
     title: { uk: 'Архів', en: 'Archive' },
-    links: [{ label: { uk: 'Архів', en: 'Archive' }, href: '/archive' }]
+    links: [{ label: { uk: 'Архів', en: 'Archive' }, href: ROUTES.ARCHIVE }]
   },
   {
     title: { uk: 'Співпраця', en: 'Cooperation' },
-    links: [{ label: { uk: 'Співпраця', en: 'Cooperation' }, href: '/cooperation' }]
+    links: [{ label: { uk: 'Співпраця', en: 'Cooperation' }, href: ROUTES.COOPERATION }]
   }
 ];
 
@@ -44,11 +45,11 @@ describe('navigationHelper', () => {
   });
 
   it('returns archive when href matches exactly', async () => {
-    await expect(getNavigationLinkByHref('/archive')).resolves.toBe('/archive');
+    await expect(getNavigationLinkByHref(ROUTES.ARCHIVE)).resolves.toBe(ROUTES.ARCHIVE);
   });
 
   it('returns cooperation for single-link navigation item', async () => {
-    await expect(getNavigationLinkByHref('/cooperation')).resolves.toBe('/cooperation');
+    await expect(getNavigationLinkByHref(ROUTES.COOPERATION)).resolves.toBe(ROUTES.COOPERATION);
   });
 
   it('returns undefined when href does not exist', async () => {
@@ -56,15 +57,15 @@ describe('navigationHelper', () => {
   });
 
   it('returns undefined for multi-link item when searching by href only', async () => {
-    await expect(getNavigationLinkByHref('/about-us')).resolves.toBeUndefined();
+    await expect(getNavigationLinkByHref(ROUTES.ABOUT_US)).resolves.toBeUndefined();
   });
 
   it('finds archive by Ukrainian label', async () => {
-    await expect(getNavigationLinkByLabel('Архів')).resolves.toBe('/archive');
+    await expect(getNavigationLinkByLabel('Архів')).resolves.toBe(ROUTES.ARCHIVE);
   });
 
   it('finds archive by English label', async () => {
-    await expect(getNavigationLinkByLabel('Archive')).resolves.toBe('/archive');
+    await expect(getNavigationLinkByLabel('Archive')).resolves.toBe(ROUTES.ARCHIVE);
   });
 
   it('returns undefined when label is not found', async () => {
@@ -72,7 +73,7 @@ describe('navigationHelper', () => {
   });
 
   it('falls back to label search when href does not match', async () => {
-    await expect(getNavigationLink('/non-existent', 'archive')).resolves.toBe('/archive');
+    await expect(getNavigationLink('/non-existent', 'archive')).resolves.toBe(ROUTES.ARCHIVE);
   });
 
   it('returns fallback when neither href nor label matches', async () => {
@@ -88,6 +89,6 @@ describe('navigationHelper', () => {
       getNavigation: jest.fn().mockResolvedValue([])
     });
 
-    await expect(getNavigationLink('/archive', 'archive', '/archive')).resolves.toBe('/archive');
+    await expect(getNavigationLink(ROUTES.ARCHIVE, 'archive', ROUTES.ARCHIVE)).resolves.toBe(ROUTES.ARCHIVE);
   });
 });

--- a/app/services/footer/footerService.test.ts
+++ b/app/services/footer/footerService.test.ts
@@ -1,6 +1,7 @@
 import type { Locale } from 'next-intl';
 
 import { createFooterService } from '~/services/footer/footerService';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 describe('footerService (composed)', () => {
   const mockContactInfo = {
@@ -33,7 +34,7 @@ describe('footerService (composed)', () => {
     copyright: { uk: '© 2025 Фундація', en: '© 2025 Foundation' },
     links: [
       { label: { uk: 'Політика', en: 'Privacy Policy' }, href: '/privacy' },
-      { label: { uk: 'Умови', en: 'Terms of Use' }, href: '/terms' }
+      { label: { uk: 'Умови', en: 'Terms of Use' }, href: ROUTES.TERMS }
     ]
   };
 
@@ -41,7 +42,7 @@ describe('footerService (composed)', () => {
     {
       title: { uk: 'Головна', en: 'Main' },
       links: [
-        { label: { uk: 'Дім', en: 'Home' }, href: '/', visibility: true },
+        { label: { uk: 'Дім', en: 'Home' }, href: ROUTES.HOME, visibility: true },
         { label: { uk: 'Про нас', en: 'About' }, href: '/about', visibility: true }
       ]
     }
@@ -99,14 +100,14 @@ describe('footerService (composed)', () => {
         text: '© 2025 Foundation',
         links: [
           { label: 'Privacy Policy', href: '/privacy' },
-          { label: 'Terms of Use', href: '/terms' }
+          { label: 'Terms of Use', href: ROUTES.TERMS }
         ]
       },
       navigation: [
         {
           title: 'Main',
           links: [
-            { label: 'Home', href: '/', visibility: true },
+            { label: 'Home', href: ROUTES.HOME, visibility: true },
             { label: 'About', href: '/about', visibility: true }
           ]
         }

--- a/app/services/header/headerService.test.ts
+++ b/app/services/header/headerService.test.ts
@@ -1,13 +1,14 @@
 import type { Locale } from 'next-intl';
 
 import { createHeaderService } from '~/services/header/headerService';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 describe('headerService (composed)', () => {
   const mockNavigationRaw = [
     {
       title: { uk: 'Головна', en: 'Main' },
       links: [
-        { label: { uk: 'Дім', en: 'Home' }, href: '/', visibility: true },
+        { label: { uk: 'Дім', en: 'Home' }, href: ROUTES.HOME, visibility: true },
         { label: { uk: 'Про нас', en: 'About' }, href: '/about', visibility: true }
       ]
     }
@@ -52,7 +53,7 @@ describe('headerService (composed)', () => {
         {
           title: 'Main',
           links: [
-            { label: 'Home', href: '/', visibility: true },
+            { label: 'Home', href: ROUTES.HOME, visibility: true },
             { label: 'About', href: '/about', visibility: true }
           ]
         }

--- a/app/shared/components/Footer/Footer.consts.ts
+++ b/app/shared/components/Footer/Footer.consts.ts
@@ -1,10 +1,12 @@
 import { SocialMediaTypes } from '~/types/enums/common.enums';
 
+import { ROUTES } from '~/shared/components/constants/routes';
+
 export const footerData = {
   text: '© 2025 Liotoshynsky Foundation. Всі права захищені.',
   links: [
     { label: 'Політика конфіденційності', href: '/privacy' },
-    { label: 'Умови користування сайтом', href: '/terms' },
+    { label: 'Умови користування сайтом', href: ROUTES.TERMS },
     { label: 'Інформація для медіа / партнерів', href: '/media' }
   ]
 };
@@ -19,16 +21,16 @@ export const sections = [
   {
     title: 'БОРИС ЛЯТОШИНСЬКИЙ',
     links: [
-      { label: 'Життєпис', href: '/biography' },
-      { label: 'Творчість', href: '/artistry' },
-      { label: 'Дослідження та наукові роботи', href: '/research' }
+      { label: 'Життєпис', href: ROUTES.BIOGRAPHY },
+      { label: 'Творчість', href: ROUTES.ARTISTRY },
+      { label: 'Дослідження та наукові роботи', href: ROUTES.RESEARCH }
     ]
   },
   {
     title: 'ПРО ФУНДАЦІЮ',
     links: [
-      { label: 'Про нас', href: '/about-us' },
-      { label: 'Новини', href: '/news' },
+      { label: 'Про нас', href: ROUTES.ABOUT_US },
+      { label: 'Новини', href: ROUTES.NEWS },
       { label: 'Ми у ЗМІ', href: '/media-about-us' }
     ]
   },

--- a/app/shared/components/Footer/Footer.tsx
+++ b/app/shared/components/Footer/Footer.tsx
@@ -16,6 +16,7 @@ import FooterNavigation from './FooterNavigation/FooterNavigation';
 
 import { createRequestContainer } from '~/di/container';
 import { mapFooterNavigation } from '~/lib/utils/footerNavigationMapper';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export default async function Footer() {
   const tFooter = await getTranslations('footer');
@@ -28,7 +29,7 @@ export default async function Footer() {
     .getFooterData(locale);
 
   const contactUsLink =
-    navigation?.[1]?.links?.find((link: { label: string; href: string }) => link.href === '/contacts')?.href ?? '';
+    navigation?.[1]?.links?.find((link: { label: string; href: string }) => link.href === ROUTES.CONTACTS)?.href ?? '';
 
   const enhancedNavigation = await mapFooterNavigation(navigation);
 

--- a/app/shared/components/Footer/FooterCopyrights/FooterCopyrights.test.tsx
+++ b/app/shared/components/Footer/FooterCopyrights/FooterCopyrights.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
+import { ROUTES } from '../../constants/routes';
 import FooterCopyrights from './FooterCopyrights';
 
 describe('FooterCopyrights', () => {
@@ -7,7 +8,7 @@ describe('FooterCopyrights', () => {
     text: 'Mock text',
     links: [
       { label: 'Mock Privacy', href: '/privacy' },
-      { label: 'Mock Terms', href: '/terms' }
+      { label: 'Mock Terms', href: ROUTES.TERMS }
     ]
   };
 

--- a/app/shared/components/Header/AudioPlayer/AudioPlayerPopover/AudioPlayerPopover.tsx
+++ b/app/shared/components/Header/AudioPlayer/AudioPlayerPopover/AudioPlayerPopover.tsx
@@ -8,6 +8,8 @@ import Button from '~/ds-components/button/Button';
 
 import { styles } from './AudioPlayerPopover.styles';
 import { calculateProgress, formatTime } from '~/utils/audioPlayer';
+
+import { ROUTES } from '~/shared/components/constants/routes';
 interface AudioPlayerPopoverProps {
   anchorEl: HTMLButtonElement | null;
   isPlaying: boolean;
@@ -111,7 +113,7 @@ const AudioPlayerPopover = ({
                 />
               </IconButton>
 
-              <Button fullWidth variant="contained" link="/artistry" sx={styles.allTracksButton}>
+              <Button fullWidth variant="contained" link={ROUTES.ARTISTRY} sx={styles.allTracksButton}>
                 Усі твори
               </Button>
             </Box>

--- a/app/shared/components/Header/Header.сlient.test.tsx
+++ b/app/shared/components/Header/Header.сlient.test.tsx
@@ -5,6 +5,7 @@ import Header from './Header.client';
 import { contactsData, LinkIcon } from '~/types/types/common.types';
 import { HeaderData } from '~/types/types/header.type';
 
+import { ROUTES } from '~/shared/components/constants/routes';
 import { useHideHeader } from '~/shared/hooks/use-hide-header/useHideHeader';
 import { useScrollDirection } from '~/shared/hooks/use-scroll-direction/useScrollDirection';
 
@@ -48,9 +49,9 @@ export const mockHeaderData: HeaderData = {
       title: 'Main Section',
       links: [
         { label: 'Home', href: '/home', visibility: true },
-        { label: 'News', href: '/news', visibility: true },
+        { label: 'News', href: ROUTES.NEWS, visibility: true },
         { label: 'Media', href: '/media', visibility: true },
-        { label: 'Archive', href: '/archive', visibility: true },
+        { label: 'Archive', href: ROUTES.ARCHIVE, visibility: true },
         { label: 'Collaboration', href: '/collaboration', visibility: true }
       ]
     },
@@ -58,9 +59,9 @@ export const mockHeaderData: HeaderData = {
       title: 'Other',
       links: [
         { label: 'Liatoshynsky', href: '/liatoshynsky', visibility: true },
-        { label: 'Biography', href: '/biography', visibility: true },
-        { label: 'Artistry', href: '/artistry', visibility: true },
-        { label: 'Research', href: '/research', visibility: true },
+        { label: 'Biography', href: ROUTES.BIOGRAPHY, visibility: true },
+        { label: 'Artistry', href: ROUTES.ARTISTRY, visibility: true },
+        { label: 'Research', href: ROUTES.RESEARCH, visibility: true },
         { label: 'Foundation', href: '/foundation', visibility: true }
       ]
     }

--- a/app/shared/components/blocks/BiographySection/BiographySection.data.ts
+++ b/app/shared/components/blocks/BiographySection/BiographySection.data.ts
@@ -3,6 +3,7 @@ import type { Locale } from 'next-intl';
 import { TipTapDoc } from '~/types/types/tiptap.types';
 
 import { boldText, makeDoc, normalText } from '~/lib/utils/tiptapHelpers';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 type LocalizedString = Record<Locale, string>;
 type LocalizedTipTapDoc = Record<Locale, TipTapDoc>;
@@ -22,7 +23,7 @@ export const ctaLabel: LocalizedString = {
   en: 'View Biography'
 };
 
-export const ctaHref = '/biography';
+export const ctaHref = ROUTES.BIOGRAPHY;
 
 export const text: LocalizedTipTapDoc = {
   uk: makeDoc([

--- a/app/shared/components/blocks/Liatoshynsky-office/LiatoshynskyOffice.test.tsx
+++ b/app/shared/components/blocks/Liatoshynsky-office/LiatoshynskyOffice.test.tsx
@@ -2,8 +2,10 @@ import { render, screen } from '@testing-library/react';
 import { useTranslations } from 'next-intl';
 import React from 'react';
 
+import { ROUTES } from '~/shared/components/constants/routes';
+
 jest.mock('~/lib/utils/navigationHelper', () => ({
-  getNavigationLink: jest.fn().mockResolvedValue('/archive')
+  getNavigationLink: jest.fn().mockResolvedValue(ROUTES.ARCHIVE)
 }));
 
 jest.mock('~/components/Quote/Quote', () => {
@@ -69,7 +71,7 @@ describe('LiatoshynskyOffice', () => {
   it('should render the call-to-action link with correct attributes', async () => {
     await setupComponent();
     const link = screen.getByRole('link', { name: 'Увійти до архіву' });
-    expect(link).toHaveAttribute('href', '/archive');
+    expect(link).toHaveAttribute('href', ROUTES.ARCHIVE);
   });
 
   it('should apply the correct font class to the text block', async () => {

--- a/app/shared/components/blocks/Liatoshynsky-office/LiatoshynskyOffice.tsx
+++ b/app/shared/components/blocks/Liatoshynsky-office/LiatoshynskyOffice.tsx
@@ -11,6 +11,7 @@ import { styles } from './LiatoshynskyOffice.styles';
 import { ILiatoshynskyOffice } from '~/types/page/about-us.types';
 
 import { getNavigationLink } from '~/lib/utils/navigationHelper';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 const oswald = Oswald({ weight: '700', subsets: ['latin'], display: 'swap' });
 
@@ -24,7 +25,7 @@ const LiatoshynskyOffice = async ({
   sx?: SxProps<Theme>;
 }) => {
   const { quote } = data;
-  const archiveUrl = await getNavigationLink('/archive', 'archive');
+  const archiveUrl = await getNavigationLink(ROUTES.ARCHIVE, 'archive');
 
   return (
     <Box sx={{ ...(styles.mainContainer as object), ...(sx as object) }} data-testid="LiatoshynskyOffice">

--- a/app/shared/components/blocks/actions-help/ActionsHelp.consts.ts
+++ b/app/shared/components/blocks/actions-help/ActionsHelp.consts.ts
@@ -2,6 +2,7 @@ import { TipTapMarkType, TipTapNodeTypes } from '~/types/enums/common.enums';
 import { TipTapDoc } from '~/types/types/tiptap.types';
 
 import { getNavigationLink } from '~/lib/utils/navigationHelper';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export const actionsHelpPageData = {
   title: 'Допомогти справами',
@@ -43,14 +44,14 @@ export const actionsHelpPageData = {
   ],
   paperButton: {
     text: 'Запропонувати допомогу',
-    link: '/'
+    link: ROUTES.HOME
   }
 };
 
 export async function getActionsHelpData() {
-  let link = '/';
+  let link: string = ROUTES.HOME;
   try {
-    link = await getNavigationLink('/cooperation', 'cooperation');
+    link = await getNavigationLink(ROUTES.COOPERATION, 'cooperation');
   } catch (err) {
     console.warn('Could not get navigation link:', err);
   }

--- a/app/shared/components/blocks/archive-case-details/ArchiveCaseDetails.test.tsx
+++ b/app/shared/components/blocks/archive-case-details/ArchiveCaseDetails.test.tsx
@@ -7,6 +7,8 @@ import ArchiveCaseDetails, {
   type ArchiveCaseDocument
 } from './ArchiveCaseDetails';
 
+import { getDynamicRoute } from '~/shared/components/constants/routes';
+
 jest.mock('~/shared/components/colored-svg/ColoredSvg', () => ({
   Svg: () => <span data-testid="SvgMock" />
 }));
@@ -18,13 +20,13 @@ describe('ArchiveCaseDetails', () => {
   ];
 
   const prevCase: ArchiveAdjacentCase = {
-    href: '/uk/archive/2/op1-spr2',
+    href: `/uk${getDynamicRoute.archiveCase(2, 'op1-spr2')}`,
     indexLabel: 'Ф. 2, оп. 1, спр. 2',
     title: 'Попередня справа'
   };
 
   const nextCase: ArchiveAdjacentCase = {
-    href: '/uk/archive/2/op1-spr4',
+    href: `/uk${getDynamicRoute.archiveCase(2, 'op1-spr4')}`,
     indexLabel: 'Ф. 2, оп. 1, спр. 4',
     title: 'Наступна справа'
   };
@@ -47,7 +49,7 @@ describe('ArchiveCaseDetails', () => {
     sheetsCount: 26,
     pdfUrl: 'https://example.com/f2-op1-spr3.pdf',
     documents,
-    fundHref: '/uk/archive/2',
+    fundHref: `/uk${getDynamicRoute.archiveFund(2)}`,
     prevCase,
     nextCase,
     labels

--- a/app/shared/components/blocks/archive-case-details/back-link/BackLink.test.tsx
+++ b/app/shared/components/blocks/archive-case-details/back-link/BackLink.test.tsx
@@ -2,12 +2,14 @@ import { render, screen } from '@testing-library/react';
 
 import BackLink, { type BackLinkProps } from './BackLink';
 
+import { getDynamicRoute } from '~/shared/components/constants/routes';
+
 jest.mock('~/shared/components/colored-svg/ColoredSvg', () => ({
   Svg: ({ alt }: { alt: string }) => <span data-testid="mock-svg" aria-label={alt} />
 }));
 
 const defaultProps: BackLinkProps = {
-  href: '/uk/archive/2',
+  href: `/uk${getDynamicRoute.archiveFund(2)}`,
   label: 'Повернутись'
 };
 

--- a/app/shared/components/blocks/archive-case-details/navigation/Navigation.test.tsx
+++ b/app/shared/components/blocks/archive-case-details/navigation/Navigation.test.tsx
@@ -3,19 +3,21 @@ import { render, screen } from '@testing-library/react';
 import type { ArchiveAdjacentCase } from '../ArchiveCaseDetails';
 import Navigation from './Navigation';
 
+import { getDynamicRoute } from '~/shared/components/constants/routes';
+
 jest.mock('~/shared/components/colored-svg/ColoredSvg', () => ({
   Svg: ({ alt }: { alt: string }) => <span data-testid="svg-mock" aria-label={alt} />
 }));
 
 describe('Navigation', () => {
   const prevCase: ArchiveAdjacentCase = {
-    href: '/uk/archive/fund/2/case/op1-spr2',
+    href: `/uk${getDynamicRoute.archiveCase(2, 'op1-spr2')}`,
     indexLabel: 'Ф. 2, оп. 1, спр. 2',
     title: 'Попередня справа'
   };
 
   const nextCase: ArchiveAdjacentCase = {
-    href: '/uk/archive/fund/2/case/op1-spr4',
+    href: `/uk${getDynamicRoute.archiveCase(2, 'op1-spr4')}`,
     indexLabel: 'Ф. 2, оп. 1, спр. 4',
     title: 'Наступна справа'
   };

--- a/app/shared/components/blocks/archive-case-details/pdf-button/PdfButton.test.tsx
+++ b/app/shared/components/blocks/archive-case-details/pdf-button/PdfButton.test.tsx
@@ -2,9 +2,11 @@ import { render, screen } from '@testing-library/react';
 
 import PdfButton, { type PdfButtonProps } from './PdfButton';
 
+import { getDynamicRoute } from '~/shared/components/constants/routes';
+
 describe('PdfButton', () => {
   const defaultProps: PdfButtonProps = {
-    href: '/uk/archive/fund/2/case/op1-spr2',
+    href: `/uk${getDynamicRoute.archiveCase(2, 'op1-spr2')}`,
     label: 'View PDF',
     dataTestId: 'PdfButton-test'
   };

--- a/app/shared/components/blocks/artistry-section/ArtistrySection.data.ts
+++ b/app/shared/components/blocks/artistry-section/ArtistrySection.data.ts
@@ -1,6 +1,7 @@
 import { TipTapDoc } from '~/types/types/tiptap.types';
 
 import { makeDoc, normalText } from '~/lib/utils/tiptapHelpers';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 type LocalizedTipTapDoc = {
   uk: TipTapDoc;
@@ -36,5 +37,5 @@ export const artistrySectionData = {
     uk: 'Переглянути усі твори',
     en: 'View All Compositions'
   },
-  buttonLink: '/artistry'
+  buttonLink: ROUTES.ARTISTRY
 };

--- a/app/shared/components/blocks/collaboration/collaboration-info/CollaborationInfo.tsx
+++ b/app/shared/components/blocks/collaboration/collaboration-info/CollaborationInfo.tsx
@@ -5,6 +5,7 @@ import { infoDoc, partnersDoc, partnershipDoc, supportDoc } from './collaboratio
 import { styles } from './CollaborationInfo.styles';
 
 import ButtonContentBlock from '~/shared/components/blocks/terms-of-use/terms-content/button-content-block/ButtonContentBlock';
+import { ROUTES } from '~/shared/components/constants/routes';
 import TitleContentBlock from '~/shared/components/design-system/all-components/title-content-block/TittleContentBlock';
 import SectionTitle from '~/shared/components/section-title/SectionTitle';
 
@@ -35,7 +36,7 @@ export default function CollaborationInfo() {
         textSx={styles.textStyle}
         textContainerSx={{ marginBottom: { xs: '24px', md: '0px' } }}
         buttonContainerSx={{ justifyContent: { xs: 'flex-start', md: 'flex-end' } }}
-        link="/support-us"
+        link={ROUTES.SUPPORT_US}
       />
       <TitleContentBlock
         containerSx={{ mt: { xs: '56px', sm: '96px', md: '112px' } }}

--- a/app/shared/components/blocks/cooperation-section/CooperationSection.data.ts
+++ b/app/shared/components/blocks/cooperation-section/CooperationSection.data.ts
@@ -2,6 +2,7 @@ import { partnersMock } from '../our-partners/partners.data';
 import { TipTapDoc } from '~/types/types/tiptap.types';
 
 import { makeDoc, normalText } from '~/lib/utils/tiptapHelpers';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 type LocalizedTipTapDoc = {
   uk: TipTapDoc;
@@ -31,6 +32,6 @@ export const cooperationSectionData = {
     uk: 'Долучитись до співпраці',
     en: 'Join the Partnership'
   },
-  buttonLink: '/cooperation',
+  buttonLink: ROUTES.COOPERATION,
   partners: partnersMock
 };

--- a/app/shared/components/blocks/cooperation-section/CooperationSection.test.tsx
+++ b/app/shared/components/blocks/cooperation-section/CooperationSection.test.tsx
@@ -4,6 +4,7 @@ import { partnersMock } from '../our-partners/partners.data';
 import CooperationSection from './CooperationSection';
 
 import { makeDoc, normalText } from '~/lib/utils/tiptapHelpers';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 jest.mock('next-intl', () => ({
   useLocale: () => 'en'
@@ -56,7 +57,7 @@ describe('CooperationSection', () => {
       uk: 'Детальніше',
       en: 'Learn More'
     },
-    buttonLink: '/cooperation',
+    buttonLink: ROUTES.COOPERATION,
     partners: partnersMock.slice(0, 3)
   };
 
@@ -72,7 +73,7 @@ describe('CooperationSection', () => {
 
     expect(screen.getByTestId('button-content-block')).toBeInTheDocument();
     expect(screen.getByTestId('button-link')).toHaveTextContent('Learn More');
-    expect(screen.getByTestId('button-link')).toHaveAttribute('href', '/cooperation');
+    expect(screen.getByTestId('button-link')).toHaveAttribute('href', ROUTES.COOPERATION);
   });
 
   it('should render partners slider with provided partners', () => {

--- a/app/shared/components/blocks/event-card/EventItem.fixture.ts
+++ b/app/shared/components/blocks/event-card/EventItem.fixture.ts
@@ -1,3 +1,4 @@
+import { getDynamicRoute, ROUTES } from '../../constants/routes';
 import type { EventItemProps } from './EventItem';
 
 export interface EventItemFixture {
@@ -20,11 +21,11 @@ export const MOCK_EVENT_ITEMS: EventItemFixture[] = [
         src: '/news-mock-images/events2.png',
         alt: 'Портрет композитора Бориса Лятошинського'
       },
-      href: '/uk/news/liatoshynsky-birthday-131',
+      href: `/uk${getDynamicRoute.newsItem('liatoshynsky-birthday-131')}`,
       actions: [
         {
           label: 'Детальніше',
-          href: '/uk/news/liatoshynsky-birthday-131'
+          href: `/uk${getDynamicRoute.newsItem('liatoshynsky-birthday-131')}`
         }
       ]
     }
@@ -43,15 +44,15 @@ export const MOCK_EVENT_ITEMS: EventItemFixture[] = [
         src: '/news-mock-images/events1.jpg',
         alt: 'Офіційне відкриття сайту Фундації Лятошинського'
       },
-      href: '/uk/news/foundation-website-launch',
+      href: `/uk${getDynamicRoute.newsItem('foundation-website-launch')}`,
       actions: [
         {
           label: 'Детальніше',
-          href: '/uk/news/foundation-website-launch'
+          href: `/uk${getDynamicRoute.newsItem('foundation-website-launch')}`
         },
         {
           label: 'Відвідати сайт',
-          href: '/'
+          href: ROUTES.HOME
         }
       ]
     }

--- a/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.content.ts
+++ b/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.content.ts
@@ -4,6 +4,7 @@ import { FundSummaryHeaderData } from './FundSummaryHeader';
 import { TipTapNodeTypes } from '~/types/enums/common.enums';
 
 import { getNavigationLink } from '~/lib/utils/navigationHelper';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 function createDescriptionText(ukText: string, enText: string) {
   return {
@@ -59,7 +60,7 @@ function createFundItem(ukTitle: string, enTitle: string, ukDescription: string,
 }
 
 export async function getFundSummaryHeaderBacklinkUrl(): Promise<string> {
-  return await getNavigationLink('/archive', 'archive');
+  return await getNavigationLink(ROUTES.ARCHIVE, 'archive');
 }
 
 export const fundSummaryBacklinkText: Record<Locale, string> = {

--- a/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.test.tsx
+++ b/app/shared/components/blocks/fund-summary-header/FundSummaryHeader.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { useLocale } from 'next-intl';
 import React from 'react';
 
+import { ROUTES } from '../../constants/routes';
 import { mockFundSummaryData } from './__fixtures__/fundSummaryHeader.fixtures';
 import FundSummaryHeader, { FundSummaryHeaderProps } from './FundSummaryHeader';
 import { TipTapNodeTypes } from '~/types/enums/common.enums';
@@ -54,7 +55,7 @@ jest.mock('~/ds-components/link/CustomLink', () => ({
 
 describe('FundSummaryHeader', () => {
   const mockData: FundSummaryHeaderProps = {
-    backLinkUrl: '/support-us',
+    backLinkUrl: ROUTES.SUPPORT_US,
     backLinkText: 'Back to Support Us',
     title: 'Fund Summary',
     data: mockFundSummaryData
@@ -76,7 +77,7 @@ describe('FundSummaryHeader', () => {
     render(<FundSummaryHeader {...mockData} />);
 
     const backLink = screen.getByTestId('custom-link');
-    expect(backLink).toHaveAttribute('href', '/support-us');
+    expect(backLink).toHaveAttribute('href', ROUTES.SUPPORT_US);
     expect(backLink).toHaveTextContent('Back to Support Us');
   });
 

--- a/app/shared/components/blocks/media-center/MediaCenter.test.tsx
+++ b/app/shared/components/blocks/media-center/MediaCenter.test.tsx
@@ -8,7 +8,7 @@ let searchParamsValue = new URLSearchParams('');
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
     replace: jest.fn((url: string) => {
-      const search = url.split('?')[1];
+      const search = url.includes('?') ? url.split('?')[1] : '';
       searchParamsValue = new URLSearchParams(search || '');
     })
   }),

--- a/app/shared/components/blocks/media-center/MediaCenter.tsx
+++ b/app/shared/components/blocks/media-center/MediaCenter.tsx
@@ -8,6 +8,7 @@ import { z } from 'zod';
 
 import { CustomTabs } from '~/ds-components/tabs/Tabs';
 
+import { ROUTES } from '../../constants/routes';
 import EventsTab from '../../events-tab/EventsTab';
 import { EventItemFixture, MOCK_EVENT_ITEMS } from '../event-card/EventItem.fixture';
 import { styles } from './MediaCenter.styles';
@@ -71,7 +72,7 @@ function MediaCenter({ newsData, mediaMentionsData }: Readonly<MediaCenterProps>
       const params = new URLSearchParams(searchParams.toString());
       params.set('tab', value);
 
-      router.replace(`/news?${params.toString()}`, {
+      router.replace(`${ROUTES.NEWS}?${params.toString()}`, {
         scroll: false
       });
     },

--- a/app/shared/components/blocks/news-section/NewsSection.data.tsx
+++ b/app/shared/components/blocks/news-section/NewsSection.data.tsx
@@ -1,6 +1,7 @@
 import { TipTapDoc } from '~/types/types/tiptap.types';
 
 import { makeDoc, normalText } from '~/lib/utils/tiptapHelpers';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 type LocalizedTipTapDoc = {
   uk: TipTapDoc;
@@ -30,5 +31,5 @@ export const newsSectionData = {
     uk: 'Переглянути усі новини',
     en: 'View All News'
   },
-  buttonLink: '/news'
+  buttonLink: ROUTES.NEWS
 };

--- a/app/shared/components/blocks/news-section/NewsSection.test.tsx
+++ b/app/shared/components/blocks/news-section/NewsSection.test.tsx
@@ -6,6 +6,7 @@ import NewsSection from './NewsSection';
 import { TipTapDoc } from '~/types/types/tiptap.types';
 
 import { createRequestContainer } from '~/di/container';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 // Mock dependencies
 jest.mock('next-intl/server', () => ({
@@ -92,7 +93,7 @@ const mockProps = {
     uk: 'Переглянути усі новини',
     en: 'View All News'
   },
-  buttonLink: '/news',
+  buttonLink: ROUTES.NEWS,
   locale: 'uk' as Locale
 };
 

--- a/app/shared/components/blocks/news-section/NewsSection.tsx
+++ b/app/shared/components/blocks/news-section/NewsSection.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import EmptyState from '~/ds-components/empty-state/EmptyState';
 
+import { getDynamicRoute } from '../../constants/routes';
 import { styles } from './NewsSection.styles';
 import { TipTapDoc } from '~/types/types/tiptap.types';
 
@@ -56,7 +57,7 @@ const NewsSection: React.FC<Props> = async ({ locale, title, textContent, button
       title: news.title,
       publicationDate: formattedDate,
       description: news.description,
-      href: `/news/${news.slug}`,
+      href: getDynamicRoute.newsItem(news.slug),
       dataTestId: `NewsCard-${news.slug}`
     };
   });

--- a/app/shared/components/blocks/our-partners/partners.data.ts
+++ b/app/shared/components/blocks/our-partners/partners.data.ts
@@ -1,3 +1,5 @@
+import { ROUTES } from '../../constants/routes';
+
 export interface Partner {
   id: string;
   link: string;
@@ -22,7 +24,7 @@ const partnerData: Partner[] = [
     id: 'liatoshynsky',
     name: 'Liatoshynsky Space',
     img: 'liatoshynsky-space.png',
-    link: '/'
+    link: ROUTES.HOME
   },
   {
     id: 'masterKlass',

--- a/app/shared/components/blocks/terms-of-use/terms-content/TermsContent.tsx
+++ b/app/shared/components/blocks/terms-of-use/terms-content/TermsContent.tsx
@@ -17,6 +17,7 @@ import {
 } from '../terms.const.';
 import ButtonContentBlock from './button-content-block/ButtonContentBlock';
 
+import { ROUTES } from '~/shared/components/constants/routes';
 import ContentBlock from '~/shared/components/design-system/all-components/content-block/ContentBlock';
 import { SkewedBlock } from '~/shared/components/design-system/all-components/skewed-block/SkewedBlock';
 import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
@@ -37,7 +38,7 @@ const TermsContent = () => {
       <ButtonContentBlock
         buttonText={isMobile ? t('buttons.library.short') : t('buttons.library.full')}
         buttonColor="tertiary"
-        link={'/artistry'}
+        link={ROUTES.ARTISTRY}
         content={testDoc[locale]}
         containerSx={{ marginBottom: { xs: '32px', md: '40px' } }}
         sx={{ maxWidth: { xs: '258px', sm: '308px' }, minWidth: { xs: '258px', sm: '308px' } }}
@@ -46,7 +47,7 @@ const TermsContent = () => {
       <ButtonContentBlock
         buttonText={isMobile ? t('buttons.archive.short') : t('buttons.archive.full')}
         buttonColor="tertiary"
-        link={'/archive'}
+        link={ROUTES.ARCHIVE}
         content={archiveDoc[locale]}
         containerSx={{ marginBottom: { xs: '32px', md: '40px' } }}
         sx={{

--- a/app/shared/components/blocks/terms-of-use/terms.const..ts
+++ b/app/shared/components/blocks/terms-of-use/terms.const..ts
@@ -1,6 +1,7 @@
 import { TipTapDoc } from '~/types/types/tiptap.types';
 
 import { boldText, linkText, makeDoc, normalText } from '~/lib/utils/tiptapHelpers';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 type LocalizedTipTapDoc = {
   uk: TipTapDoc;
@@ -94,11 +95,11 @@ export const rightsManagementDoc: LocalizedTipTapDoc = {
 export const privacyDoc: LocalizedTipTapDoc = {
   uk: makeDoc([
     normalText('Уся персональна інформація захищена відповідно до '),
-    linkText('Політики конфіденційності', '/privacy-policy')
+    linkText('Політики конфіденційності', ROUTES.PRIVACY_POLICY)
   ]),
   en: makeDoc([
     normalText('All personal information is protected in accordance with the '),
-    linkText('Privacy Policy', '/privacy-policy')
+    linkText('Privacy Policy', ROUTES.PRIVACY_POLICY)
   ])
 };
 
@@ -107,14 +108,14 @@ export const supportDoc: LocalizedTipTapDoc = {
     normalText(
       'Ми прагнемо забезпечити стабільну роботу сайту. Якщо ви помітили технічну помилку або маєте труднощі з доступом до матеріалів — '
     ),
-    linkText('напишіть нам', '/contacts'),
+    linkText('напишіть нам', ROUTES.CONTACTS),
     normalText('.')
   ]),
   en: makeDoc([
     normalText(
       'We strive to ensure the stable operation of the site. If you notice a technical error or have difficulty accessing the materials — '
     ),
-    linkText('contact us', '/contacts'),
+    linkText('contact us', ROUTES.CONTACTS),
     normalText('.')
   ])
 };

--- a/app/shared/components/constants/routes.ts
+++ b/app/shared/components/constants/routes.ts
@@ -1,0 +1,23 @@
+export const ROUTES = {
+  HOME: '/', // +
+  WAR_IN_UKRAINE: '/war-in-ukraine', // +
+  COOPERATION: '/cooperation', // +
+  ARCHIVE: '/archive', // +
+  ABOUT_US: '/about-us', // +
+  NEWS: '/news', // +
+  CONTACTS: '/contacts', // +
+  BIOGRAPHY: '/biography', // +
+  ARTISTRY: '/artistry', // +
+  RESEARCH: '/research', // +
+  SUPPORT_US: '/support-us', // +
+  PRIVACY_POLICY: '/privacy-policy', // +
+  TERMS: '/terms' // +
+} as const;
+
+export const getDynamicRoute = {
+  archiveFund: (id: string | number) => `${ROUTES.ARCHIVE}/${id}`,
+  archiveCase: (fundId: string | number, caseId: string | number) => `${ROUTES.ARCHIVE}/${fundId}/${caseId}`,
+  newsItem: (slug: string) => `${ROUTES.NEWS}/${slug}`
+};
+
+export type RouteValue = (typeof ROUTES)[keyof typeof ROUTES];

--- a/app/shared/components/constants/routes.ts
+++ b/app/shared/components/constants/routes.ts
@@ -1,17 +1,17 @@
 export const ROUTES = {
-  HOME: '/', // +
-  WAR_IN_UKRAINE: '/war-in-ukraine', // +
-  COOPERATION: '/cooperation', // +
-  ARCHIVE: '/archive', // +
-  ABOUT_US: '/about-us', // +
-  NEWS: '/news', // +
-  CONTACTS: '/contacts', // +
-  BIOGRAPHY: '/biography', // +
-  ARTISTRY: '/artistry', // +
-  RESEARCH: '/research', // +
-  SUPPORT_US: '/support-us', // +
-  PRIVACY_POLICY: '/privacy-policy', // +
-  TERMS: '/terms' // +
+  HOME: '/',
+  WAR_IN_UKRAINE: '/war-in-ukraine',
+  COOPERATION: '/cooperation',
+  ARCHIVE: '/archive',
+  ABOUT_US: '/about-us',
+  NEWS: '/news',
+  CONTACTS: '/contacts',
+  BIOGRAPHY: '/biography',
+  ARTISTRY: '/artistry',
+  RESEARCH: '/research',
+  SUPPORT_US: '/support-us',
+  PRIVACY_POLICY: '/privacy-policy',
+  TERMS: '/terms'
 } as const;
 
 export const getDynamicRoute = {

--- a/app/shared/components/content-slider/ContentSlider.test.tsx
+++ b/app/shared/components/content-slider/ContentSlider.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 jest.mock('swiper/css', () => ({}));
 jest.mock('swiper/css/navigation', () => ({}));
 
+import { getDynamicRoute } from '../constants/routes';
 import { ContentSlider } from './ContentSlider';
 
 // Mock Swiper components
@@ -37,7 +38,7 @@ const mockCards = [
     title: 'News Title 1',
     publicationDate: '15.01.25',
     description: 'Description 1',
-    href: '/news/news-1',
+    href: getDynamicRoute.newsItem('news-1'),
     dataTestId: 'news-card-1'
   },
   {
@@ -45,7 +46,7 @@ const mockCards = [
     title: 'News Title 2',
     publicationDate: '16.01.25',
     description: 'Description 2',
-    href: '/news/news-2',
+    href: getDynamicRoute.newsItem('news-2'),
     dataTestId: 'news-card-2'
   },
   {
@@ -53,7 +54,7 @@ const mockCards = [
     title: 'News Title 3',
     publicationDate: '17.01.25',
     description: 'Description 3',
-    href: '/news/news-3',
+    href: getDynamicRoute.newsItem('news-3'),
     dataTestId: 'news-card-3'
   }
 ];

--- a/app/shared/components/cookie-modal/modal/CookieModal.tsx
+++ b/app/shared/components/cookie-modal/modal/CookieModal.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import Button from '~/ds-components/button/Button';
 import { Modal } from '~/ds-components/modal/Modal';
 
+import { ROUTES } from '../../constants/routes';
 import { styles } from './CookieModal.styles';
 import { PositionEnum } from '~/types/enums/common.enums';
 
@@ -21,7 +22,7 @@ export const CookieModal: React.FC<CookieModalProps> = ({ open, onClose, showPre
   const t = useTranslations('cookie.modal');
 
   const renderLink = (chunks: React.ReactNode) => (
-    <Link href="/privacy-policy" style={styles.link}>
+    <Link href={ROUTES.PRIVACY_POLICY} style={styles.link}>
       {chunks}
     </Link>
   );

--- a/app/shared/components/design-system/all-components/base-card/newsAndMedia.mock.ts
+++ b/app/shared/components/design-system/all-components/base-card/newsAndMedia.mock.ts
@@ -1,5 +1,7 @@
 import type { BaseCardProps } from '~/ds-components/base-card/BaseCard';
 
+import { getDynamicRoute } from '~/shared/components/constants/routes';
+
 export const mockNewsCards: Omit<BaseCardProps, 'variant'>[] = [
   {
     image: '/images/placeholder.png',
@@ -7,7 +9,7 @@ export const mockNewsCards: Omit<BaseCardProps, 'variant'>[] = [
     publicationDate: '15.01.25',
     description:
       'Національна філармонія України запрошує на урочистий концерт, присвячений ювілею видатного композитора. У програмі - найкращі твори майстра.',
-    href: '/news/concert-130-anniversary'
+    href: getDynamicRoute.newsItem('concert-130-anniversary')
   },
   {
     image: '/images/placeholder.png',
@@ -15,7 +17,7 @@ export const mockNewsCards: Omit<BaseCardProps, 'variant'>[] = [
     publicationDate: '10.01.25',
     description:
       'Фундація представляє цифрову реставрацію історичного запису Третьої симфонії під орудою Натана Рахліна 1951 року.',
-    href: '/news/third-symphony-recording'
+    href: getDynamicRoute.newsItem('third-symphony-recording')
   },
   {
     image: '/images/placeholder.png',
@@ -23,7 +25,7 @@ export const mockNewsCards: Omit<BaseCardProps, 'variant'>[] = [
     publicationDate: '05.01.25',
     description:
       'У Національному музеї літератури відкрилась виставка рідкісних рукописів, листів та фотографій із родинного архіву композитора.',
-    href: '/news/archive-exhibition'
+    href: getDynamicRoute.newsItem('archive-exhibition')
   }
 ];
 

--- a/app/shared/components/design-system/all-components/breadcrumbs/BreadCrumbs.spec.tsx
+++ b/app/shared/components/design-system/all-components/breadcrumbs/BreadCrumbs.spec.tsx
@@ -3,6 +3,8 @@ import * as nextNavigation from 'next/navigation';
 
 import CustomBreadcrumbs from './CustomBreadCrumbs';
 
+import { ROUTES } from '~/shared/components/constants/routes';
+
 jest.mock('next/navigation', () => ({
   ...jest.requireActual('next/navigation'),
   usePathname: jest.fn()
@@ -14,7 +16,7 @@ describe('CustomBreadcrumbs', () => {
   });
 
   it('should render Custom Breadcrumbs component', () => {
-    (nextNavigation.usePathname as jest.Mock).mockReturnValue('/');
+    (nextNavigation.usePathname as jest.Mock).mockReturnValue(ROUTES.HOME);
 
     render(<CustomBreadcrumbs />);
     const breadcrumbNav = screen.getByRole('navigation');
@@ -22,7 +24,7 @@ describe('CustomBreadcrumbs', () => {
   });
 
   it('should render Home page link', () => {
-    (nextNavigation.usePathname as jest.Mock).mockReturnValue('/');
+    (nextNavigation.usePathname as jest.Mock).mockReturnValue(ROUTES.HOME);
 
     render(<CustomBreadcrumbs />);
     expect(screen.getByRole('link', { name: /home page/i })).toBeInTheDocument();
@@ -39,7 +41,7 @@ describe('CustomBreadcrumbs', () => {
     expect(screen.queryByRole('link', { name: /level3/i })).not.toBeInTheDocument();
   });
   it('should render Typography  if the element is the last in the breadcrumb', () => {
-    (nextNavigation.usePathname as jest.Mock).mockReturnValue('/about-us');
+    (nextNavigation.usePathname as jest.Mock).mockReturnValue(ROUTES.ABOUT_US);
     render(<CustomBreadcrumbs />);
     expect(screen.getByRole('link', { name: /home page/i })).toBeInTheDocument();
     const typography = screen.getByText('about-us');
@@ -47,7 +49,7 @@ describe('CustomBreadcrumbs', () => {
   });
 
   it('should renders nothing for just base path', () => {
-    (nextNavigation.usePathname as jest.Mock).mockReturnValue('/');
+    (nextNavigation.usePathname as jest.Mock).mockReturnValue(ROUTES.HOME);
 
     render(<CustomBreadcrumbs />);
     expect(screen.queryByText('not exisitng breadcrumb1')).not.toBeInTheDocument();

--- a/app/shared/components/design-system/all-components/logo/Logo.test.tsx
+++ b/app/shared/components/design-system/all-components/logo/Logo.test.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 import Logo from './Logo';
 
+import { ROUTES } from '~/shared/components/constants/routes';
+
 jest.mock('~/i18n/navigation', () => ({
   Link: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>
 }));
@@ -23,7 +25,7 @@ describe('Logo component', () => {
 
     expect(logo).toBeInTheDocument();
     expect(parent).toBeInTheDocument();
-    expect(parent).toHaveAttribute('href', '/');
+    expect(parent).toHaveAttribute('href', ROUTES.HOME);
   });
 
   it('renders office variant without link', () => {

--- a/app/shared/components/design-system/all-components/media-list/MediaList.test.tsx
+++ b/app/shared/components/design-system/all-components/media-list/MediaList.test.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 import MediaList from './MediaList';
 
+import { getDynamicRoute } from '~/shared/components/constants/routes';
+
 jest.mock('next-intl', () => ({
   useTranslations: () => (key: string) => (key === 'viewMore' ? 'Переглянути більше' : key)
 }));
@@ -86,7 +88,7 @@ describe('MediaList Component', () => {
     const cards = screen.getAllByTestId('base-card');
     expect(cards).toHaveLength(2);
     expect(cards[0]).toHaveTextContent('News 1');
-    expect(cards[0]).toHaveAttribute('data-href', '/news/1');
+    expect(cards[0]).toHaveAttribute('data-href', getDynamicRoute.newsItem('1'));
   });
 
   it('should render "Load More" button when hasMore is true', () => {

--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.test.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.test.tsx
@@ -4,9 +4,10 @@ import type { SVGProps } from 'react';
 import DesktopNav from './DesktopNav';
 
 import type { NavigationDTO } from '~/domain/dto/navigation.dto';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 jest.mock('~/i18n/navigation', () => ({
-  usePathname: jest.fn(() => '/')
+  usePathname: jest.fn(() => ROUTES.HOME)
 }));
 
 jest.mock('~/shared/components/colored-svg/ColoredSvg.tsx', () => ({
@@ -30,13 +31,13 @@ const navLabels: NavigationDTO[] = [
     title: 'Фундація',
     links: [
       { label: 'Про Фундацію', href: '/about', visibility: true },
-      { label: 'Новини', href: '/news', visibility: true },
+      { label: 'Новини', href: ROUTES.NEWS, visibility: true },
       { label: 'Медіа про нас', href: '/media', visibility: true }
     ]
   },
   {
     title: 'Архів',
-    links: [{ label: 'Архів', href: '/archive', visibility: true }]
+    links: [{ label: 'Архів', href: ROUTES.ARCHIVE, visibility: true }]
   },
   {
     title: 'Співпраця',
@@ -102,7 +103,7 @@ describe('DesktopNav', () => {
     const archiveLink = screen.getByText('Архів').closest('a');
     const collabLink = screen.getByText('Співпраця').closest('a');
 
-    expect(archiveLink).toHaveAttribute('href', '/archive');
+    expect(archiveLink).toHaveAttribute('href', ROUTES.ARCHIVE);
     expect(collabLink).toHaveAttribute('href', '/collaboration');
   });
 
@@ -110,7 +111,7 @@ describe('DesktopNav', () => {
     render(<DesktopNav navLabels={navLabels} specialNav={specialNav} scrollDirection="up" />);
     fireEvent.click(screen.getByText('Фундація'));
 
-    expect(screen.getByText('Новини').closest('a')).toHaveAttribute('href', '/news');
+    expect(screen.getByText('Новини').closest('a')).toHaveAttribute('href', ROUTES.NEWS);
     expect(screen.getByText('Медіа про нас').closest('a')).toHaveAttribute('href', '/media');
   });
 

--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
@@ -18,6 +18,7 @@ import { isPathWithin, normalizePath } from '~/lib/utils/navPath';
 import ChevronDown from '~/public/icons/chevron-down.svg';
 import ChevronUp from '~/public/icons/chevron-up.svg';
 import { Svg } from '~/shared/components/colored-svg/ColoredSvg';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 export interface DropdownItem {
   label: string;
@@ -78,7 +79,7 @@ const DesktopNav = ({
 
     if (groupIndex !== -1) {
       setActiveButton(groupIndex);
-    } else if (currentPath === '/') {
+    } else if (currentPath === ROUTES.HOME) {
       setActiveButton(1);
     } else {
       setActiveButton(undefined);

--- a/app/shared/components/events-section/EventSection.data.ts
+++ b/app/shared/components/events-section/EventSection.data.ts
@@ -1,6 +1,7 @@
 import { TipTapDoc } from '~/types/types/tiptap.types';
 
 import { makeDoc, normalText } from '~/lib/utils/tiptapHelpers';
+import { ROUTES } from '~/shared/components/constants/routes';
 
 type LocalizedTipTapDoc = {
   uk: TipTapDoc;
@@ -46,7 +47,7 @@ export const eventsCtaLabel = {
 };
 
 export const mockEventsData = {
-  ctaHref: '/news',
+  ctaHref: ROUTES.NEWS,
   events: [
     {
       id: '1',

--- a/app/shared/components/forms/contact-form/ContactForm.test.tsx
+++ b/app/shared/components/forms/contact-form/ContactForm.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
+import { ROUTES } from '../../constants/routes';
 import ContactForm from './ContactForm';
 
 jest.mock('public/icons/info-error.svg', () => {
@@ -77,7 +78,7 @@ describe('ContactForm', () => {
     if (!link) {
       throw new Error('Expected a privacy policy link to be present.');
     }
-    expect(link).toHaveAttribute('href', '/privacy-policy');
+    expect(link).toHaveAttribute('href', ROUTES.PRIVACY_POLICY);
   });
 
   it('should render a submit button', () => {

--- a/app/shared/components/forms/contact-form/ContactForm.tsx
+++ b/app/shared/components/forms/contact-form/ContactForm.tsx
@@ -12,6 +12,7 @@ import NotesConfirmModal from '~/components/get-notes-modal/notes-confirmation-m
 import ModalComponent from '~/components/modal-component/ModalComponent';
 import Button from '~/ds-components/button/Button';
 
+import { ROUTES } from '../../constants/routes';
 import PaperComponent from '../../paper-component/PaperComponent';
 import { styles } from './ContactForm.styles';
 
@@ -186,7 +187,7 @@ function ContactForm({ onSubmit, disabled = false }: Readonly<ContactFormProps>)
               label={
                 <Box>
                   <Typography variant="customItalic14" sx={styles.confidentialPolicyText}>
-                    {t('policyText')} <Link href="/privacy-policy">{t('policyLink')}</Link>
+                    {t('policyText')} <Link href={ROUTES.PRIVACY_POLICY}>{t('policyLink')}</Link>
                   </Typography>
                   {errors.policy && (
                     <FormHelperText sx={styles.checkboxError}>

--- a/app/shared/components/foundation-section/FoundationSection.data.tsx
+++ b/app/shared/components/foundation-section/FoundationSection.data.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { ROUTES } from '~/shared/components/constants/routes';
+
 type Localized<T> = {
   uk: T;
   en: T;
@@ -39,6 +41,6 @@ export const foundationButtonText: LocalizedString = {
 
 export const foundationSectionData = {
   imageSrc: '/images/foundation-section.jpg',
-  buttonLink: '/about-us',
+  buttonLink: ROUTES.ABOUT_US,
   caption: ''
 };

--- a/app/shared/components/tables/CompositionTable/MusicTableSection.test.tsx
+++ b/app/shared/components/tables/CompositionTable/MusicTableSection.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { ROUTES } from '../../constants/routes';
 import MusicTableSection from './MusicTableSection';
 
 import { useFetchStaticFilters } from '~/shared/hooks/use-fetch-static-filters/useFetchStaticFilters';
@@ -19,7 +20,7 @@ jest.mock('next-intl', () => ({
 jest.mock('~/i18n/navigation', () => ({
   Link: ({ children, href = '#' }: any) => <a href={href}>{children}</a>,
   useRouter: () => ({ push: jest.fn() }),
-  usePathname: () => '/',
+  usePathname: () => ROUTES.HOME,
   useLocale: () => 'en'
 }));
 
@@ -144,7 +145,7 @@ jest.mock('~/shared/components/get-notes-modal/GetNotesModal', () => ({
 }));
 
 jest.mock('next-intl/navigation', () => ({
-  usePathname: () => '/',
+  usePathname: () => ROUTES.HOME,
   useRouter: () => ({ push: jest.fn() }),
   useLocale: () => 'en',
   redirect: jest.fn()

--- a/app/shared/components/tables/DocumentsTable/DocumentTableSection.test.tsx
+++ b/app/shared/components/tables/DocumentsTable/DocumentTableSection.test.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import DocumentTableSection from './DocumentTableSection';
 import { DocumentRecord } from '~/types/types/document.types';
 
+import { ROUTES } from '~/shared/components/constants/routes';
+
 jest.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key
 }));
@@ -19,7 +21,7 @@ jest.mock('next/navigation', () => ({
     back: jest.fn(),
     prefetch: jest.fn()
   }),
-  usePathname: () => '/uk/archive/fund-1'
+  usePathname: () => `/uk${ROUTES.ARCHIVE}/fund-1`
 }));
 
 const mockUseBreakpoints = jest.fn();

--- a/app/shared/components/tables/WorksTable/WorkTableSection.test.tsx
+++ b/app/shared/components/tables/WorksTable/WorkTableSection.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
+import { ROUTES } from '../../constants/routes';
 import { WorkTableSection } from './WorkTableSection';
 
 import { useFetchStaticFilters } from '~/shared/hooks/use-fetch-static-filters/useFetchStaticFilters';
@@ -25,7 +26,7 @@ jest.mock('next-intl', () => ({
 jest.mock('~/i18n/navigation', () => ({
   Link: ({ children, href = '#' }: any) => <a href={href}>{children}</a>,
   useRouter: () => ({ push: jest.fn() }),
-  usePathname: () => '/',
+  usePathname: () => ROUTES.HOME,
   useLocale: () => 'en'
 }));
 

--- a/app/shared/components/under-development/UnderDevelopment.test.tsx
+++ b/app/shared/components/under-development/UnderDevelopment.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 jest.unmock('~/components/under-development/UnderDevelopment');
 
+import { ROUTES } from '../constants/routes';
 import UnderDevelopment from './UnderDevelopment';
 
 jest.mock('next-intl', () => ({
@@ -60,6 +61,6 @@ describe('UnderDevelopment component', () => {
   it('should wrap the button inside a link to "/"', () => {
     render(<UnderDevelopment />);
     const link = screen.getByRole('link', { name: 'Повернутися на головну' });
-    expect(link).toHaveAttribute('href', '/');
+    expect(link).toHaveAttribute('href', ROUTES.HOME);
   });
 });

--- a/app/shared/components/year-tabs/YearTabs.test.tsx
+++ b/app/shared/components/year-tabs/YearTabs.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
+import { ROUTES } from '../constants/routes';
 import YearTabs from './YearTabs';
 
 const MOCK_YEARS = ['2025', '2024', '2023'];
@@ -74,7 +75,7 @@ describe('YearTabs', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     ioInstances = [];
-    globalThis.history.pushState(null, '', '/');
+    globalThis.history.pushState(null, '', ROUTES.HOME);
 
     Object.defineProperty(globalThis, 'innerHeight', { value: 800, writable: true });
 

--- a/app/shared/components/year-with-line/YearWithLine.test.tsx
+++ b/app/shared/components/year-with-line/YearWithLine.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import useBreakpoints from '~/hooks/use-breakpoints/useBreakpoints';
 
 import YearWithLine from './YearWithLine';
+HTMLCanvasElement.prototype.getContext = jest.fn();
 
 jest.mock('~/hooks/use-breakpoints/useBreakpoints', () => ({
   __esModule: true,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,8 @@
 import { MetadataRoute } from 'next';
 import { headers } from 'next/headers';
 
+import { ROUTES } from '~/shared/components/constants/routes';
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const headersList = await headers();
   const hostName = headersList.get('host') ?? 'localhost:3000';
@@ -8,7 +10,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = `${protocol}://${hostName}`;
 
   const languages = ['en', 'uk'];
-  const staticPages = ['', '/artistry'];
+  const staticPages = ['', ROUTES.ARTISTRY];
 
   const staticRoutes: MetadataRoute.Sitemap = [];
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from 'react';
 import { createElement, ReactNode } from 'react';
+
+import { ROUTES } from '~/shared/components/constants/routes';
 jest.mock('swiper/css', () => ({}));
 jest.mock('swiper/css/navigation', () => ({}));
 jest.mock('swiper/css/pagination', () => ({}));
@@ -32,9 +34,9 @@ jest.mock('next-intl/navigation', () => ({
   createNavigation: () => ({
     Link: ({ children, href }: { children: ReactNode; href?: string }) => createElement('a', { href }, children),
     redirect: () => undefined,
-    usePathname: () => '/',
+    usePathname: () => ROUTES.HOME,
     useRouter: () => ({}),
-    getPathname: () => '/'
+    getPathname: () => ROUTES.HOME
   })
 }));
 


### PR DESCRIPTION
## Description

This PR centralizes the application's navigation by replacing all hardcoded URL strings with `ROUTES` constants across the `client `components, services, and tests. This refactoring ensures a single source of truth for routing and improves maintainability.

## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [X] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Run all unit tests locally (`npm run test`) to ensure everything passes successfully (1256/1256).
2. Start the development server (`npm run dev`).
3. Manually click through the main navigation menu, footer links, and call-to-action buttons (e.g., "Support Us", "Contact Us") to verify that routing works correctly.
4. Verify that dynamic routes (e.g., specific news items or archive cases) still resolve properly.

## Actual result (Before):
Routes were hardcoded as strings (e.g., `'/biography'`) throughout the codebase, making future URL updates difficult and prone to errors.

## Expected result (After):
All navigation relies on the centralized `ROUTES` object (e.g., `ROUTES.BIOGRAPHY`). The change is fully covered.

## Checklist

- [X] PR name follows the naming convention
- [X] Code compiles and runs correctly
- [X] Tests pass successfully
- [X] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [X] Branch is up to date with the target branch
- [X] Linked issue/task included
- [ ] Task moved to the review column on the board

Closes: https://github.com/Liatoshynsky-Foundation/lf-client/issues/1219
