### PR TITLE
fix(UI): active page group on home page

### DIFF
--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
@@ -76,11 +76,7 @@ const DesktopNav = ({
 
     const groupIndex = navLabels.findIndex((group) => group.links.some((link) => isPathWithin(link.href, currentPath)));
 
-    if (groupIndex !== -1) {
-      setActiveButton(groupIndex);
-    } else {
-      setActiveButton(undefined);
-    }
+    setActiveButton(groupIndex >= 0 ? groupIndex : undefined);
   }, [normalizedPath, navLabels, specialNav]);
 
   useEffect(() => {

--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
@@ -18,7 +18,6 @@ import { isPathWithin, normalizePath } from '~/lib/utils/navPath';
 import ChevronDown from '~/public/icons/chevron-down.svg';
 import ChevronUp from '~/public/icons/chevron-up.svg';
 import { Svg } from '~/shared/components/colored-svg/ColoredSvg';
-import { ROUTES } from '~/shared/components/constants/routes';
 
 export interface DropdownItem {
   label: string;
@@ -79,8 +78,6 @@ const DesktopNav = ({
 
     if (groupIndex !== -1) {
       setActiveButton(groupIndex);
-    } else if (currentPath === ROUTES.HOME) {
-      setActiveButton(1);
     } else {
       setActiveButton(undefined);
     }


### PR DESCRIPTION
## Description

Fixed incorrect active navigation state on the Home page.

Previously, the Foundation page group was automatically marked as active when the user opened the Home page. This happened because the Home route explicitly set activeButton to index 1.

The logic was simplified so that no navigation item is selected when the user is on the Home page.

Fixes #1275

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the Home page.
2. Wait until the animation is complete.
3. Check the navigation menu.
4. Verify that no page group is marked as active on the Home page.
5. Navigate to other pages and verify that active navigation highlighting still works correctly.

## Video / Screenshots

Before the fix
<img width="740" height="95" alt="Screenshot 2026-05-28 at 13 08 16" src="https://github.com/user-attachments/assets/ef2f40c9-83c3-40d4-8fc4-715ec083a0d0" />

After the fix
<img width="772" height="95" alt="Screenshot 2026-05-28 at 13 09 12" src="https://github.com/user-attachments/assets/31fef7a6-137e-4aa0-9b61-7d5ef6795ad1" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---