### PR TITLE
feature: implement a single news page

### DIFF
--- a/app/[lang]/news/[slug]/page.test.tsx
+++ b/app/[lang]/news/[slug]/page.test.tsx
@@ -1,0 +1,207 @@
+import { render, screen } from '@testing-library/react';
+import { notFound } from 'next/navigation';
+
+import type { ArticleDetailProps } from '~/components/blocks/article-detail/ArticleDetail';
+
+import NewsDetailPage, { generateMetadata } from './page';
+
+import { createSeoMeta } from '~/lib/utils/createSeoMeta';
+import { formatIsoDateToDdMmYy } from '~/lib/utils/parseIsoDate';
+
+const mockGetNewsBySlug = jest.fn();
+
+let capturedArticleDetailProps: ArticleDetailProps | undefined;
+let articleDetailCallCount = 0;
+
+jest.mock('next/navigation', () => ({
+  notFound: jest.fn(() => {
+    throw new Error('NOT_FOUND');
+  })
+}));
+
+jest.mock('next-intl/server', () => ({
+  setRequestLocale: jest.fn(),
+  getLocale: jest.fn()
+}));
+
+jest.mock('~/di/container', () => ({
+  createRequestContainer: jest.fn(() => ({
+    resolve: jest.fn(() => ({
+      getNewsBySlug: mockGetNewsBySlug
+    }))
+  }))
+}));
+
+jest.mock('~/lib/utils/createSeoMeta', () => ({
+  createSeoMeta: jest.fn((config) => config)
+}));
+
+jest.mock('~/lib/utils/parseIsoDate', () => ({
+  formatIsoDateToDdMmYy: jest.fn()
+}));
+
+jest.mock('~/components/blocks/article-detail/ArticleDetail', () => ({
+  ArticleDetail: (props: ArticleDetailProps) => {
+    capturedArticleDetailProps = props;
+    articleDetailCallCount += 1;
+    return <div data-testid="ArticleDetail" />;
+  }
+}));
+
+const mockedNotFound = notFound as unknown as jest.Mock;
+const mockedCreateSeoMeta = createSeoMeta as unknown as jest.Mock;
+const mockedFormatDate = formatIsoDateToDdMmYy as jest.Mock;
+
+const mockNews = {
+  title: 'Тестова новина',
+  description: 'Опис тестової новини',
+  coverImage: { src: 'https://example.com/image.jpg', alt: 'Test' },
+  publishedAt: '2024-05-01T00:00:00.000Z',
+  content: {
+    content: {
+      blocks: [
+        { id: '1', type: 'paragraph', props: {}, content: [{ type: 'text', text: 'Hello', styles: {} }], children: [] }
+      ]
+    }
+  },
+  meta: { views: 42 }
+};
+
+describe('generateMetadata', () => {
+  beforeEach(() => {
+    mockGetNewsBySlug.mockReset();
+    mockedCreateSeoMeta.mockClear();
+  });
+
+  it('returns full metadata when news is found', async () => {
+    mockGetNewsBySlug.mockResolvedValue(mockNews);
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ lang: 'uk', slug: 'test-slug' })
+    });
+
+    expect(mockGetNewsBySlug).toHaveBeenCalledWith('test-slug', 'uk');
+    expect(mockedCreateSeoMeta).toHaveBeenCalledWith({
+      title: mockNews.title,
+      description: mockNews.description,
+      url: '/news/test-slug',
+      imageUrl: mockNews.coverImage.src,
+      locale: 'uk'
+    });
+    expect(metadata).toEqual(
+      expect.objectContaining({
+        title: mockNews.title,
+        description: mockNews.description
+      })
+    );
+  });
+
+  it('returns fallback metadata when news is not found', async () => {
+    mockGetNewsBySlug.mockResolvedValue(null);
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ lang: 'uk', slug: 'missing-slug' })
+    });
+
+    expect(mockGetNewsBySlug).toHaveBeenCalledWith('missing-slug', 'uk');
+    expect(mockedCreateSeoMeta).toHaveBeenCalledWith({
+      title: 'News not found',
+      description: '',
+      url: '/news/missing-slug',
+      locale: 'uk'
+    });
+    expect(metadata).toEqual(
+      expect.objectContaining({
+        title: 'News not found',
+        description: ''
+      })
+    );
+  });
+});
+
+describe('NewsDetailPage', () => {
+  beforeEach(() => {
+    mockGetNewsBySlug.mockReset();
+    mockedNotFound.mockClear();
+    mockedFormatDate.mockReset();
+    capturedArticleDetailProps = undefined;
+    articleDetailCallCount = 0;
+
+    const { getLocale } = jest.requireMock('next-intl/server');
+    (getLocale as jest.Mock).mockResolvedValue('uk');
+  });
+
+  it('renders ArticleDetail with correct props when news is found', async () => {
+    mockGetNewsBySlug.mockResolvedValue(mockNews);
+    mockedFormatDate.mockReturnValue('01.05.24');
+
+    const jsx = await NewsDetailPage({
+      params: Promise.resolve({ lang: 'uk', slug: 'test-slug' })
+    });
+
+    render(jsx);
+
+    expect(screen.getByTestId('ArticleDetail')).toBeInTheDocument();
+    expect(mockedNotFound).not.toHaveBeenCalled();
+    expect(articleDetailCallCount).toBe(1);
+
+    const props = capturedArticleDetailProps!;
+    expect(props.lang).toBe('uk');
+    expect(props.title).toBe(mockNews.title);
+    expect(props.date).toBe('01.05.24');
+    expect(props.views).toBe(mockNews.meta.views);
+    expect(props.coverImage).toEqual(mockNews.coverImage);
+    expect(props.blocks).toEqual(mockNews.content.content.blocks);
+  });
+
+  it('calls notFound when news is not found', async () => {
+    mockGetNewsBySlug.mockResolvedValue(null);
+
+    await expect(NewsDetailPage({ params: Promise.resolve({ lang: 'uk', slug: 'missing-slug' }) })).rejects.toThrow(
+      'NOT_FOUND'
+    );
+
+    expect(mockedNotFound).toHaveBeenCalledTimes(1);
+    expect(articleDetailCallCount).toBe(0);
+  });
+
+  it('passes empty blocks array when content.blocks is missing', async () => {
+    mockGetNewsBySlug.mockResolvedValue({ ...mockNews, content: {} });
+    mockedFormatDate.mockReturnValue('01.05.24');
+
+    const jsx = await NewsDetailPage({
+      params: Promise.resolve({ lang: 'uk', slug: 'test-slug' })
+    });
+
+    render(jsx);
+
+    expect(capturedArticleDetailProps!.blocks).toEqual([]);
+  });
+
+  it('passes empty string as date when publishedAt is null', async () => {
+    mockGetNewsBySlug.mockResolvedValue({ ...mockNews, publishedAt: null });
+    mockedFormatDate.mockReturnValue(null);
+
+    const jsx = await NewsDetailPage({
+      params: Promise.resolve({ lang: 'uk', slug: 'test-slug' })
+    });
+
+    render(jsx);
+
+    expect(capturedArticleDetailProps!.date).toBe('');
+    expect(mockedFormatDate).not.toHaveBeenCalled();
+  });
+
+  it('uses locale from getLocale for fetching news', async () => {
+    const { getLocale } = jest.requireMock('next-intl/server');
+    (getLocale as jest.Mock).mockResolvedValue('en');
+    mockGetNewsBySlug.mockResolvedValue(mockNews);
+    mockedFormatDate.mockReturnValue('01.05.24');
+
+    await NewsDetailPage({
+      params: Promise.resolve({ lang: 'uk', slug: 'test-slug' })
+    });
+
+    expect(mockGetNewsBySlug).toHaveBeenCalledWith('test-slug', 'en');
+  });
+});

