### PR TITLE
refactor(ui): separate grid layout from decorative vertical lines

### DIFF
--- a/app/[lang]/archive/[fund]/page.tsx
+++ b/app/[lang]/archive/[fund]/page.tsx
@@ -41,7 +41,7 @@ export default async function FundDetailsPage({ params }: Readonly<FundDetailsPa
   const fundSummaryBacklinkUrl = await getFundSummaryHeaderBacklinkUrl();
 
   return (
-    <MainLayout withLines>
+    <MainLayout>
       <FundSummaryHeader
         backLinkUrl={fundSummaryBacklinkUrl}
         backLinkText={fundSummaryBacklinkText[locale]}

--- a/app/[lang]/cooperation/page.tsx
+++ b/app/[lang]/cooperation/page.tsx
@@ -58,19 +58,17 @@ export default async function CollaborationPage({ params }: Readonly<Language>) 
   }
 
   return (
-    <>
-      <MainLayout withLines>
-        <CollaborationIntro
-          title={collaborationIntroPageData[lang].title}
-          subtitle={collaborationIntroPageData[lang].subtitle}
-          contentAbove={collaborationIntroPageData[lang].contentAbove}
-          content={collaborationIntroPageData[lang].content}
-        />
-        {page.blocks.partnershipFormats && <PartnershipFormats data={page.blocks.partnershipFormats} />}
-        <CollaborationInfo />
-        <OurPartners />
-      </MainLayout>
+    <MainLayout withLines>
+      <CollaborationIntro
+        title={collaborationIntroPageData[lang].title}
+        subtitle={collaborationIntroPageData[lang].subtitle}
+        contentAbove={collaborationIntroPageData[lang].contentAbove}
+        content={collaborationIntroPageData[lang].content}
+      />
+      {page.blocks.partnershipFormats && <PartnershipFormats data={page.blocks.partnershipFormats} />}
+      <CollaborationInfo />
+      <OurPartners />
       <OfferCollaboration />
-    </>
+    </MainLayout>
   );
 }

