### PR TITLE
fix(ui): add contour images styles

### DIFF
--- a/app/shared/components/design-system/all-components/base-card/BaseCard.styles.ts
+++ b/app/shared/components/design-system/all-components/base-card/BaseCard.styles.ts
@@ -34,6 +34,37 @@ export const styles = {
       xs: '100%',
       sm: '400px',
       md: '501px'
+    },
+
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      inset: 0,
+      background: mainHexPallete.blue[200],
+      clipPath: `
+    polygon(
+      0% calc(5.5%),
+      100% 0%,
+      100% calc(0% + 1px),
+      0% calc(5.5% + 1px)
+    )
+  `,
+      zIndex: 1
+    },
+
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      inset: 0,
+      background: mainHexPallete.blue[200],
+      clipPath: `
+    polygon(
+      0% calc(100% - 1px),
+      100% calc(94.5% - 1px),
+      100% 94.5%,
+      0% 100%
+    )
+  `
     }
   },
 


### PR DESCRIPTION
## Description

Updated styles in BaseCard.styles.ts by adding ::before and ::after pseudo-elements to the imageContainer in the BaseCard component.
As a result, each image on the News, Events & Media page now has top and bottom contour lines that follow the shape of the image.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open lf-client.
2. In the navigation, go to Foundation.
3. Select News, Events & Media.
4. Check the images on the page.

Expected result:
Each image has thin contour lines at the top and bottom that follow the shape of the image.

## Video / Screenshots


https://github.com/user-attachments/assets/877010e3-a5c5-4549-ab74-b080e8c2540f

<img width="459" height="299" alt="image" src="https://github.com/user-attachments/assets/07ca01c3-5086-4277-903f-bae775db5867" />




## Checklist

- [ ] PR name follows the naming convention
- [ ] Code compiles and runs correctly
- [ ] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [ ] Linked issue/task included
- [ ] Task moved to the review column on the board

---

issue: https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/134