### PR TITLE
fix: display photo on news card

### DIFF
--- a/app/infrastructure/models/news/news.model.ts
+++ b/app/infrastructure/models/news/news.model.ts
@@ -31,7 +31,13 @@ const newsSchema = new Schema<INewsDocument>(
         uk: { type: String, required: true },
         en: { type: String, required: true }
       },
-      isTmp: { type: Boolean, default: false }
+      isTmp: { type: Boolean, default: false },
+      crop: {
+        x: { type: Number },
+        y: { type: Number },
+        width: { type: Number },
+        height: { type: Number }
+      }
     },
     status: {
       type: String,

--- a/app/shared/components/blocks/media-center/MediaCenter.tsx
+++ b/app/shared/components/blocks/media-center/MediaCenter.tsx
@@ -31,6 +31,7 @@ type newsCardItemImage = {
   alt?: string;
   caption?: string;
   isTmp?: boolean;
+  crop?: { x: number; y: number; width: number; height: number } | null;
 };
 
 export type newsPressCardItem = {

--- a/app/shared/components/design-system/all-components/base-card/BaseCard.test.tsx
+++ b/app/shared/components/design-system/all-components/base-card/BaseCard.test.tsx
@@ -131,9 +131,9 @@ describe('BaseCard', () => {
     });
 
     it('should treat http:// links as external (short-circuit branch)', () => {
-      render(<BaseCard {...defaultProps} href="http://external.com" />);
+      render(<BaseCard {...defaultProps} href="http://localhost/page" />);
       const link = screen.getByRole('link');
-      expect(link).toHaveAttribute('href', 'http://external.com');
+      expect(link).toHaveAttribute('href', 'http://localhost/page');
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });

--- a/app/shared/components/design-system/all-components/base-card/BaseCard.test.tsx
+++ b/app/shared/components/design-system/all-components/base-card/BaseCard.test.tsx
@@ -51,11 +51,11 @@ jest.mock('~/shared/components/svg-image/SvgImage', () => ({
   SvgImage: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} data-testid="svg-image" />
 }));
 
-global.ResizeObserver = class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
+globalThis.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn()
+}));
 
 describe('BaseCard', () => {
   const defaultProps: BaseCardProps = {
@@ -179,11 +179,11 @@ describe('BaseCard', () => {
 
   describe('Crop functionality', () => {
     afterEach(() => {
-      global.ResizeObserver = class ResizeObserver {
-        observe() {}
-        unobserve() {}
-        disconnect() {}
-      };
+      globalThis.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect: jest.fn()
+      }));
       Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', { configurable: true, get: () => 0 });
       Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', { configurable: true, get: () => 0 });
     });
@@ -207,13 +207,11 @@ describe('BaseCard', () => {
 
     it('should disconnect ResizeObserver on unmount', () => {
       const disconnectMock = jest.fn();
-      global.ResizeObserver = class {
-        observe() {}
-        unobserve() {}
-        disconnect() {
-          disconnectMock();
-        }
-      } as unknown as typeof ResizeObserver;
+      globalThis.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect: disconnectMock
+      }));
 
       const { unmount } = render(<BaseCard {...defaultProps} />);
       unmount();
@@ -232,20 +230,13 @@ describe('BaseCard', () => {
     });
 
     it('should call handleImageLoad and buildCroppedStyle when image loads with sized container', () => {
-      global.ResizeObserver = class {
-        private cb: ResizeObserverCallback;
-        constructor(cb: ResizeObserverCallback) {
-          this.cb = cb;
-        }
-        observe() {
-          this.cb(
-            [{ contentRect: { width: 400, height: 300 } } as ResizeObserverEntry],
-            this as unknown as ResizeObserver
-          );
-        }
-        unobserve() {}
-        disconnect() {}
-      } as unknown as typeof ResizeObserver;
+      globalThis.ResizeObserver = jest.fn().mockImplementation((cb: ResizeObserverCallback) => ({
+        observe: jest.fn(() => {
+          cb([{ contentRect: { width: 400, height: 300 } } as ResizeObserverEntry], {} as ResizeObserver);
+        }),
+        unobserve: jest.fn(),
+        disconnect: jest.fn()
+      }));
 
       Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', { configurable: true, get: () => 800 });
       Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', { configurable: true, get: () => 600 });

--- a/app/shared/components/design-system/all-components/base-card/BaseCard.test.tsx
+++ b/app/shared/components/design-system/all-components/base-card/BaseCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
 import BaseCard, { BaseCardProps } from './BaseCard';
@@ -50,6 +50,12 @@ jest.mock('~/ds-components/button/Button', () => ({
 jest.mock('~/shared/components/svg-image/SvgImage', () => ({
   SvgImage: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} data-testid="svg-image" />
 }));
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
 
 describe('BaseCard', () => {
   const defaultProps: BaseCardProps = {
@@ -123,6 +129,14 @@ describe('BaseCard', () => {
       const link = screen.getByTestId('next-link');
       expect(link).toHaveAttribute('href', '/internal-page');
     });
+
+    it('should treat http:// links as external (short-circuit branch)', () => {
+      render(<BaseCard {...defaultProps} href="http://external.com" />);
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('href', 'http://external.com');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
   });
 
   describe('Variants: news vs press', () => {
@@ -160,6 +174,92 @@ describe('BaseCard', () => {
       const longTitle = 'A'.repeat(100);
       render(<BaseCard {...defaultProps} title={longTitle} />);
       expect(screen.getByText(longTitle)).toBeInTheDocument();
+    });
+  });
+
+  describe('Crop functionality', () => {
+    afterEach(() => {
+      global.ResizeObserver = class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      };
+      Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', { configurable: true, get: () => 0 });
+      Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', { configurable: true, get: () => 0 });
+    });
+
+    it('should render native img when crop is provided', () => {
+      const crop = { x: 0, y: 0, width: 200, height: 150 };
+      render(<BaseCard {...defaultProps} crop={crop} />);
+
+      const img = screen.getByRole('img', { name: defaultProps.title });
+      expect(img.tagName).toBe('IMG');
+      expect(img).toHaveAttribute('src', defaultProps.image);
+      expect(img).toHaveAttribute('alt', defaultProps.title);
+      expect(screen.queryByTestId('next-image')).not.toBeInTheDocument();
+    });
+
+    it('should render Next.js Image when crop is null', () => {
+      render(<BaseCard {...defaultProps} crop={null} />);
+
+      expect(screen.getByTestId('next-image')).toBeInTheDocument();
+    });
+
+    it('should disconnect ResizeObserver on unmount', () => {
+      const disconnectMock = jest.fn();
+      global.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {
+          disconnectMock();
+        }
+      } as unknown as typeof ResizeObserver;
+
+      const { unmount } = render(<BaseCard {...defaultProps} />);
+      unmount();
+
+      expect(disconnectMock).toHaveBeenCalled();
+    });
+
+    it('should skip ResizeObserver setup when containerRef is null', () => {
+      const nullRef = new Proxy({ current: null as HTMLDivElement | null }, { set: () => true });
+      const useRefSpy = jest.spyOn(React, 'useRef');
+      useRefSpy.mockReturnValueOnce(nullRef as React.RefObject<HTMLDivElement>);
+
+      expect(() => render(<BaseCard {...defaultProps} />)).not.toThrow();
+
+      useRefSpy.mockRestore();
+    });
+
+    it('should call handleImageLoad and buildCroppedStyle when image loads with sized container', () => {
+      global.ResizeObserver = class {
+        private cb: ResizeObserverCallback;
+        constructor(cb: ResizeObserverCallback) {
+          this.cb = cb;
+        }
+        observe() {
+          this.cb(
+            [{ contentRect: { width: 400, height: 300 } } as ResizeObserverEntry],
+            this as unknown as ResizeObserver
+          );
+        }
+        unobserve() {}
+        disconnect() {}
+      } as unknown as typeof ResizeObserver;
+
+      Object.defineProperty(HTMLImageElement.prototype, 'naturalWidth', { configurable: true, get: () => 800 });
+      Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', { configurable: true, get: () => 600 });
+
+      const crop = { x: 10, y: 20, width: 200, height: 150 };
+      render(<BaseCard {...defaultProps} crop={crop} />);
+
+      const img = screen.getByRole('img', { name: defaultProps.title });
+
+      act(() => {
+        fireEvent.load(img);
+      });
+
+      expect(img.style.transform).toContain('translate');
     });
   });
 });

--- a/app/shared/components/design-system/all-components/base-card/BaseCard.tsx
+++ b/app/shared/components/design-system/all-components/base-card/BaseCard.tsx
@@ -111,7 +111,7 @@ export default function BaseCard({
   const cardContent = (
     <Box component="article" sx={styles.card} data-testid={dataTestId} aria-label={title}>
       <Box ref={containerRef} sx={styles.imageContainer} data-testid={`${dataTestId}-imageContainer`}>
-        {crop != null ? (
+        {crop ? (
           <img ref={imgRef} src={image} alt={title} loading="lazy" onLoad={handleImageLoad} style={croppedImgStyle} />
         ) : (
           <Image src={image} alt={title} fill style={styles.image} sizes="(max-width: 768px) 100vw, 33vw" />

--- a/app/shared/components/design-system/all-components/base-card/BaseCard.tsx
+++ b/app/shared/components/design-system/all-components/base-card/BaseCard.tsx
@@ -3,6 +3,7 @@ import { Box, Typography } from '@mui/material';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import Button from '~/ds-components/button/Button';
 
@@ -12,14 +13,46 @@ import { SvgImage } from '~/shared/components/svg-image/SvgImage';
 
 export type Variant = 'news' | 'press';
 
+export type CropRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
 export interface BaseCardProps {
   image: string;
+  crop?: CropRect | null;
   title: string;
   publicationDate: string;
   description: string;
   href: string;
   variant: Variant;
   dataTestId?: string;
+}
+
+function buildCroppedStyle(
+  crop: CropRect,
+  natW: number,
+  natH: number,
+  containerW: number,
+  containerH: number
+): React.CSSProperties {
+  const scaleX = containerW / crop.width;
+  const scaleY = containerH / crop.height;
+  const scale = Math.max(scaleX, scaleY);
+  const translateX = -(crop.x * scale) + (containerW - crop.width * scale) / 2;
+  const translateY = -(crop.y * scale) + (containerH - crop.height * scale) / 2;
+  return {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: natW,
+    height: natH,
+    maxWidth: 'none',
+    transformOrigin: '0 0',
+    transform: `translate(${translateX}px, ${translateY}px) scale(${scale})`
+  };
 }
 
 const BUTTON_CONFIG = {
@@ -29,6 +62,7 @@ const BUTTON_CONFIG = {
 
 export default function BaseCard({
   image,
+  crop,
   title,
   publicationDate,
   description,
@@ -40,10 +74,48 @@ export default function BaseCard({
   const buttonConfig = BUTTON_CONFIG[variant];
   const isExternalLink = href.startsWith('http://') || href.startsWith('https://');
 
+  const containerRef = useRef<HTMLDivElement>(null);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [natSize, setNatSize] = useState({ w: 0, h: 0 });
+  const [containerSize, setContainerSize] = useState({ w: 0, h: 0 });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(([entry]) => {
+      setContainerSize({ w: entry.contentRect.width, h: entry.contentRect.height });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!crop) return;
+    const img = imgRef.current;
+    if (img?.complete && img.naturalWidth) {
+      setNatSize({ w: img.naturalWidth, h: img.naturalHeight });
+    }
+  }, [crop]);
+
+  const handleImageLoad = useCallback((e: React.SyntheticEvent<HTMLImageElement>) => {
+    setNatSize({ w: e.currentTarget.naturalWidth, h: e.currentTarget.naturalHeight });
+  }, []);
+
+  const croppedImgStyle = useMemo((): React.CSSProperties => {
+    if (!natSize.w || !natSize.h || !containerSize.w || !containerSize.h) {
+      return { position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' };
+    }
+    return buildCroppedStyle(crop!, natSize.w, natSize.h, containerSize.w, containerSize.h);
+  }, [crop, natSize, containerSize]);
+
   const cardContent = (
     <Box component="article" sx={styles.card} data-testid={dataTestId} aria-label={title}>
-      <Box sx={styles.imageContainer} data-testid={`${dataTestId}-imageContainer`}>
-        <Image src={image} alt={title} fill style={styles.image} sizes="(max-width: 768px) 100vw, 33vw" />
+      <Box ref={containerRef} sx={styles.imageContainer} data-testid={`${dataTestId}-imageContainer`}>
+        {crop != null ? (
+          <img ref={imgRef} src={image} alt={title} loading="lazy" onLoad={handleImageLoad} style={croppedImgStyle} />
+        ) : (
+          <Image src={image} alt={title} fill style={styles.image} sizes="(max-width: 768px) 100vw, 33vw" />
+        )}
       </Box>
 
       <Box sx={styles.content} data-testid={`${dataTestId}-content`}>

--- a/app/shared/components/design-system/all-components/media-list/MediaList.test.tsx
+++ b/app/shared/components/design-system/all-components/media-list/MediaList.test.tsx
@@ -129,6 +129,77 @@ describe('MediaList Component', () => {
     expect(screen.getByTestId('pagination-component')).toHaveAttribute('data-sibling-count', '0');
   });
 
+  it('should use newsItem.url as href when variant is press and url is present', () => {
+    const pressData = [
+      {
+        _id: '1',
+        title: 'Press 1',
+        description: 'Desc 1',
+        coverImage: { src: 'img1.jpg' },
+        publishedAt: '2023-01-01T00:00:00.000Z',
+        url: 'https://external.com/article'
+      }
+    ];
+    mockUsePagination.mockReturnValue({
+      ...mockUsePagination(),
+      paginatedData: pressData
+    });
+
+    render(<MediaList mediaData={pressData as any} variant="press" dataTestId="press" />);
+
+    expect(screen.getByTestId('base-card')).toHaveAttribute('data-href', 'https://external.com/article');
+  });
+
+  it('should use slug in href when newsItem has slug', () => {
+    const dataWithSlug = [
+      {
+        _id: '1',
+        slug: 'my-news-slug',
+        title: 'News 1',
+        description: 'Desc 1',
+        coverImage: { src: 'img1.jpg' },
+        publishedAt: '2023-01-01T00:00:00.000Z'
+      }
+    ];
+    mockUsePagination.mockReturnValue({
+      ...mockUsePagination(),
+      paginatedData: dataWithSlug
+    });
+
+    render(<MediaList mediaData={dataWithSlug as any} variant="news" dataTestId="news" />);
+
+    expect(screen.getByTestId('base-card')).toHaveAttribute('data-href', getDynamicRoute.newsItem('my-news-slug'));
+  });
+
+  it('should pass crop to BaseCard when coverImage has crop', () => {
+    const dataWithCrop = [
+      {
+        _id: '1',
+        title: 'News 1',
+        description: 'Desc 1',
+        coverImage: { src: 'img1.jpg', crop: { x: 10, y: 20, width: 200, height: 150 } },
+        publishedAt: '2023-01-01T00:00:00.000Z'
+      }
+    ];
+    mockUsePagination.mockReturnValue({
+      ...mockUsePagination(),
+      paginatedData: dataWithCrop
+    });
+
+    render(<MediaList mediaData={dataWithCrop as any} variant="news" dataTestId="news" />);
+
+    expect(screen.getByTestId('base-card')).toBeInTheDocument();
+  });
+
+  it('should set siblingCount to 0 when isTablet is true', () => {
+    mockUseBreakpoints.mockReturnValue({ isMobile: false, isTablet: true });
+    mockUsePagination.mockReturnValue({ ...mockUsePagination(), totalPages: 5 });
+
+    render(<MediaList mediaData={mockData as any} variant="news" dataTestId="news" />);
+
+    expect(screen.getByTestId('pagination-component')).toHaveAttribute('data-sibling-count', '0');
+  });
+
   it('should call scrollIntoView when page changes', () => {
     const handlePageChangeMock = jest.fn();
     const handleLoadMoreMock = jest.fn();

--- a/app/shared/components/design-system/all-components/media-list/MediaList.tsx
+++ b/app/shared/components/design-system/all-components/media-list/MediaList.tsx
@@ -69,6 +69,7 @@ function MediaList({ mediaData, itemsPerPage = 9, variant, dataTestId }: Readonl
               key={newsItem._id}
               description={newsItem.description}
               image={newsItem.coverImage.src}
+              crop={newsItem.coverImage.crop ?? null}
               title={newsItem.title}
               publicationDate={new Date(newsItem.publishedAt || '').toLocaleDateString('uk-UA')}
             />

--- a/app/validators/news.schema.ts
+++ b/app/validators/news.schema.ts
@@ -4,11 +4,21 @@ import { translatedFieldSchema } from './constants';
 
 import { NewsStatus } from '~/domain/dto/news.dto';
 
+export const cropRectSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number()
+});
+
+export type CropRect = z.infer<typeof cropRectSchema>;
+
 export const newsImageSchema = z.object({
   src: z.string(),
   alt: translatedFieldSchema,
   caption: translatedFieldSchema,
-  isTmp: z.boolean()
+  isTmp: z.boolean(),
+  crop: cropRectSchema.nullable().optional()
 });
 
 export const mongoObjectIdSchema = z

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,10 +4,16 @@ import createNextIntlPlugin from 'next-intl/plugin';
 const AZURE_SAS_URL = process.env.AZURE_SAS_URL;
 const azureHostname = AZURE_SAS_URL ? new URL(AZURE_SAS_URL).hostname : null;
 
+const STORAGE_BASE_URL = process.env.STORAGE_BASE_URL;
+const storageHostname = STORAGE_BASE_URL ? new URL(STORAGE_BASE_URL).hostname : null;
+
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       ...(azureHostname ? [{ protocol: 'https' as const, hostname: azureHostname, port: '', pathname: '/**' }] : []),
+      ...(storageHostname
+        ? [{ protocol: 'https' as const, hostname: storageHostname, port: '', pathname: '/**' }]
+        : []),
       //dev only! remove in production
       {
         protocol: 'https',


### PR DESCRIPTION
## DESCRIPTION
This PR adds support for displaying cropped images on news cards in the client side of the site.

PROBLEM
Photos were not displayed on news cards

WHAT WAS FIXED:
- BaseCard is the main change. The component received a crop prop. If it is passed, instead of <Image> (next/image), a native <img> with a style is rendered that calculates the translate + scale transformation via buildCroppedStyle, which cuts out the desired image area according to the specified coordinates and dimensions. ResizeObserver is used for responsiveness to container size changes
- MediaList — passes coverImage.crop into BaseCard
- MediaCenter — type newsCardItemImage extended with field crop
- news.model.ts and news.schema.ts — MongoDB schema and Zod validation supplemented with the crop (x, y, width, height) field in coverImage
- next.config.ts — Cloudflare R2 domain (STORAGE_BASE_URL) added to allowed for next/image so that images from R2 can be loaded
- update tests for BaseCard and MediaList

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

- go to lf-client page news
- scrolling to list of news
- the user should see every card with a photo on it


## Video / Screenshots

BEFORE FIX

<img width="2557" height="1398" alt="image" src="https://github.com/user-attachments/assets/0330314e-2cdc-4e6c-b251-d76ed3dc57bc" />


AFTER FIXED

<img width="2560" height="1393" alt="image" src="https://github.com/user-attachments/assets/f45d5d17-8307-4e55-8ba5-c0235579c02f" />


## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [x] Task moved to the review column on the board

Close https://github.com/Liatoshynsky-Foundation/lf-client/issues/1331