--- a/app/[lang]/news/[slug]/page.test.tsx
+++ b/app/[lang]/news/[slug]/page.test.tsx
@@ -149,8 +149,6 @@ describe('NewsDetailPage', () => {
     expect(props.lang).toBe('uk');
     expect(props.title).toBe(mockNews.title);
     expect(props.date).toBe('01.05.24');
-    expect(props.views).toBe(mockNews.meta.views);
-    expect(props.coverImage).toEqual(mockNews.coverImage);
     expect(props.blocks).toEqual(mockNews.content.content.blocks);
   });
 

--- a/app/[lang]/news/[slug]/page.tsx
+++ b/app/[lang]/news/[slug]/page.tsx
@@ -1,0 +1,68 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import type { Locale } from 'next-intl';
+import { getLocale, setRequestLocale } from 'next-intl/server';
+
+import { ArticleDetail } from '~/components/blocks/article-detail/ArticleDetail';
+import type { BlockNoteBlock } from '~/components/blocks/article-detail/BlockNoteContent';
+
+import { createRequestContainer } from '~/di/container';
+import { createSeoMeta } from '~/lib/utils/createSeoMeta';
+import { formatIsoDateToDdMmYy } from '~/lib/utils/parseIsoDate';
+
+type NewsDetailPageParams = { lang: Locale; slug: string };
+type NewsDetailPageProps = { params: Promise<NewsDetailPageParams> };
+
+export async function generateMetadata({ params }: Readonly<NewsDetailPageProps>): Promise<Metadata> {
+  const { lang, slug } = await params;
+  setRequestLocale(lang);
+
+  const container = createRequestContainer();
+  const newsService = container.resolve('newsService');
+  const news = await newsService.getNewsBySlug(slug, lang);
+
+  if (!news) {
+    return createSeoMeta({
+      title: 'News not found',
+      description: '',
+      url: `/news/${slug}`,
+      locale: lang
+    });
+  }
+
+  return createSeoMeta({
+    title: news.title,
+    description: news.description,
+    url: `/news/${slug}`,
+    imageUrl: news.coverImage.src,
+    locale: lang
+  });
+}
+
+export default async function NewsDetailPage({ params }: Readonly<NewsDetailPageProps>) {
+  const { lang, slug } = await params;
+  setRequestLocale(lang);
+  const locale = await getLocale();
+
+  const container = createRequestContainer();
+  const newsService = container.resolve('newsService');
+
+  const news = await newsService.getNewsBySlug(slug, locale as Locale);
+
+  if (!news) notFound();
+
+  const displayDate = news.publishedAt ? (formatIsoDateToDdMmYy(news.publishedAt) ?? '') : '';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const blocks = ((news.content as any)?.content?.blocks ?? []) as BlockNoteBlock[];
+
+  return (
+    <ArticleDetail
+      lang={lang}
+      coverImage={news.coverImage}
+      date={displayDate}
+      views={news.meta.views}
+      title={news.title}
+      blocks={blocks}
+    />
+  );
+}

--- a/app/[lang]/news/[slug]/page.tsx
+++ b/app/[lang]/news/[slug]/page.tsx
@@ -55,14 +55,5 @@ export default async function NewsDetailPage({ params }: Readonly<NewsDetailPage
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const blocks = ((news.content as any)?.content?.blocks ?? []) as BlockNoteBlock[];
 
-  return (
-    <ArticleDetail
-      lang={lang}
-      coverImage={news.coverImage}
-      date={displayDate}
-      views={news.meta.views}
-      title={news.title}
-      blocks={blocks}
-    />
-  );
+  return <ArticleDetail lang={lang} date={displayDate} title={news.title} blocks={blocks} />;
 }

--- a/app/shared/components/blocks/article-detail/ArticleDetail.test.tsx
+++ b/app/shared/components/blocks/article-detail/ArticleDetail.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+
+import { ArticleDetail } from './ArticleDetail';
+import type { BlockNoteBlock } from './BlockNoteContent';
+
+let capturedBlockNoteBlocks: BlockNoteBlock[] | undefined;
+
+jest.mock('~/layouts/main-layout/MainLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="MainLayout">{children}</div>
+}));
+
+jest.mock('~/ds-components/link/CustomLink', () => ({
+  __esModule: true,
+  default: ({ children, path }: { children: React.ReactNode; path: string }) => (
+    <a data-testid="BackLink" href={path}>
+      {children}
+    </a>
+  )
+}));
+
+jest.mock('~/shared/components/svg-image/SvgImage', () => ({
+  SvgImage: () => <span data-testid="SvgImage" />
+}));
+
+jest.mock('./BlockNoteContent', () => ({
+  BlockNoteContent: ({ blocks }: { blocks: BlockNoteBlock[] }) => {
+    capturedBlockNoteBlocks = blocks;
+    return <div data-testid="BlockNoteContent" />;
+  }
+}));
+
+const mockBlocks: BlockNoteBlock[] = [
+  { id: '1', type: 'paragraph', props: {}, content: [{ type: 'text', text: 'Hello', styles: {} }], children: [] },
+  {
+    id: '2',
+    type: 'heading',
+    props: { level: 2 },
+    content: [{ type: 'text', text: 'Section', styles: {} }],
+    children: []
+  }
+];
+
+const baseProps = {
+  lang: 'uk',
+  coverImage: { src: 'https://example.com/image.jpg', alt: 'Cover' },
+  title: 'Лятошинський. 30 років після запису',
+  blocks: mockBlocks
+};
+
+describe('ArticleDetail', () => {
+  beforeEach(() => {
+    capturedBlockNoteBlocks = undefined;
+  });
+
+  it('renders inside MainLayout', () => {
+    render(<ArticleDetail {...baseProps} />);
+    expect(screen.getByTestId('MainLayout')).toBeInTheDocument();
+  });
+
+  it('renders the article title', () => {
+    render(<ArticleDetail {...baseProps} />);
+    expect(screen.getByText(baseProps.title)).toBeInTheDocument();
+  });
+
+  it('renders the back link with correct path for lang', () => {
+    render(<ArticleDetail {...baseProps} lang="uk" />);
+    const link = screen.getByTestId('BackLink');
+    expect(link).toHaveAttribute('href', '/uk/news');
+  });
+
+  it('renders the back link with correct path for different lang', () => {
+    render(<ArticleDetail {...baseProps} lang="en" />);
+    const link = screen.getByTestId('BackLink');
+    expect(link).toHaveAttribute('href', '/en/news');
+  });
+
+  it('renders publication date with prefix when date is provided', () => {
+    render(<ArticleDetail {...baseProps} date="01.05.24" />);
+    expect(screen.getByText(/Опубліковано:.*01\.05\.24/)).toBeInTheDocument();
+  });
+
+  it('renders without crashing when date is not provided', () => {
+    render(<ArticleDetail {...baseProps} date={undefined} />);
+    expect(screen.getByText(baseProps.title)).toBeInTheDocument();
+  });
+
+  it('passes blocks to BlockNoteContent', () => {
+    render(<ArticleDetail {...baseProps} />);
+    expect(screen.getByTestId('BlockNoteContent')).toBeInTheDocument();
+    expect(capturedBlockNoteBlocks).toEqual(mockBlocks);
+  });
+
+  it('passes empty blocks array to BlockNoteContent when blocks is empty', () => {
+    render(<ArticleDetail {...baseProps} blocks={[]} />);
+    expect(capturedBlockNoteBlocks).toEqual([]);
+  });
+});

