### PR TITLE
fix: prevent custom cursor from showing out of boundaries

### DIFF
--- a/app/shared/components/blocks/home-page-hero/custom-cursor/BoxButton/BoxButton.tsx
+++ b/app/shared/components/blocks/home-page-hero/custom-cursor/BoxButton/BoxButton.tsx
@@ -20,7 +20,7 @@ type BoxButtonProps = {
 };
 
 export const BoxButton = ({ onClick, children, cursorContent, customSX, testID = 'box-button' }: BoxButtonProps) => {
-  const { cursorConfig, eventHandlers } = useButtonCursor();
+  const { cursorConfig, eventHandlers, ref } = useButtonCursor();
   const bp = useBreakpoints();
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -42,7 +42,7 @@ export const BoxButton = ({ onClick, children, cursorContent, customSX, testID =
 
   return (
     <>
-      <Box {...interactionProps} data-testid={testID} sx={[...sxToArray(customSX)]}>
+      <Box ref={ref} {...interactionProps} data-testid={testID} sx={[...sxToArray(customSX)]}>
         {children}
       </Box>
 

--- a/app/shared/components/blocks/home-page-hero/custom-cursor/useButtonCursor.tsx
+++ b/app/shared/components/blocks/home-page-hero/custom-cursor/useButtonCursor.tsx
@@ -1,14 +1,15 @@
 import { MotionValue, useMotionValue } from 'framer-motion';
-import { MouseEvent, useState } from 'react';
+import { MouseEvent, RefObject, useEffect, useRef, useState } from 'react';
 
 interface UseButtonCursorReturn {
+  ref: RefObject<HTMLDivElement | null>;
   cursorConfig: {
     x: MotionValue<number>;
     y: MotionValue<number>;
     isHovering: boolean;
   };
   eventHandlers: {
-    onMouseEnter: () => void;
+    onMouseEnter: (e: MouseEvent<HTMLElement>) => void;
     onMouseLeave: () => void;
     onMouseMove: (e: MouseEvent<HTMLElement>) => void;
   };
@@ -17,11 +18,49 @@ interface UseButtonCursorReturn {
 export const useButtonCursor = (): UseButtonCursorReturn => {
   const [isHovering, setIsHovering] = useState(false);
 
+  const ref = useRef<HTMLDivElement | null>(null);
+
   const x = useMotionValue(0);
   const y = useMotionValue(0);
 
+  useEffect(() => {
+    const handleScroll = () => {
+      if (!isHovering || !ref.current) return;
+
+      const rect = ref.current.getBoundingClientRect();
+      const currentX = x.get();
+      const currentY = y.get();
+
+      const isInside =
+        currentX >= rect.left && currentX <= rect.right && currentY >= rect.top && currentY <= rect.bottom;
+
+      if (!isInside) {
+        setIsHovering(false);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll, { capture: true, passive: true });
+    return () => window.removeEventListener('scroll', handleScroll, { capture: true });
+  }, [isHovering, x, y]);
+
+  useEffect(() => {
+    if (isHovering) {
+      document.body.style.setProperty('cursor', 'none', 'important');
+    } else {
+      document.body.style.removeProperty('cursor');
+    }
+
+    return () => {
+      document.body.style.removeProperty('cursor');
+    };
+  }, [isHovering]);
+
   const eventHandlers = {
-    onMouseEnter: () => setIsHovering(true),
+    onMouseEnter: (e: MouseEvent<HTMLElement>) => {
+      setIsHovering(true);
+      x.set(e.clientX);
+      y.set(e.clientY);
+    },
     onMouseLeave: () => setIsHovering(false),
     onMouseMove: (e: MouseEvent<HTMLElement>) => {
       x.set(e.clientX);
@@ -30,6 +69,7 @@ export const useButtonCursor = (): UseButtonCursorReturn => {
   };
 
   return {
+    ref,
     cursorConfig: {
       x,
       y,


### PR DESCRIPTION
 ## Description

Fixed two edge-case bugs related to the custom cursor implementation on the `BoxButton` component that occurred during page scrolling.

- **Fixed "Phantom Hover" (Stuck Cursor):** Browsers do not fire `onMouseLeave` when an element scrolls away from a stationary physical mouse. To fix this, a JavaScript-powered hover detector was implemented in `useButtonCursor.tsx`. By attaching a ref and a window scroll listener, we calculate if the stationary mouse coordinates still intersect with the moving button's bounding box (`getBoundingClientRect()`). The moment the mouse falls outside the bounds, `isHovering` is forced to false.


## Type of change

 - [x] Bug fix
 
## How to test

1.Go to [Home page](http://localhost:3001/en).
2. Hover over the `BoxButton` to trigger the custom cursor.
3. Ensure that button is shown, without moving a mouse, scroll down, press `Space`, or reach the other part of page without moving a cursor.
4. Verify that the custom cursor instantly disappears as the button bounds leave the mouse area.
5. Verify that the default system arrow cursor instantly reappears without needing to jiggle the hardware mouse.

## Video / Screenshots

**Cursor Disappearing on Scroll:**

https://github.com/user-attachments/assets/e10a032d-2773-4755-ac6b-e216469e13a7


## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
 - [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board