--- a/app/[lang]/news/page.tsx
+++ b/app/[lang]/news/page.tsx
@@ -47,7 +47,7 @@ const News = async ({ params }: Readonly<Language>) => {
   const mediaMentionsData = await mediaMentionService.getAllPublishedMediaMentions();
 
   return (
-    <MainLayout withLines>
+    <MainLayout>
       <MediaIntroSection />
       <MediaCenter eventsData={eventsData} newsData={newsData} mediaMentionsData={mediaMentionsData} />
     </MainLayout>

--- a/app/shared/components/blocks/collaboration/offer-collaboration/OfferCollaboration.styles.ts
+++ b/app/shared/components/blocks/collaboration/offer-collaboration/OfferCollaboration.styles.ts
@@ -3,7 +3,12 @@ import { mainHexPallete } from '~/ds-components/theme/colors';
 export const styles = {
   mainContainer: {
     position: 'relative',
-    width: '100%'
+    width: '100vw',
+    left: '50%',
+    right: '50%',
+    marginLeft: '-50vw',
+    marginRight: '-50vw',
+    gridColumn: '1 / -1'
   },
   paper: {
     position: 'absolute',

--- a/app/shared/layouts/main-layout/MainLayout.styles.ts
+++ b/app/shared/layouts/main-layout/MainLayout.styles.ts
@@ -1,28 +1,35 @@
-export const styles = {
-  width: '100%',
-  maxWidth: '1728px',
-  minHeight: 'inherit',
-  display: 'grid',
-  gridTemplateColumns: {
-    xs: 'repeat(4, 1fr)',
-    sm: 'repeat(8, 1fr)',
-    md: 'repeat(12, 1fr)'
+import type { SxProps, Theme } from '@mui/material/styles';
+
+export const styles: Record<string, SxProps<Theme>> = {
+  wrapper: {
+    width: '100%',
+    maxWidth: '1728px',
+    minHeight: 'inherit',
+    m: '0 auto',
+    position: 'relative',
+    pt: {
+      xs: '70px',
+      sm: '82px',
+      md: '100px',
+      lg: '92px'
+    },
+    px: {
+      xs: '24px',
+      sm: '56px',
+      md: '72px'
+    }
   },
-  columnGap: {
-    xs: '16px',
-    sm: '24px',
-    md: '40px'
-  },
-  m: '0 auto',
-  pt: {
-    xs: '70px',
-    sm: '82px',
-    md: '100px',
-    lg: '92px'
-  },
-  px: {
-    xs: '24px',
-    sm: '56px',
-    md: '72px'
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: {
+      xs: 'repeat(4, 1fr)',
+      sm: 'repeat(8, 1fr)',
+      md: 'repeat(12, 1fr)'
+    },
+    columnGap: {
+      xs: '16px',
+      sm: '24px',
+      md: '40px'
+    }
   }
 };

--- a/app/shared/layouts/main-layout/MainLayout.tsx
+++ b/app/shared/layouts/main-layout/MainLayout.tsx
@@ -11,9 +11,10 @@ export interface MainLayoutProps extends BoxProps {
 
 const MainLayout: React.FC<MainLayoutProps> = ({ withLines = false, lineColor, children, sx, ...props }) => {
   return (
-    <Box sx={[styles, ...(Array.isArray(sx) ? sx : [sx])]} {...props}>
+    <Box sx={[styles.wrapper, ...(Array.isArray(sx) ? sx : [sx])]} {...props}>
       {withLines && <ColumnGuides lineColor={lineColor} />}
-      {children}
+
+      <Box sx={styles.grid}>{children}</Box>
     </Box>
   );
 };


### PR DESCRIPTION
## Description

Refactor MainLayout to separate the core CSS grid layout from the decorative vertical lines (ColumnGuides). This prevents unexpected layout shifts and ensures the grid system is strictly responsible for content alignment. Resolved a visual regression on the Cooperation page by moving OfferCollaboration inside the layout and applying a full-bleed breakout layout to preserve its full-width beige background.

## Type of change
MODIFIED:

- app/shared/layouts/main-layout/MainLayout.tsx — extracted the grid structure into an inner container to separate ColumnGuides from the grid items layout logic.
- app/shared/layouts/main-layout/MainLayout.styles.ts — split styles into wrapper (with position: relative) and grid (pure CSS grid setup).
- app/[lang]/cooperation/page.tsx — moved <OfferCollaboration /> inside <MainLayout withLines> so the vertical lines stretch to the very bottom of the page.
- app/shared/components/blocks/collaboration/offer-collaboration/OfferCollaboration.styles.ts — added full-bleed breakout CSS (width: 100vw, negative margins) to allow the beige background to stretch across the viewport while being part of the layout grid.
- lines were removed from the News Events and Media page and the foundation page

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Run the lf-client project locally.
2. Go to the NeWs, EveNtS aNd MeDia page.
3. Make sure there are no lines on this page.
4. Go to the Archive page and then to the fund page.
5. Make sure there are no lines on this page.
6. Go to the Cooperation page.
7. Scroll down to the bottom of the page to the OfferCollaboration block.
8. Verify that the decorative vertical lines successfully go all the way to the bottom of the page, passing over the beige background.
9. Verify that the slanted beige background of OfferCollaboration stretches completely across the screen (full width) without any side margins. 

## Video / Screenshots
How it was:
<img width="1280" height="680" alt="photo_2026-06-02_21-26-24" src="https://github.com/user-attachments/assets/459b4ff8-f781-4b2c-887c-2e7011186bbf" />

<img width="1280" height="680" alt="photo_2026-06-02_21-28-32" src="https://github.com/user-attachments/assets/c9e6f421-7c80-4de9-a459-101e3e398b9c" />

Result:
<img width="1920" height="1020" alt="Знімок екрана 2026-06-02 212906" src="https://github.com/user-attachments/assets/d006c132-55df-4706-b3b1-e7b91153bc07" />
<img width="1920" height="1020" alt="Знімок екрана 2026-06-02 212934" src="https://github.com/user-attachments/assets/14afd8ff-e7ab-4f13-aec1-60ed78ecf876" />



## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

Closed task #1342 
