### PR TITLE
fix: auto scroll carousel to focused item

### DIFF
--- a/app/shared/components/content-slider/ContentSlider.tsx
+++ b/app/shared/components/content-slider/ContentSlider.tsx
@@ -3,6 +3,7 @@ import 'swiper/css';
 import 'swiper/css/navigation';
 import { Box } from '@mui/material';
 import React from 'react';
+import type { Swiper as SwiperType } from 'swiper';
 import { Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
@@ -19,6 +20,7 @@ export interface ContentSliderProps {
 }
 
 export const ContentSlider: React.FC<ContentSliderProps> = ({ cards, variant = 'news' }) => {
+  const swiperRef = React.useRef<SwiperType | null>(null);
   return (
     <Box sx={styles.sliderContainer}>
       <Box sx={styles.navigationContainer}>
@@ -32,6 +34,9 @@ export const ContentSlider: React.FC<ContentSliderProps> = ({ cards, variant = '
 
       <Swiper
         modules={[Navigation]}
+        onSwiper={(swiper) => {
+          swiperRef.current = swiper;
+        }}
         navigation={{
           prevEl: '.swiper-button-prev',
           nextEl: '.swiper-button-next'
@@ -54,8 +59,13 @@ export const ContentSlider: React.FC<ContentSliderProps> = ({ cards, variant = '
           }
         }}
       >
-        {cards.map((card) => (
-          <SwiperSlide key={card.href}>
+        {cards.map((card, index) => (
+          <SwiperSlide
+            key={card.href}
+            onFocusCapture={() => {
+              swiperRef.current?.slideTo(index);
+            }}
+          >
             <BaseCard
               image={card.image}
               crop={card.crop}


### PR DESCRIPTION
## Description

<!-- Briefly describe the purpose of this PR and what was changed -->
Fixed keyboard navigation behavior in the News/Events carousel.

Changes:

* Added automatic carousel scrolling when a carousel item receives keyboard focus.
* Ensured focused carousel items remain visible during keyboard navigation.
* Improved accessibility and user experience for keyboard users.

Fixes #1371

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

<!-- Describe steps to test this PR locally or link to CI pipeline -->

1. Open the Home Page.
2. Scroll to the News/Events carousel section.
3. Use the Tab key to navigate through carousel items.
4. Continue pressing Tab until focus moves to a card outside the currently visible area.
5. Verify that the carousel automatically scrolls and keeps the focused item visible.

## Video / Screenshots

https://github.com/user-attachments/assets/3edfe7e0-cfe5-4d42-bc84-4e7824877a8c

<!-- Attach a video recording or screenshots demonstrating the changes, if applicable -->

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [x] Documentation updated (if applicable)
- [x] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---
