### PR TITLE
refactor(theme): convert hardcoded z-indices to design system constants

### DIFF
--- a/app/shared/components/Footer/Footer.styles.ts
+++ b/app/shared/components/Footer/Footer.styles.ts
@@ -5,7 +5,7 @@ export const styles = {
     overflow: 'hidden',
     paddingTop: 'calc(100vw * 0.035)',
     marginTop: 'calc((100vw * 0.035) * -1)',
-    zIndex: '2',
+    zIndex: 2,
     left: 0
   },
   backgroundBox: {

--- a/app/shared/components/Header/Header.styles.ts
+++ b/app/shared/components/Header/Header.styles.ts
@@ -1,3 +1,5 @@
+import { theme } from '~/shared/components/design-system/all-components/theme/Theme';
+
 export const styles = {
   mainContainer: (hideHeader: boolean) => ({
     display: 'flex',
@@ -11,7 +13,7 @@ export const styles = {
     },
     left: 0,
     right: 0,
-    zIndex: 1000,
+    zIndex: theme.zIndex.appBar,
     alignItems: 'center',
     justifyContent: 'space-between',
     width: '100vw',
@@ -36,7 +38,7 @@ export const styles = {
       xs: 'translate(-17px)',
       sm: 'translate(-22px)'
     },
-    zIndex: 1000
+    zIndex: theme.zIndex.appBar
   },
   navigationContainer: {
     marginRight: { xl: '35px', xxl: '70px' },
@@ -50,8 +52,8 @@ export const styles = {
     display: 'flex',
     justifyContent: 'end',
     alignItems: 'center',
-    gap: '20px',
-    zIndex: 1000
+    zIndex: theme.zIndex.appBar,
+    gap: '20px'
   },
   navWrapper: {
     display: 'flex',

--- a/app/shared/components/Header/Header.styles.ts
+++ b/app/shared/components/Header/Header.styles.ts
@@ -13,7 +13,7 @@ export const styles = {
     },
     left: 0,
     right: 0,
-    zIndex: theme.zIndex.appBar,
+    zIndex: theme.zIndex.headerAppBar,
     alignItems: 'center',
     justifyContent: 'space-between',
     width: '100vw',
@@ -38,7 +38,7 @@ export const styles = {
       xs: 'translate(-17px)',
       sm: 'translate(-22px)'
     },
-    zIndex: theme.zIndex.appBar
+    zIndex: theme.zIndex.headerAppBar
   },
   navigationContainer: {
     marginRight: { xl: '35px', xxl: '70px' },
@@ -52,7 +52,7 @@ export const styles = {
     display: 'flex',
     justifyContent: 'end',
     alignItems: 'center',
-    zIndex: theme.zIndex.appBar,
+    zIndex: theme.zIndex.headerAppBar,
     gap: '20px'
   },
   navWrapper: {

--- a/app/shared/components/blocks/home-page-hero/HeroSection.styles.ts
+++ b/app/shared/components/blocks/home-page-hero/HeroSection.styles.ts
@@ -1,3 +1,5 @@
+import { theme } from '../../design-system/all-components/theme/Theme';
+
 import { mainHexPallete } from '~/shared/components/design-system/all-components/theme/colors';
 
 export const heroSectionStyles = {
@@ -91,7 +93,7 @@ export const heroSectionStyles = {
     position: 'fixed',
     transform: 'translate(-50%, -50%)',
     pointerEvents: 'none',
-    zIndex: 9999,
+    zIndex: theme.zIndex.cursor,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',

--- a/app/shared/components/blocks/home-page-hero/animation/IntroAnimation.tsx
+++ b/app/shared/components/blocks/home-page-hero/animation/IntroAnimation.tsx
@@ -6,6 +6,7 @@ import { FC, ReactNode, useState } from 'react';
 import { wordEightPaths } from './logoSVGPaths';
 import { WordMorpher } from './WordMorpher';
 
+import { theme } from '~/shared/components/design-system/all-components/theme/Theme';
 import { useIntroAnimation } from '~/shared/context/IntroAnimationContext';
 
 interface IntroAnimationProps {
@@ -30,7 +31,7 @@ export const IntroAnimation: FC<IntroAnimationProps> = ({ children, testID = 'in
           width: '100vw',
           height: '100vh',
           backgroundColor: '#ffffff',
-          zIndex: 9999
+          zIndex: theme.zIndex.introAnimationBackground
         }}
       />
     );
@@ -65,7 +66,7 @@ export const IntroAnimation: FC<IntroAnimationProps> = ({ children, testID = 'in
               width: '100vw',
               height: '100vh',
               backgroundColor: '#ffffff',
-              zIndex: 9999,
+              zIndex: theme.zIndex.introAnimationBackground,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center'
@@ -96,7 +97,7 @@ export const IntroAnimation: FC<IntroAnimationProps> = ({ children, testID = 'in
               width: '100vw',
               height: '100vh',
               backgroundColor: '#ffffff',
-              zIndex: 9998,
+              zIndex: theme.zIndex.introAnimationExpansion,
               pointerEvents: 'none',
               display: 'flex',
               alignItems: 'center',

--- a/app/shared/components/blocks/partnership-formats/PartnershipFormats.styles.ts
+++ b/app/shared/components/blocks/partnership-formats/PartnershipFormats.styles.ts
@@ -1,5 +1,6 @@
 import type { SxProps, Theme } from '@mui/material/styles';
 
+import { theme } from '../../design-system/all-components/theme/Theme';
 import { PartnershipImageType } from '~/types/page/cooperation.types';
 
 type ImageConfig = {
@@ -469,7 +470,7 @@ const baseStyles = {
     position: 'absolute',
     width: '30px',
     height: '30px',
-    zIndex: '100',
+    zIndex: theme.zIndex.modalCloseButton,
     top: {
       xs: '10px',
       lg: '16px'

--- a/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/MobileNav.styles.ts
+++ b/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/MobileNav.styles.ts
@@ -1,5 +1,7 @@
 import { backgroundColors } from '~/ds-components/theme/colors';
 
+import { theme } from '../../theme/Theme';
+
 export const styles = {
   iconButton: (isMobile: boolean) => ({
     borderRadius: '32px',
@@ -7,7 +9,7 @@ export const styles = {
     height: isMobile ? '40px' : '52px',
     backgroundColor: 'rgb(238, 238, 237) !important',
     border: `${isMobile ? 4 : 6}px solid ${backgroundColors.white}`,
-    zIndex: 3000,
+    zIndex: theme.zIndex.mobileNavButton,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',

--- a/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/mobile-overlay/MobileOverlay.styles.ts
+++ b/app/shared/components/design-system/all-components/navigation-bar/mobile-nav/mobile-overlay/MobileOverlay.styles.ts
@@ -1,4 +1,5 @@
 import { mainHexPallete } from '../../../theme/colors';
+import { theme } from '../../../theme/Theme';
 
 const columnBase = {
   display: 'flex',
@@ -22,7 +23,7 @@ export const styles = {
     width: '100vw',
     height: '100vh',
     backgroundColor: mainHexPallete.yellow[500],
-    zIndex: 900,
+    zIndex: theme.zIndex.mobileOverlay,
     clipPath: {
       xs: 'polygon(0 0, 100% 0, 100% 100%, 0 100%)',
       sm: 'polygon(0 0, 100% 0, 100% 94%, 0 100%)'

--- a/app/shared/components/design-system/all-components/theme/Theme.ts
+++ b/app/shared/components/design-system/all-components/theme/Theme.ts
@@ -172,6 +172,7 @@ declare module '@mui/material/styles' {
     introAnimationBackground: number;
     introAnimationExpansion: number;
     mobileOverlay: number;
+    headerAppBar: number;
     mobileNavButton: number;
     modalCloseButton: number;
     stickyYearsTab: number;
@@ -221,7 +222,7 @@ export const theme = createTheme({
     introAnimationBackground: 3000,
     introAnimationExpansion: 2999,
     mobileOverlay: 1050,
-    appBar: 1100,
+    headerAppBar: 1100,
     mobileNavButton: 1100,
     modalCloseButton: 100,
     stickyYearsTab: 50,

--- a/app/shared/components/design-system/all-components/theme/Theme.ts
+++ b/app/shared/components/design-system/all-components/theme/Theme.ts
@@ -166,6 +166,18 @@ declare module '@mui/material/Button' {
     tertiary: true;
   }
 }
+
+declare module '@mui/material/styles' {
+  interface ZIndex {
+    introAnimationBackground: number;
+    introAnimationExpansion: number;
+    mobileOverlay: number;
+    mobileNavButton: number;
+    modalCloseButton: number;
+    stickyYearsTab: number;
+    cursor: number;
+  }
+}
 export const theme = createTheme({
   palette: {
     primary: {
@@ -204,6 +216,15 @@ export const theme = createTheme({
       sm: 768,
       xs: 0
     }
+  },
+  zIndex: {
+    introAnimationBackground: 3000,
+    introAnimationExpansion: 2999,
+    mobileOverlay: 1099,
+    mobileNavButton: 3000,
+    modalCloseButton: 100,
+    stickyYearsTab: 50,
+    cursor: 9999
   },
   typography: {
     h1: {

--- a/app/shared/components/design-system/all-components/theme/Theme.ts
+++ b/app/shared/components/design-system/all-components/theme/Theme.ts
@@ -220,11 +220,12 @@ export const theme = createTheme({
   zIndex: {
     introAnimationBackground: 3000,
     introAnimationExpansion: 2999,
-    mobileOverlay: 1099,
-    mobileNavButton: 3000,
+    mobileOverlay: 1050,
+    appBar: 1100,
+    mobileNavButton: 1100,
     modalCloseButton: 100,
     stickyYearsTab: 50,
-    cursor: 9999
+    cursor: 9000
   },
   typography: {
     h1: {

--- a/app/shared/components/get-notes-modal/GetNotesModal.styles.ts
+++ b/app/shared/components/get-notes-modal/GetNotesModal.styles.ts
@@ -1,3 +1,4 @@
+import { theme } from '../design-system/all-components/theme/Theme';
 import { GetNotesState } from '~/types/enums/getNotes.enums';
 
 export const styles = {
@@ -64,7 +65,7 @@ export const styles = {
       position: 'absolute',
       width: '30px',
       height: '30px',
-      zIndex: '100',
+      zIndex: theme.zIndex.modalCloseButton,
       right: '23px'
     };
     if (state === GetNotesState.LIST) {

--- a/app/shared/components/year-tabs/YearTabs.styles.ts
+++ b/app/shared/components/year-tabs/YearTabs.styles.ts
@@ -1,3 +1,5 @@
+import { theme } from '../design-system/all-components/theme/Theme';
+
 export const styles = {
   buttonGroup: {
     position: 'fixed',
@@ -6,7 +8,7 @@ export const styles = {
     transform: 'translate(-50%)',
     borderRadius: '48px',
     p: '4px',
-    zIndex: 10,
+    zIndex: theme.zIndex.stickyYearsTab,
 
     '& [aria-label="indicator"]': {
       height: 'calc(100% - 8px)',


### PR DESCRIPTION
## Description
- Implement theme variables for z index
- refactor and convert old hardcoded values into new constant variables.

## Type of change
- [x] Refactoring / Tech debt

## How to test
So to test it you need to run client side locally and check:
- if main animation is working correctly.
- if navbar is above all content
- if main logo and support button is above mobile overlay.
- if years navigation is above all content in biography page.

## Video / Screenshots

https://github.com/user-attachments/assets/33173ee4-98ee-4e2e-b85b-b5c735df563e

Vid. 1. ensure that mobile menu is working correctly

https://github.com/user-attachments/assets/19b6698d-5efb-422d-b6ab-96e7e9f8b236

Vid. 2. ensure that biography navigation bar is working

https://github.com/user-attachments/assets/47c0f7e0-a935-4e46-9a42-3883c7276dab

Vid. 3. Check if main animation is above all content

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

## Acceptance Criteria:

- [x] Hardcoded z-index values are removed from all components.
- [x] Stacking order is managed via the centralized theme definition.
- [x] No regressions in UI layering (modals, tooltips, and headers behave as expected).

---

closes #1355 