### PR TITLE
fix(ui): add fallback image for missing media thumbnails

### DIFF
--- a/app/shared/components/design-system/all-components/base-card/BaseCard.styles.ts
+++ b/app/shared/components/design-system/all-components/base-card/BaseCard.styles.ts
@@ -73,6 +73,15 @@ export const styles = {
     objectPosition: '45% 48%'
   },
 
+  fallbackImage: {
+    position: 'absolute' as const,
+    inset: 0,
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover' as const,
+    objectPosition: '45% 48%'
+  },
+
   content: {
     display: 'flex',
     flexDirection: 'column',

--- a/app/shared/components/design-system/all-components/base-card/BaseCard.tsx
+++ b/app/shared/components/design-system/all-components/base-card/BaseCard.tsx
@@ -63,6 +63,7 @@ export default function BaseCard({
   const { containerRef, imgRef, handleImageLoad, croppedImgStyle } = useImageCrop(crop);
   const initialSrc = isValidUrl(image) ? image : FALLBACK_IMAGE;
   const [imageSrc, setImageSrc] = useState<string>(initialSrc);
+  const isFallbackImage = imageSrc === FALLBACK_IMAGE;
 
   useEffect(() => {
     setImageSrc(isValidUrl(image) ? image : FALLBACK_IMAGE);
@@ -74,11 +75,11 @@ export default function BaseCard({
         {crop ? (
           <img
             ref={imgRef}
-            src={image}
+            src={imageSrc}
             alt={title}
             loading="lazy"
             onLoad={handleImageLoad}
-            style={croppedImgStyle}
+            style={isFallbackImage ? styles.fallbackImage : croppedImgStyle}
             onError={() => setImageSrc(FALLBACK_IMAGE)}
           />
         ) : (


### PR DESCRIPTION
## Description

Added fallback image handling for News, Events and Media cards when the original image is missing or fails to load.

The fallback image is now used for both regular and cropped card images. Also updated fallback image styling to keep the card layout consistent and avoid empty placeholders or visible alt text.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the Новини, події та медіа page.
2. Verify that cards with valid images display their original images correctly.
3. Temporarily use a broken image URL for a card.
4. Verify that the fallback image is displayed instead.
5. Temporarily remove or clear an image URL for a card.
6. Verify that the fallback image is displayed.
7. Check that the card layout remains consistent and no alt text or empty image space is shown.

## Video / Screenshots

<img width="1713" height="532" alt="image" src="https://github.com/user-attachments/assets/b66f7a40-d166-402e-a9de-ac5a540c441e" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [ ] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Close [#1352](https://github.com/Liatoshynsky-Foundation/lf-client/issues/1352)
