### PR TITLE
fix: Automatic locale switching to English when switching to BIOGRAPHY, ARTISTRY, RESEARCH

### DIFF
--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.test.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { SVGProps } from 'react';
+import type { AnchorHTMLAttributes, SVGProps } from 'react';
 
 import DesktopNav from './DesktopNav';
 
@@ -7,7 +7,12 @@ import type { NavigationDTO } from '~/domain/dto/navigation.dto';
 import { ROUTES } from '~/shared/components/constants/routes';
 
 jest.mock('~/i18n/navigation', () => ({
-  usePathname: jest.fn(() => ROUTES.HOME)
+  usePathname: jest.fn(() => ROUTES.HOME),
+  Link: ({ children, href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  )
 }));
 
 jest.mock('~/shared/components/colored-svg/ColoredSvg.tsx', () => ({

--- a/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/dekstop-nav/DesktopNav.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mui/material';
-import Link from 'next/link';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import Button from '~/ds-components/button/Button';
@@ -13,7 +12,7 @@ import { styles } from './DesktopNav.styles';
 import type { ScrollDirection } from '~/types/types/common.types';
 
 import { NavigationDTO } from '~/domain/dto/navigation.dto';
-import { usePathname } from '~/i18n/navigation';
+import { Link, usePathname } from '~/i18n/navigation';
 import { isPathWithin, normalizePath } from '~/lib/utils/navPath';
 import ChevronDown from '~/public/icons/chevron-down.svg';
 import ChevronUp from '~/public/icons/chevron-up.svg';
@@ -152,7 +151,7 @@ const DesktopNav = ({
   });
 
   const renderedDropdownItems = openDropdownState?.items.map((item, index) => (
-    <Link href={item.href} key={`${item.href}-${index}`} passHref>
+    <Link href={item.href} key={`${item.href}-${index}`}>
       <CustomMenuItem sx={styles.menuItem} onClick={handleDropdownClose}>
         {item.label}
       </CustomMenuItem>

--- a/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/MobileNav.test.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/MobileNav.test.tsx
@@ -1,12 +1,12 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { usePathname } from 'next/navigation';
 
 import MobileNav from './MobileNav';
 import { contactsData, LinkIcon } from '~/types/types/common.types';
 
 import { NavigationDTO } from '~/domain/dto/navigation.dto';
+import { usePathname } from '~/i18n/navigation';
 
-jest.mock('next/navigation', () => ({
+jest.mock('~/i18n/navigation', () => ({
   usePathname: jest.fn(),
   useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() })
 }));

--- a/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/MobileNav.tsx
+++ b/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/MobileNav.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@mui/material';
-import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import MobileMenuOverlay from './mobile-overlay/MobileOverlay';
@@ -7,6 +6,7 @@ import { styles } from './MobileNav.styles';
 import { contactsData, LinkIcon } from '~/types/types/common.types';
 
 import { NavigationDTO } from '~/domain/dto/navigation.dto';
+import { usePathname } from '~/i18n/navigation';
 import useBreakpoints from '~/shared/hooks/use-breakpoints/useBreakpoints';
 
 interface MobileNavProps {


### PR DESCRIPTION
## Description

Fixed selecting Ukrainian and navigating to Biography, Artistry, or Research via the menu silently switched the locale to English.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the site with the browser language set to English.
2. Switch the site locale to UA.
3. Open one of: Biography / Artistry / Research and Academic Works from the nav menu.
4. **Before**: locale flips to EN (URL becomes /en/...) with no user action.
**After**: locale stays uk (/uk/...); other pages (News, About Us) unchanged.

## Video / Screenshots

https://github.com/user-attachments/assets/afe1d840-1022-413e-8a9e-e54626cecd3f

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
