### PR TITLE
fix: prevent audio autoplay when opening the player popover

### DIFF
--- a/app/shared/components/Header/AudioPlayer/AudioPlayer.test.tsx
+++ b/app/shared/components/Header/AudioPlayer/AudioPlayer.test.tsx
@@ -177,10 +177,10 @@ describe('AudioPlayer', () => {
     }
   });
 
-  it('should call togglePlay when button clicked and isPlaying is false', () => {
+  it('should NOT call togglePlay when button clicked and isPlaying is false', () => {
     renderComponent({ isPlaying: false });
     fireEvent.click(screen.getByRole('button', { name: /toggle audio player/i }));
-    expect(mockTogglePlay).toHaveBeenCalled();
+    expect(mockTogglePlay).not.toHaveBeenCalled();
   });
 
   it('should NOT call togglePlay when button clicked and isPlaying is true', () => {

--- a/app/shared/components/Header/AudioPlayer/AudioPlayer.tsx
+++ b/app/shared/components/Header/AudioPlayer/AudioPlayer.tsx
@@ -156,11 +156,7 @@ export default function AudioPlayer() {
 
   const handlePopoverToggle = useCallback(() => {
     setAnchorEl((prev) => (prev ? null : buttonRef.current));
-
-    if (src && !isPlaying) {
-      togglePlay();
-    }
-  }, [isPlaying, togglePlay, src]);
+  }, []);
 
   const onSeek = useCallback((newProgress: number) => {
     const audio = audioRef.current;


### PR DESCRIPTION
## Description

Fixed an issue where the audio would automatically start playing upon opening the player popover from the header.

**Fixed "Autoplay on Open":** The `handlePopoverToggle` function inside `AudioPlayer.tsx` was previously bound to immediately call `togglePlay()` if the audio was not currently playing. This forced the playback to start just by opening the menu. By removing this call, the EQ button now strictly handles the UI state (opening/closing the popover) without mutating the playback state. The unit tests in `AudioPlayer.test.tsx` were also updated to assert that `togglePlay` is not triggered on popover toggle.

Closes #1324

## Type of change

- [x] Bug fix

## How to test

1. Go to any page with the header.
2. Click on the EQ (audio player) icon in the header to open the player menu.
3. Verify that the popover opens smoothly and the audio **does not** start playing automatically.
4. Verify that clicking the explicit "Play" button inside the opened popover successfully starts the audio.

## Video / Screenshots

How it was:

https://github.com/user-attachments/assets/78a42427-df50-49da-b2d3-75274d23a6f9

Result:

https://github.com/user-attachments/assets/ed3736db-1152-41d1-85ce-489aee8309d8



## Checklist

- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
