### PR TITLE
feat(intro): implement one-time intro animation via session storage

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -20,6 +20,7 @@ import CookieModalWrapper from '~/shared/components/cookie-modal/CookieModalWrap
 import EmotionProvider from '~/shared/components/emotion-provider/EmotionProvider';
 import Header from '~/shared/components/Header/Header.server';
 import { AudioPlayerProvider } from '~/shared/context/AudioPlayerContext';
+import { IntroAnimationProvider } from '~/shared/context/IntroAnimationContext';
 import QueryProvider from '~/shared/providers/QueryProvider';
 
 const geistSans = Geist({
@@ -117,16 +118,18 @@ export default async function RootLayout({ children, params }: RootLayoutParams)
             <ThemeProvider>
               <QueryProvider>
                 <AudioPlayerProvider>
-                  <Box sx={styles.container}>
-                    <Header />
-                    <Box sx={styles.childrenBox}>{children}</Box>
-                    <Footer />
-                  </Box>
-                  <CookieModalWrapper
-                    consent_cookie={cookieConsent}
-                    trackingId={process.env.TRACKING_ID || ''}
-                    gtmId={process.env.GTM_ID || ''}
-                  />
+                  <IntroAnimationProvider>
+                    <Box sx={styles.container}>
+                      <Header />
+                      <Box sx={styles.childrenBox}>{children}</Box>
+                      <Footer />
+                    </Box>
+                    <CookieModalWrapper
+                      consent_cookie={cookieConsent}
+                      trackingId={process.env.TRACKING_ID || ''}
+                      gtmId={process.env.GTM_ID || ''}
+                    />
+                  </IntroAnimationProvider>
                 </AudioPlayerProvider>
               </QueryProvider>
             </ThemeProvider>

--- a/app/shared/components/blocks/home-page-hero/animation/IntroAnimation.tsx
+++ b/app/shared/components/blocks/home-page-hero/animation/IntroAnimation.tsx
@@ -6,15 +6,39 @@ import { FC, ReactNode, useState } from 'react';
 import { wordEightPaths } from './logoSVGPaths';
 import { WordMorpher } from './WordMorpher';
 
+import { useIntroAnimation } from '~/shared/context/IntroAnimationContext';
+
 interface IntroAnimationProps {
   children: ReactNode;
   testID?: string;
 }
 
 export const IntroAnimation: FC<IntroAnimationProps> = ({ children, testID = 'intro-animation' }) => {
+  const { hasSeenIntro, markIntroAsSeen, isInitialized } = useIntroAnimation();
+
   const [showIntro, setShowIntro] = useState(true);
   const [showExpansion, setShowExpansion] = useState(false);
   const [showContent, setShowContent] = useState(false);
+
+  if (!isInitialized) {
+    return (
+      <div
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100vw',
+          height: '100vh',
+          backgroundColor: '#ffffff',
+          zIndex: 9999
+        }}
+      />
+    );
+  }
+
+  if (hasSeenIntro) {
+    return <>{children}</>;
+  }
 
   const expansionVariants = {
     initial: {
@@ -56,6 +80,7 @@ export const IntroAnimation: FC<IntroAnimationProps> = ({ children, testID = 'in
         onExitComplete={() => {
           setShowContent(true);
           setShowExpansion(false);
+          markIntroAsSeen();
         }}
       >
         {showExpansion && (

--- a/app/shared/context/IntroAnimationContext.test.tsx
+++ b/app/shared/context/IntroAnimationContext.test.tsx
@@ -1,0 +1,70 @@
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
+
+import { IntroAnimationProvider, useIntroAnimation } from './IntroAnimationContext';
+
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+
+Object.defineProperty(window, 'sessionStorage', {
+  value: {
+    getItem: mockGetItem,
+    setItem: mockSetItem
+  },
+  writable: true
+});
+
+describe('IntroAnimationContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <IntroAnimationProvider>{children}</IntroAnimationProvider>
+  );
+
+  it('should initialize with hasSeenIntro as false when sessionStorage is empty', () => {
+    mockGetItem.mockReturnValue(null);
+
+    const { result } = renderHook(() => useIntroAnimation(), { wrapper });
+
+    expect(result.current.isInitialized).toBe(true);
+    expect(result.current.hasSeenIntro).toBe(false);
+    expect(mockGetItem).toHaveBeenCalledWith('hasSeenIntro');
+  });
+
+  it('should initialize with hasSeenIntro as true when sessionStorage has a saved value', () => {
+    mockGetItem.mockReturnValue('true');
+
+    const { result } = renderHook(() => useIntroAnimation(), { wrapper });
+
+    expect(result.current.isInitialized).toBe(true);
+    expect(result.current.hasSeenIntro).toBe(true);
+    expect(mockGetItem).toHaveBeenCalledWith('hasSeenIntro');
+  });
+
+  it('should update state and write to sessionStorage when markIntroAsSeen is called', () => {
+    mockGetItem.mockReturnValue(null);
+
+    const { result } = renderHook(() => useIntroAnimation(), { wrapper });
+
+    expect(result.current.hasSeenIntro).toBe(false);
+
+    act(() => {
+      result.current.markIntroAsSeen();
+    });
+
+    expect(result.current.hasSeenIntro).toBe(true);
+    expect(mockSetItem).toHaveBeenCalledWith('hasSeenIntro', 'true');
+  });
+
+  it('should throw an error if useIntroAnimation is used outside of IntroAnimationProvider', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(() => useIntroAnimation());
+    }).toThrow('useIntroAnimation must be used within an IntroAnimationProvider');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/app/shared/context/IntroAnimationContext.test.tsx
+++ b/app/shared/context/IntroAnimationContext.test.tsx
@@ -6,7 +6,7 @@ import { IntroAnimationProvider, useIntroAnimation } from './IntroAnimationConte
 const mockGetItem = jest.fn();
 const mockSetItem = jest.fn();
 
-Object.defineProperty(window, 'sessionStorage', {
+Object.defineProperty(globalThis, 'sessionStorage', {
   value: {
     getItem: mockGetItem,
     setItem: mockSetItem

--- a/app/shared/context/IntroAnimationContext.tsx
+++ b/app/shared/context/IntroAnimationContext.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+interface IntroAnimationContextType {
+  hasSeenIntro: boolean;
+  markIntroAsSeen: () => void;
+  isInitialized: boolean;
+}
+
+const IntroAnimationContext = createContext<IntroAnimationContextType | undefined>(undefined);
+
+export const IntroAnimationProvider = ({ children }: { children: React.ReactNode }) => {
+  const [hasSeenIntro, setHasSeenIntro] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  useEffect(() => {
+    const storedValue = sessionStorage.getItem('hasSeenIntro');
+    if (storedValue === 'true') {
+      setHasSeenIntro(true);
+    }
+    setIsInitialized(true);
+  }, []);
+
+  const markIntroAsSeen = () => {
+    setHasSeenIntro(true);
+    sessionStorage.setItem('hasSeenIntro', 'true');
+  };
+
+  return (
+    <IntroAnimationContext.Provider value={{ hasSeenIntro, markIntroAsSeen, isInitialized }}>
+      {children}
+    </IntroAnimationContext.Provider>
+  );
+};
+
+export const useIntroAnimation = () => {
+  const context = useContext(IntroAnimationContext);
+  if (context === undefined) {
+    throw new Error('useIntroAnimation must be used within an IntroAnimationProvider');
+  }
+  return context;
+};

--- a/app/shared/context/IntroAnimationContext.tsx
+++ b/app/shared/context/IntroAnimationContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 interface IntroAnimationContextType {
   hasSeenIntro: boolean;
@@ -22,16 +22,21 @@ export const IntroAnimationProvider = ({ children }: { children: React.ReactNode
     setIsInitialized(true);
   }, []);
 
-  const markIntroAsSeen = () => {
+  const markIntroAsSeen = useCallback(() => {
     setHasSeenIntro(true);
     sessionStorage.setItem('hasSeenIntro', 'true');
-  };
+  }, []);
 
-  return (
-    <IntroAnimationContext.Provider value={{ hasSeenIntro, markIntroAsSeen, isInitialized }}>
-      {children}
-    </IntroAnimationContext.Provider>
+  const contextValue = useMemo(
+    () => ({
+      hasSeenIntro,
+      markIntroAsSeen,
+      isInitialized
+    }),
+    [hasSeenIntro, markIntroAsSeen, isInitialized]
   );
+
+  return <IntroAnimationContext.Provider value={contextValue}>{children}</IntroAnimationContext.Provider>;
 };
 
 export const useIntroAnimation = () => {

--- a/next.config.ts
+++ b/next.config.ts
@@ -20,12 +20,6 @@ const nextConfig: NextConfig = {
         hostname: 'images.unsplash.com',
         port: '',
         pathname: '/**'
-      },
-      {
-        protocol: 'https',
-        hostname: 'pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev',
-        port: '',
-        pathname: '/**'
       }
     ]
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,12 @@ const nextConfig: NextConfig = {
         hostname: 'images.unsplash.com',
         port: '',
         pathname: '/**'
+      },
+      {
+        protocol: 'https',
+        hostname: 'pub-2b50c59c64954ab89b7837f9f4607e12.r2.dev',
+        port: '',
+        pathname: '/**'
       }
     ]
   },


### PR DESCRIPTION
## Description

Implemented a feature to ensure the intro animation on the homepage is only played once per session, improving the overall user experience. This was achieved by creating a new IntroAnimationContext that tracks the user's state using sessionStorage. The IntroAnimation component now checks this context before rendering.

## Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the homepage (/ or /[lang]).
2. Verify: The intro animation should play fully.
3. Navigate to any other page (e.g., About Us) and return to the homepage.
4. Verify: The homepage content should load instantly without the animation.
5. Reload the page (F5).
6. Verify: The animation is skipped, and content loads instantly.
7. Close the browser tab/window completely, then open a new tab and go to the homepage.
8. Verify: The intro animation should play again (since the session was cleared).

## Video / Screenshots


https://github.com/user-attachments/assets/728df7a6-a86d-4225-8260-db7a39a474ad



## Expected result:
The intro animation plays only on the very first visit to the homepage during a browser session. Subsequent navigations or reloads within the same session bypass the animation, allowing users immediate access to the content.

Closes: https://github.com/Liatoshynsky-Foundation/lf-client/issues/1325