### PR TITLE
fix: add overflow hidden

### DIFF
--- a/app/shared/components/blocks/home-page-hero/animation/WordMorpher.tsx
+++ b/app/shared/components/blocks/home-page-hero/animation/WordMorpher.tsx
@@ -88,9 +88,11 @@ export const WordMorpher: FC<WordMorpherProps> = ({ onComplete, testID = 'word-m
   }, [onComplete]);
 
   useEffect(() => {
+    document.body.style.overflow = 'hidden';
     let autoplayTimer: ReturnType<typeof setInterval>;
 
     const handleAnimationComplete = () => {
+      document.body.style.overflow = '';
       clearInterval(autoplayTimer);
       setTimeout(() => {
         onCompleteRef.current?.();


### PR DESCRIPTION
## Description

This PR added sroll blocking logic while animation started and ended on home page.

## Type of change

- [x] Bug fix

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Go to home page
2. Test that scroll is disable while animation is going. Also scroll should be able while animation is done.

## Video / Screenshots

<img width="2559" height="1270" alt="image" src="https://github.com/user-attachments/assets/58667c12-b8b2-4815-a833-937d5eadc6b7" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Task moved to the review column on the board

---