--- a/app/shared/components/blocks/article-detail/ArticleDetail.tsx
+++ b/app/shared/components/blocks/article-detail/ArticleDetail.tsx
@@ -11,14 +11,12 @@ import { SvgImage } from '~/shared/components/svg-image/SvgImage';
 
 export type ArticleDetailProps = {
   lang: string;
-  coverImage: { src: string; alt: string };
   date?: string;
-  views?: number;
   title: string;
   blocks: BlockNoteBlock[];
 };
 
-export function ArticleDetail({ lang, date, title, blocks }: ArticleDetailProps) {
+export function ArticleDetail({ lang, date, title, blocks }: Readonly<ArticleDetailProps>) {
   return (
     <MainLayout withLines>
       <Box sx={styles.newsHeader}>

--- a/app/shared/components/blocks/article-detail/ArticleDetail.tsx
+++ b/app/shared/components/blocks/article-detail/ArticleDetail.tsx
@@ -1,0 +1,47 @@
+import { Box, Typography } from '@mui/material';
+
+import CustomLink from '~/ds-components/link/CustomLink';
+
+import { styles } from './ArticleDetails.styles';
+import type { BlockNoteBlock } from './BlockNoteContent';
+import { BlockNoteContent } from './BlockNoteContent';
+
+import MainLayout from '~/layouts/main-layout/MainLayout';
+import { SvgImage } from '~/shared/components/svg-image/SvgImage';
+
+export type ArticleDetailProps = {
+  lang: string;
+  coverImage: { src: string; alt: string };
+  date?: string;
+  views?: number;
+  title: string;
+  blocks: BlockNoteBlock[];
+};
+
+export function ArticleDetail({ lang, date, title, blocks }: ArticleDetailProps) {
+  return (
+    <MainLayout withLines>
+      <Box sx={styles.newsHeader}>
+        <CustomLink
+          sx={styles.backLink}
+          labelSx={styles.backLinkLabel}
+          path={`/${lang}/news`}
+          startIcon={<SvgImage src="/icons/arrow-left.svg" alt="" width={24} height={24} />}
+        >
+          Повернутись до новин
+        </CustomLink>
+        <Box sx={styles.newsHeaderTopRow}>
+          <Typography variant="h1" sx={styles.newsTitle}>
+            {title}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={styles.publicDate}>
+            Опубліковано: {date}
+          </Typography>
+        </Box>
+      </Box>
+      <Box sx={styles.container}>
+        <BlockNoteContent blocks={blocks} />
+      </Box>
+    </MainLayout>
+  );
+}

--- a/app/shared/components/blocks/article-detail/ArticleDetails.styles.ts
+++ b/app/shared/components/blocks/article-detail/ArticleDetails.styles.ts
@@ -1,0 +1,59 @@
+export const styles = {
+  container: {
+    gridColumn: '1 / -1',
+    width: { xs: '100%', sm: '80%', md: '57%' },
+    marginLeft: { xs: 0, sm: 'auto', md: 'auto' },
+    marginRight: { xs: 0, sm: 'auto', md: 0 },
+    mb: { xs: '80px', md: '130px' },
+    '& .MuiTypography-body1': {
+      fontFamily: 'Mulish',
+      fontWeight: 400,
+      lineHeight: '160%',
+      fontSize: '20px'
+    }
+  },
+  newsHeader: {
+    gridColumn: '1 / -1',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    gap: { xs: '12px', md: '24px' },
+    mb: { xs: '32px', md: '64px' },
+    mt: { xs: '50px', md: '97px' }
+  },
+  newsHeaderTopRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    flexDirection: { xs: 'column', md: 'row' },
+    alignItems: 'center',
+    width: '100%'
+  },
+  newsTitle: {
+    fontFamily: 'Mulish',
+    fontWeight: 600,
+    fontSize: { xs: '24px', md: '40px' },
+    lineHeight: '150%',
+    textTransform: 'uppercase',
+    mt: 0,
+    mb: 0
+  },
+  content: {},
+  backLink: {
+    paddingLeft: 0
+  },
+  backLinkLabel: {
+    fontFamily: 'Mulish',
+    fontWeight: 500,
+    fontSize: { xs: '12px', md: '16px' },
+    lineHeight: '150%'
+  },
+  publicDate: {
+    whiteSpace: 'nowrap',
+    flexShrink: 0,
+    fontFamily: 'Mulish',
+    fontWeight: 500,
+    fontSize: { xs: '12px', md: '16px' },
+    lineHeight: '150%'
+  }
+};

--- a/app/shared/components/blocks/article-detail/ArticleDetails.styles.ts
+++ b/app/shared/components/blocks/article-detail/ArticleDetails.styles.ts
@@ -1,3 +1,10 @@
+const smallLabel = {
+  fontFamily: 'Mulish',
+  fontWeight: 500,
+  fontSize: { xs: '12px', md: '16px' },
+  lineHeight: '150%'
+} as const;
+
 export const styles = {
   container: {
     gridColumn: '1 / -1',
@@ -38,22 +45,13 @@ export const styles = {
     mt: 0,
     mb: 0
   },
-  content: {},
   backLink: {
     paddingLeft: 0
   },
-  backLinkLabel: {
-    fontFamily: 'Mulish',
-    fontWeight: 500,
-    fontSize: { xs: '12px', md: '16px' },
-    lineHeight: '150%'
-  },
+  backLinkLabel: smallLabel,
   publicDate: {
+    ...smallLabel,
     whiteSpace: 'nowrap',
-    flexShrink: 0,
-    fontFamily: 'Mulish',
-    fontWeight: 500,
-    fontSize: { xs: '12px', md: '16px' },
-    lineHeight: '150%'
+    flexShrink: 0
   }
 };

--- a/app/shared/components/blocks/article-detail/BlockNoteContent.test.tsx
+++ b/app/shared/components/blocks/article-detail/BlockNoteContent.test.tsx
@@ -15,11 +15,16 @@ const makeBlock = (overrides: Partial<BlockNoteBlock> & Pick<BlockNoteBlock, 'ty
   ...overrides
 });
 
+const inlineText = (text: string, styles = {}) => ({ type: 'text' as const, text, styles });
+
 const textBlock = (text: string, styles = {}): BlockNoteBlock =>
-  makeBlock({
-    type: 'paragraph',
-    content: [{ type: 'text', text, styles }]
-  });
+  makeBlock({ type: 'paragraph', content: [inlineText(text, styles)] });
+
+const headingBlock = (level: number, text: string): BlockNoteBlock =>
+  makeBlock({ type: 'heading', props: { level }, content: [inlineText(text)] });
+
+const listItemBlock = (type: 'bulletListItem' | 'numberedListItem', text: string, id = 'test-id'): BlockNoteBlock =>
+  makeBlock({ id, type, content: [inlineText(text)] });
 
 describe('BlockNoteContent', () => {
   describe('empty state', () => {
@@ -84,9 +89,7 @@ describe('BlockNoteContent', () => {
     it('renders link with correct href', () => {
       const block = makeBlock({
         type: 'paragraph',
-        content: [
-          { type: 'link', href: 'https://example.com', content: [{ type: 'text', text: 'Click me', styles: {} }] }
-        ]
+        content: [{ type: 'link', href: 'https://example.com', content: [inlineText('Click me')] }]
       });
       render(<BlockNoteContent blocks={[block]} />);
       const link = screen.getByRole('link', { name: 'Click me' });
@@ -96,7 +99,7 @@ describe('BlockNoteContent', () => {
     it('renders link with target="_blank" and rel="noopener noreferrer"', () => {
       const block = makeBlock({
         type: 'paragraph',
-        content: [{ type: 'link', href: 'https://example.com', content: [{ type: 'text', text: 'Link', styles: {} }] }]
+        content: [{ type: 'link', href: 'https://example.com', content: [inlineText('Link')] }]
       });
       render(<BlockNoteContent blocks={[block]} />);
       const link = screen.getByRole('link', { name: 'Link' });
@@ -107,52 +110,29 @@ describe('BlockNoteContent', () => {
 
   describe('headings', () => {
     it('renders heading level 1 as h1', () => {
-      const block = makeBlock({
-        type: 'heading',
-        props: { level: 1 },
-        content: [{ type: 'text', text: 'Title H1', styles: {} }]
-      });
-      render(<BlockNoteContent blocks={[block]} />);
+      render(<BlockNoteContent blocks={[headingBlock(1, 'Title H1')]} />);
       expect(screen.getByRole('heading', { level: 1, name: 'Title H1' })).toBeInTheDocument();
     });
 
     it('renders heading level 2 as h2', () => {
-      const block = makeBlock({
-        type: 'heading',
-        props: { level: 2 },
-        content: [{ type: 'text', text: 'Title H2', styles: {} }]
-      });
-      render(<BlockNoteContent blocks={[block]} />);
+      render(<BlockNoteContent blocks={[headingBlock(2, 'Title H2')]} />);
       expect(screen.getByRole('heading', { level: 2, name: 'Title H2' })).toBeInTheDocument();
     });
 
     it('renders heading level 3 as h3', () => {
-      const block = makeBlock({
-        type: 'heading',
-        props: { level: 3 },
-        content: [{ type: 'text', text: 'Title H3', styles: {} }]
-      });
-      render(<BlockNoteContent blocks={[block]} />);
+      render(<BlockNoteContent blocks={[headingBlock(3, 'Title H3')]} />);
       expect(screen.getByRole('heading', { level: 3, name: 'Title H3' })).toBeInTheDocument();
     });
 
     it('caps heading level at h3 for level > 3', () => {
-      const block = makeBlock({
-        type: 'heading',
-        props: { level: 5 },
-        content: [{ type: 'text', text: 'Title H5', styles: {} }]
-      });
-      render(<BlockNoteContent blocks={[block]} />);
+      render(<BlockNoteContent blocks={[headingBlock(5, 'Title H5')]} />);
       expect(screen.getByRole('heading', { level: 3, name: 'Title H5' })).toBeInTheDocument();
     });
   });
 
   describe('bullet list', () => {
     it('renders bullet list items inside <ul>', () => {
-      const blocks = [
-        makeBlock({ id: '1', type: 'bulletListItem', content: [{ type: 'text', text: 'Item A', styles: {} }] }),
-        makeBlock({ id: '2', type: 'bulletListItem', content: [{ type: 'text', text: 'Item B', styles: {} }] })
-      ];
+      const blocks = [listItemBlock('bulletListItem', 'Item A', '1'), listItemBlock('bulletListItem', 'Item B', '2')];
       render(<BlockNoteContent blocks={blocks} />);
       expect(document.querySelector('ul')).toBeInTheDocument();
       expect(screen.getByText('Item A')).toBeInTheDocument();
@@ -161,9 +141,9 @@ describe('BlockNoteContent', () => {
 
     it('groups consecutive bullet items into one <ul>', () => {
       const blocks = [
-        makeBlock({ id: '1', type: 'bulletListItem', content: [{ type: 'text', text: 'A', styles: {} }] }),
-        makeBlock({ id: '2', type: 'bulletListItem', content: [{ type: 'text', text: 'B', styles: {} }] }),
-        makeBlock({ id: '3', type: 'bulletListItem', content: [{ type: 'text', text: 'C', styles: {} }] })
+        listItemBlock('bulletListItem', 'A', '1'),
+        listItemBlock('bulletListItem', 'B', '2'),
+        listItemBlock('bulletListItem', 'C', '3')
       ];
       render(<BlockNoteContent blocks={blocks} />);
       expect(document.querySelectorAll('ul')).toHaveLength(1);
@@ -171,24 +151,20 @@ describe('BlockNoteContent', () => {
 
     it('creates separate <ul> groups when separated by a paragraph', () => {
       const blocks = [
-        makeBlock({ id: '1', type: 'bulletListItem', content: [{ type: 'text', text: 'A', styles: {} }] }),
+        listItemBlock('bulletListItem', 'A', '1'),
         textBlock('Paragraph between'),
-        makeBlock({ id: '3', type: 'bulletListItem', content: [{ type: 'text', text: 'B', styles: {} }] })
+        listItemBlock('bulletListItem', 'B', '3')
       ];
       render(<BlockNoteContent blocks={blocks} />);
       expect(document.querySelectorAll('ul')).toHaveLength(2);
     });
 
     it('renders nested children inside bullet list item', () => {
-      const childBlock = makeBlock({
-        id: 'child',
-        type: 'bulletListItem',
-        content: [{ type: 'text', text: 'Nested', styles: {} }]
-      });
+      const childBlock = listItemBlock('bulletListItem', 'Nested', 'child');
       const block = makeBlock({
         id: 'parent',
         type: 'bulletListItem',
-        content: [{ type: 'text', text: 'Parent', styles: {} }],
+        content: [inlineText('Parent')],
         children: [childBlock]
       });
       render(<BlockNoteContent blocks={[block]} />);
@@ -199,8 +175,8 @@ describe('BlockNoteContent', () => {
   describe('numbered list', () => {
     it('renders numbered list items inside <ol>', () => {
       const blocks = [
-        makeBlock({ id: '1', type: 'numberedListItem', content: [{ type: 'text', text: 'Step 1', styles: {} }] }),
-        makeBlock({ id: '2', type: 'numberedListItem', content: [{ type: 'text', text: 'Step 2', styles: {} }] })
+        listItemBlock('numberedListItem', 'Step 1', '1'),
+        listItemBlock('numberedListItem', 'Step 2', '2')
       ];
       render(<BlockNoteContent blocks={blocks} />);
       expect(document.querySelector('ol')).toBeInTheDocument();
@@ -209,10 +185,7 @@ describe('BlockNoteContent', () => {
     });
 
     it('creates separate groups for bullet and numbered lists', () => {
-      const blocks = [
-        makeBlock({ id: '1', type: 'bulletListItem', content: [{ type: 'text', text: 'Bullet', styles: {} }] }),
-        makeBlock({ id: '2', type: 'numberedListItem', content: [{ type: 'text', text: 'Number', styles: {} }] })
-      ];
+      const blocks = [listItemBlock('bulletListItem', 'Bullet', '1'), listItemBlock('numberedListItem', 'Number', '2')];
       render(<BlockNoteContent blocks={blocks} />);
       expect(document.querySelector('ul')).toBeInTheDocument();
       expect(document.querySelector('ol')).toBeInTheDocument();
@@ -221,33 +194,21 @@ describe('BlockNoteContent', () => {
 
   describe('checkListItem', () => {
     it('renders checked checkbox', () => {
-      const block = makeBlock({
-        type: 'checkListItem',
-        props: { checked: true },
-        content: [{ type: 'text', text: 'Done', styles: {} }]
-      });
+      const block = makeBlock({ type: 'checkListItem', props: { checked: true }, content: [inlineText('Done')] });
       render(<BlockNoteContent blocks={[block]} />);
       const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
       expect(checkbox.checked).toBe(true);
     });
 
     it('renders unchecked checkbox', () => {
-      const block = makeBlock({
-        type: 'checkListItem',
-        props: { checked: false },
-        content: [{ type: 'text', text: 'Todo', styles: {} }]
-      });
+      const block = makeBlock({ type: 'checkListItem', props: { checked: false }, content: [inlineText('Todo')] });
       render(<BlockNoteContent blocks={[block]} />);
       const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
       expect(checkbox.checked).toBe(false);
     });
 
     it('renders checkbox as readOnly', () => {
-      const block = makeBlock({
-        type: 'checkListItem',
-        props: { checked: true },
-        content: [{ type: 'text', text: 'Task', styles: {} }]
-      });
+      const block = makeBlock({ type: 'checkListItem', props: { checked: true }, content: [inlineText('Task')] });
       render(<BlockNoteContent blocks={[block]} />);
       expect(screen.getByRole('checkbox')).toHaveAttribute('readOnly');
     });
@@ -286,7 +247,7 @@ describe('BlockNoteContent', () => {
 
   describe('unknown block type', () => {
     it('renders inline content for unknown type', () => {
-      const block = makeBlock({ type: 'unknown', content: [{ type: 'text', text: 'Fallback text', styles: {} }] });
+      const block = makeBlock({ type: 'unknown', content: [inlineText('Fallback text')] });
       render(<BlockNoteContent blocks={[block]} />);
       expect(screen.getByText('Fallback text')).toBeInTheDocument();
     });

--- a/app/shared/components/blocks/article-detail/BlockNoteContent.test.tsx
+++ b/app/shared/components/blocks/article-detail/BlockNoteContent.test.tsx
@@ -1,0 +1,300 @@
+import { render, screen } from '@testing-library/react';
+
+import { type BlockNoteBlock, BlockNoteContent } from './BlockNoteContent';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} data-testid="next-image" />
+}));
+
+const makeBlock = (overrides: Partial<BlockNoteBlock> & Pick<BlockNoteBlock, 'type'>): BlockNoteBlock => ({
+  id: 'test-id',
+  props: {},
+  content: [],
+  children: [],
+  ...overrides
+});
+
+const textBlock = (text: string, styles = {}): BlockNoteBlock =>
+  makeBlock({
+    type: 'paragraph',
+    content: [{ type: 'text', text, styles }]
+  });
+
+describe('BlockNoteContent', () => {
+  describe('empty state', () => {
+    it('renders without crashing when blocks is empty', () => {
+      const { container } = render(<BlockNoteContent blocks={[]} />);
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+
+  describe('paragraph', () => {
+    it('renders paragraph text', () => {
+      render(<BlockNoteContent blocks={[textBlock('Hello world')]} />);
+      expect(screen.getByText('Hello world')).toBeInTheDocument();
+    });
+
+    it('renders paragraph as <p> element', () => {
+      render(<BlockNoteContent blocks={[textBlock('Paragraph text')]} />);
+      expect(screen.getByText('Paragraph text').tagName).toBe('P');
+    });
+  });
+
+  describe('text styles', () => {
+    it('renders bold text inside <strong>', () => {
+      render(<BlockNoteContent blocks={[textBlock('Bold', { bold: true })]} />);
+      expect(document.querySelector('strong')).toHaveTextContent('Bold');
+    });
+
+    it('renders italic text inside <em>', () => {
+      render(<BlockNoteContent blocks={[textBlock('Italic', { italic: true })]} />);
+      expect(document.querySelector('em')).toHaveTextContent('Italic');
+    });
+
+    it('renders underlined text inside <u>', () => {
+      render(<BlockNoteContent blocks={[textBlock('Underline', { underline: true })]} />);
+      expect(document.querySelector('u')).toHaveTextContent('Underline');
+    });
+
+    it('renders strikethrough text inside <s>', () => {
+      render(<BlockNoteContent blocks={[textBlock('Strike', { strikethrough: true })]} />);
+      expect(document.querySelector('s')).toHaveTextContent('Strike');
+    });
+
+    it('renders code text inside <code>', () => {
+      render(<BlockNoteContent blocks={[textBlock('const x = 1', { code: true })]} />);
+      expect(document.querySelector('code')).toHaveTextContent('const x = 1');
+    });
+
+    it('renders combined bold and italic styles', () => {
+      render(<BlockNoteContent blocks={[textBlock('BoldItalic', { bold: true, italic: true })]} />);
+      expect(document.querySelector('em strong')).toHaveTextContent('BoldItalic');
+    });
+
+    it('renders plain text without wrapper tags when no styles', () => {
+      render(<BlockNoteContent blocks={[textBlock('Plain')]} />);
+      expect(screen.getByText('Plain')).toBeInTheDocument();
+      expect(document.querySelector('strong')).toBeNull();
+      expect(document.querySelector('em')).toBeNull();
+    });
+  });
+
+  describe('links', () => {
+    it('renders link with correct href', () => {
+      const block = makeBlock({
+        type: 'paragraph',
+        content: [
+          { type: 'link', href: 'https://example.com', content: [{ type: 'text', text: 'Click me', styles: {} }] }
+        ]
+      });
+      render(<BlockNoteContent blocks={[block]} />);
+      const link = screen.getByRole('link', { name: 'Click me' });
+      expect(link).toHaveAttribute('href', 'https://example.com');
+    });
+
+    it('renders link with target="_blank" and rel="noopener noreferrer"', () => {
+      const block = makeBlock({
+        type: 'paragraph',
+        content: [{ type: 'link', href: 'https://example.com', content: [{ type: 'text', text: 'Link', styles: {} }] }]
+      });
+      render(<BlockNoteContent blocks={[block]} />);
+      const link = screen.getByRole('link', { name: 'Link' });
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+  });
+
+  describe('headings', () => {
+    it('renders heading level 1 as h1', () => {
+      const block = makeBlock({
+        type: 'heading',
+        props: { level: 1 },
+        content: [{ type: 'text', text: 'Title H1', styles: {} }]
+      });
+      render(<BlockNoteContent blocks={[block]} />);
+      expect(screen.getByRole('heading', { level: 1, name: 'Title H1' })).toBeInTheDocument();
+    });
+
+    it('renders heading level 2 as h2', () => {
+      const block = makeBlock({
+        type: 'heading',
+        props: { level: 2 },
+        content: [{ type: 'text', text: 'Title H2', styles: {} }]
+      });
+      render(<BlockNoteContent blocks={[block]} />);
+      expect(screen.getByRole('heading', { level: 2, name: 'Title H2' })).toBeInTheDocument();
+    });
+
+    it('renders heading level 3 as h3', () => {
+      const block = makeBlock({
+        type: 'heading',
+        props: { level: 3 },
+        content: [{ type: 'text', text: 'Title H3', styles: {} }]
+      });
+      render(<BlockNoteContent blocks={[block]} />);
+      expect(screen.getByRole('heading', { level: 3, name: 'Title H3' })).toBeInTheDocument();
+    });
+
+    it('caps heading level at h3 for level > 3', () => {
+      const block = makeBlock({
+        type: 'heading',
+        props: { level: 5 },
+        content: [{ type: 'text', text: 'Title H5', styles: {} }]
+      });
+      render(<BlockNoteContent blocks={[block]} />);
+      expect(screen.getByRole('heading', { level: 3, name: 'Title H5' })).toBeInTheDocument();
+    });
+  });
+
+  describe('bullet list', () => {
+    it('renders bullet list items inside <ul>', () => {
+      const blocks = [
+        makeBlock({ id: '1', type: 'bulletListItem', content: [{ type: 'text', text: 'Item A', styles: {} }] }),
+        makeBlock({ id: '2', type: 'bulletListItem', content: [{ type: 'text', text: 'Item B', styles: {} }] })
+      ];
+      render(<BlockNoteContent blocks={blocks} />);
+      expect(document.querySelector('ul')).toBeInTheDocument();
+      expect(screen.getByText('Item A')).toBeInTheDocument();
+      expect(screen.getByText('Item B')).toBeInTheDocument();
+    });
+
+    it('groups consecutive bullet items into one <ul>', () => {
+      const blocks = [
+        makeBlock({ id: '1', type: 'bulletListItem', content: [{ type: 'text', text: 'A', styles: {} }] }),
+        makeBlock({ id: '2', type: 'bulletListItem', content: [{ type: 'text', text: 'B', styles: {} }] }),
+        makeBlock({ id: '3', type: 'bulletListItem', content: [{ type: 'text', text: 'C', styles: {} }] })
+      ];
+      render(<BlockNoteContent blocks={blocks} />);
+      expect(document.querySelectorAll('ul')).toHaveLength(1);
+    });
+
+    it('creates separate <ul> groups when separated by a paragraph', () => {
+      const blocks = [
+        makeBlock({ id: '1', type: 'bulletListItem', content: [{ type: 'text', text: 'A', styles: {} }] }),
+        textBlock('Paragraph between'),
+        makeBlock({ id: '3', type: 'bulletListItem', content: [{ type: 'text', text: 'B', styles: {} }] })
+      ];
+      render(<BlockNoteContent blocks={blocks} />);
+      expect(document.querySelectorAll('ul')).toHaveLength(2);
+    });
+
+    it('renders nested children inside bullet list item', () => {
+      const childBlock = makeBlock({
+        id: 'child',
+        type: 'bulletListItem',
+        content: [{ type: 'text', text: 'Nested', styles: {} }]
+      });
+      const block = makeBlock({
+        id: 'parent',
+        type: 'bulletListItem',
+        content: [{ type: 'text', text: 'Parent', styles: {} }],
+        children: [childBlock]
+      });
+      render(<BlockNoteContent blocks={[block]} />);
+      expect(screen.getByText('Nested')).toBeInTheDocument();
+    });
+  });
+
+  describe('numbered list', () => {
+    it('renders numbered list items inside <ol>', () => {
+      const blocks = [
+        makeBlock({ id: '1', type: 'numberedListItem', content: [{ type: 'text', text: 'Step 1', styles: {} }] }),
+        makeBlock({ id: '2', type: 'numberedListItem', content: [{ type: 'text', text: 'Step 2', styles: {} }] })
+      ];
+      render(<BlockNoteContent blocks={blocks} />);
+      expect(document.querySelector('ol')).toBeInTheDocument();
+      expect(screen.getByText('Step 1')).toBeInTheDocument();
+      expect(screen.getByText('Step 2')).toBeInTheDocument();
+    });
+
+    it('creates separate groups for bullet and numbered lists', () => {
+      const blocks = [
+        makeBlock({ id: '1', type: 'bulletListItem', content: [{ type: 'text', text: 'Bullet', styles: {} }] }),
+        makeBlock({ id: '2', type: 'numberedListItem', content: [{ type: 'text', text: 'Number', styles: {} }] })
+      ];
+      render(<BlockNoteContent blocks={blocks} />);
+      expect(document.querySelector('ul')).toBeInTheDocument();
+      expect(document.querySelector('ol')).toBeInTheDocument();
+    });
+  });
+
+  describe('checkListItem', () => {
+    it('renders checked checkbox', () => {
+      const block = makeBlock({
+        type: 'checkListItem',
+        props: { checked: true },
+        content: [{ type: 'text', text: 'Done', styles: {} }]
+      });
+      render(<BlockNoteContent blocks={[block]} />);
+      const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+    });
+
+    it('renders unchecked checkbox', () => {
+      const block = makeBlock({
+        type: 'checkListItem',
+        props: { checked: false },
+        content: [{ type: 'text', text: 'Todo', styles: {} }]
+      });
+      render(<BlockNoteContent blocks={[block]} />);
+      const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+      expect(checkbox.checked).toBe(false);
+    });
+
+    it('renders checkbox as readOnly', () => {
+      const block = makeBlock({
+        type: 'checkListItem',
+        props: { checked: true },
+        content: [{ type: 'text', text: 'Task', styles: {} }]
+      });
+      render(<BlockNoteContent blocks={[block]} />);
+      expect(screen.getByRole('checkbox')).toHaveAttribute('readOnly');
+    });
+  });
+
+  describe('image', () => {
+    it('renders image with correct src and alt from caption', () => {
+      const block = makeBlock({ type: 'image', props: { url: 'https://example.com/photo.jpg', caption: 'A photo' } });
+      render(<BlockNoteContent blocks={[block]} />);
+      const img = screen.getByTestId('next-image');
+      expect(img).toHaveAttribute('src', 'https://example.com/photo.jpg');
+      expect(img).toHaveAttribute('alt', 'A photo');
+    });
+
+    it('renders figcaption when caption is provided', () => {
+      const block = makeBlock({
+        type: 'image',
+        props: { url: 'https://example.com/photo.jpg', caption: 'My caption' }
+      });
+      render(<BlockNoteContent blocks={[block]} />);
+      expect(screen.getByText('My caption')).toBeInTheDocument();
+    });
+
+    it('does not render figcaption when caption is empty', () => {
+      const block = makeBlock({ type: 'image', props: { url: 'https://example.com/photo.jpg', caption: '' } });
+      render(<BlockNoteContent blocks={[block]} />);
+      expect(document.querySelector('figcaption')).toBeNull();
+    });
+
+    it('renders nothing when image src is missing', () => {
+      const block = makeBlock({ type: 'image', props: { url: '' } });
+      render(<BlockNoteContent blocks={[block]} />);
+      expect(screen.queryByTestId('next-image')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('unknown block type', () => {
+    it('renders inline content for unknown type', () => {
+      const block = makeBlock({ type: 'unknown', content: [{ type: 'text', text: 'Fallback text', styles: {} }] });
+      render(<BlockNoteContent blocks={[block]} />);
+      expect(screen.getByText('Fallback text')).toBeInTheDocument();
+    });
+
+    it('renders nothing for unknown type without content', () => {
+      const block = makeBlock({ type: 'unknown', content: [] });
+      const { container } = render(<BlockNoteContent blocks={[block]} />);
+      expect(container.textContent).toBe('');
+    });
+  });
+});

--- a/app/shared/components/blocks/article-detail/BlockNoteContent.tsx
+++ b/app/shared/components/blocks/article-detail/BlockNoteContent.tsx
@@ -1,0 +1,174 @@
+import { Box, Typography } from '@mui/material';
+import Image from 'next/image';
+import { Fragment } from 'react';
+
+type TextStyles = {
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+  code?: boolean;
+};
+
+type TextContent = {
+  type: 'text';
+  text: string;
+  styles: TextStyles;
+};
+
+type LinkContent = {
+  type: 'link';
+  href: string;
+  content: TextContent[];
+};
+
+type InlineContent = TextContent | LinkContent;
+
+export type BlockNoteBlock = {
+  id: string;
+  type: string;
+  props: Record<string, unknown>;
+  content?: InlineContent[];
+  children: BlockNoteBlock[];
+};
+
+type ListGroup = { isGroup: true; listType: 'bullet' | 'numbered'; items: BlockNoteBlock[] };
+type BlockOrGroup = BlockNoteBlock | ListGroup;
+
+function applyTextStyles(item: TextContent): React.ReactNode {
+  let node: React.ReactNode = item.text;
+  if (item.styles?.bold) node = <strong>{node}</strong>;
+  if (item.styles?.italic) node = <em>{node}</em>;
+  if (item.styles?.underline) node = <u>{node}</u>;
+  if (item.styles?.strikethrough) node = <s>{node}</s>;
+  if (item.styles?.code) node = <code>{node}</code>;
+  return node;
+}
+
+function renderInline(content: InlineContent[]): React.ReactNode {
+  return content.map((item, i) => {
+    if (item.type === 'link') {
+      return (
+        <a key={i} href={item.href} target="_blank" rel="noopener noreferrer">
+          {item.content.map((c, j) => (
+            <Fragment key={j}>{applyTextStyles(c)}</Fragment>
+          ))}
+        </a>
+      );
+    }
+    return <Fragment key={i}>{applyTextStyles(item)}</Fragment>;
+  });
+}
+
+function groupBlocks(blocks: BlockNoteBlock[]): BlockOrGroup[] {
+  const result: BlockOrGroup[] = [];
+
+  for (const block of blocks) {
+    const isBullet = block.type === 'bulletListItem';
+    const isNumbered = block.type === 'numberedListItem';
+
+    if (isBullet || isNumbered) {
+      const listType = isBullet ? 'bullet' : 'numbered';
+      const last = result.at(-1);
+      if (last && 'isGroup' in last && last.listType === listType) {
+        last.items.push(block);
+      } else {
+        result.push({ isGroup: true, listType, items: [block] });
+      }
+    } else {
+      result.push(block);
+    }
+  }
+
+  return result;
+}
+
+function renderBlock(block: BlockNoteBlock): React.ReactNode {
+  const inline = block.content ? renderInline(block.content) : null;
+
+  switch (block.type) {
+    case 'paragraph':
+      return (
+        <Typography key={block.id} variant="body1" component="p" sx={{ mb: 2 }}>
+          {inline}
+        </Typography>
+      );
+
+    case 'heading': {
+      const level = (block.props.level as number) ?? 1;
+      const variant = `h${Math.min(level, 3)}` as 'h1' | 'h2' | 'h3';
+      return (
+        <Typography key={block.id} variant={variant} sx={{ mt: 4, mb: 2 }}>
+          {inline}
+        </Typography>
+      );
+    }
+
+    case 'bulletListItem':
+    case 'numberedListItem':
+      return (
+        <Box key={block.id} component="li">
+          {inline}
+          {block.children.length > 0 && (
+            <Box component="ul" sx={{ pl: 2 }}>
+              {block.children.map(renderBlock)}
+            </Box>
+          )}
+        </Box>
+      );
+
+    case 'checkListItem': {
+      const checked = block.props.checked as boolean;
+      return (
+        <Box key={block.id} component="li" sx={{ display: 'flex', gap: 1, mb: 1 }}>
+          <input type="checkbox" checked={checked} readOnly />
+          <span>{inline}</span>
+        </Box>
+      );
+    }
+
+    case 'image': {
+      const src = block.props.url as string;
+      const alt = (block.props.caption as string) ?? '';
+      if (!src) return null;
+      return (
+        <Box key={block.id} sx={{ position: 'relative', width: '100%', height: { xs: '240px', md: '400px' }, my: 3 }}>
+          <Image src={src} alt={alt} fill style={{ objectFit: 'contain' }} />
+          {alt && (
+            <Typography variant="caption" component="figcaption" sx={{ mt: 1, textAlign: 'center', display: 'block' }}>
+              {alt}
+            </Typography>
+          )}
+        </Box>
+      );
+    }
+
+    default:
+      return inline ? (
+        <Box key={block.id} sx={{ mb: 2 }}>
+          {inline}
+        </Box>
+      ) : null;
+  }
+}
+
+function renderGroup(group: BlockOrGroup, index: number): React.ReactNode {
+  if ('isGroup' in group) {
+    const Component = group.listType === 'bullet' ? 'ul' : 'ol';
+    return (
+      <Box key={index} component={Component} sx={{ pl: 3, mb: 2 }}>
+        {group.items.map(renderBlock)}
+      </Box>
+    );
+  }
+  return <Fragment key={group.id}>{renderBlock(group)}</Fragment>;
+}
+
+type BlockNoteContentProps = {
+  blocks: BlockNoteBlock[];
+};
+
+export function BlockNoteContent({ blocks }: BlockNoteContentProps) {
+  const groups = groupBlocks(blocks);
+  return <Box>{groups.map(renderGroup)}</Box>;
+}

--- a/app/shared/components/blocks/article-detail/BlockNoteContent.tsx
+++ b/app/shared/components/blocks/article-detail/BlockNoteContent.tsx
@@ -46,17 +46,17 @@ function applyTextStyles(item: TextContent): React.ReactNode {
 }
 
 function renderInline(content: InlineContent[]): React.ReactNode {
-  return content.map((item, i) => {
+  return content.map((item) => {
     if (item.type === 'link') {
       return (
-        <a key={i} href={item.href} target="_blank" rel="noopener noreferrer">
-          {item.content.map((c, j) => (
-            <Fragment key={j}>{applyTextStyles(c)}</Fragment>
+        <a key={`link-${item.href}`} href={item.href} target="_blank" rel="noopener noreferrer">
+          {item.content.map((c) => (
+            <Fragment key={`text-${c.text}`}>{applyTextStyles(c)}</Fragment>
           ))}
         </a>
       );
     }
-    return <Fragment key={i}>{applyTextStyles(item)}</Fragment>;
+    return <Fragment key={`text-${item.text}`}>{applyTextStyles(item)}</Fragment>;
   });
 }
 
@@ -168,7 +168,7 @@ type BlockNoteContentProps = {
   blocks: BlockNoteBlock[];
 };
 
-export function BlockNoteContent({ blocks }: BlockNoteContentProps) {
+export function BlockNoteContent({ blocks }: Readonly<BlockNoteContentProps>) {
   const groups = groupBlocks(blocks);
-  return <Box>{groups.map(renderGroup)}</Box>;
+  return <Box>{groups.map((group, index) => renderGroup(group, index))}</Box>;
 }

--- a/app/shared/components/design-system/all-components/media-list/MediaList.tsx
+++ b/app/shared/components/design-system/all-components/media-list/MediaList.tsx
@@ -59,7 +59,7 @@ function MediaList({ mediaData, itemsPerPage = 9, variant, dataTestId }: Readonl
           const href =
             variant === 'press' && 'url' in newsItem && typeof newsItem.url === 'string'
               ? newsItem.url
-              : `/${variant}/${newsItem._id}`;
+              : `/${variant}/${newsItem.slug ?? newsItem._id}`;
 
           return (
             <BaseCard

--- a/app/validators/localization.ts
+++ b/app/validators/localization.ts
@@ -21,6 +21,7 @@ function isTranslatedField(value: unknown, locale: Locale): value is TranslatedF
 }
 
 function doesTipTapHaveTranslations(root: z.infer<typeof TipTapDocSchema>): boolean {
+  if (!Array.isArray(root.content)) return true;
   for (const node of root.content) {
     if (!node.content) {
       continue;

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,13 +2,14 @@ import { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
 
 const AZURE_SAS_URL = process.env.AZURE_SAS_URL;
+const azureHostname = AZURE_SAS_URL ? new URL(AZURE_SAS_URL).hostname : '';
 
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: `${AZURE_SAS_URL}`,
+        hostname: azureHostname,
         port: '',
         pathname: '/**'
       },

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,17 +2,12 @@ import { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
 
 const AZURE_SAS_URL = process.env.AZURE_SAS_URL;
-const azureHostname = AZURE_SAS_URL ? new URL(AZURE_SAS_URL).hostname : '';
+const azureHostname = AZURE_SAS_URL ? new URL(AZURE_SAS_URL).hostname : null;
 
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: azureHostname,
-        port: '',
-        pathname: '/**'
-      },
+      ...(azureHostname ? [{ protocol: 'https' as const, hostname: azureHostname, port: '', pathname: '/**' }] : []),
       //dev only! remove in production
       {
         protocol: 'https',


### PR DESCRIPTION
## Description
This PR is contain the code to create a page to display specific publiced news. For got this goal was added page which displays selected news, added BlockNoteContent component renderer supporting paragraphs, headings, lists, images and links and 
 add ArticleDetail component with responsive layout and styles. Also was added test files for every new component.

## Key changes
- Add /news/[slug] server page with SEO metadata generation
- Add ArticleDetail component with responsive layout and styles
- Add BlockNoteContent renderer supporting paragraphs, headings, lists, images and links
- Add  test files for every new component
- Fix news card href in MediaList
- Add Cloudflare R2 hostname to next.config remotePatterns for news cover images

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Load lf-client site 
2. Go to FOUNDATION -> NEWS, EVENTS AND MEDIA
3. You'll lead to tab NEWS with list of news
4. Select anyone news to go to the view page news

## Video / Screenshots

https://github.com/user-attachments/assets/35fe6243-4158-44ca-90f4-883999d99ac5

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
Closed task https://github.com/Liatoshynsky-Foundation/lf-client/issues/1303