### PR TITLE
fix(ui): normalize contact name spaces

### DIFF
--- a/app/shared/components/forms/contact-form/ContactForm.tsx
+++ b/app/shared/components/forms/contact-form/ContactForm.tsx
@@ -42,6 +42,8 @@ function ContactForm({ onSubmit, disabled = false }: Readonly<ContactFormProps>)
   const phoneInputRef = useRef<HTMLInputElement | null>(null);
   const nameRegex = /^[\p{L}'’ -]+$/u;
 
+  const normalizeNameSpaces = (value: string) => value.trim().replace(/\s+/g, ' ');
+
   const phoneSchema = z
     .string()
     .trim()
@@ -58,11 +60,15 @@ function ContactForm({ onSubmit, disabled = false }: Readonly<ContactFormProps>)
   const schema = z.object({
     name: z
       .string()
-      .trim()
-      .min(1, tErrors('nameRequired'))
-      .min(2, tErrors('nameMinLength'))
-      .max(50, tErrors('nameMaxLength'))
-      .regex(nameRegex, tErrors('nameInvalid')),
+      .transform(normalizeNameSpaces)
+      .pipe(
+        z
+          .string()
+          .min(1, tErrors('nameRequired'))
+          .min(2, tErrors('nameMinLength'))
+          .max(50, tErrors('nameMaxLength'))
+          .regex(nameRegex, tErrors('nameInvalid'))
+      ),
     email: z.string().min(1, tErrors('emailRequired')).email(tErrors('emailInvalid')),
     phoneNumber: phoneSchema.optional(),
     message: z
@@ -93,6 +99,7 @@ function ContactForm({ onSubmit, disabled = false }: Readonly<ContactFormProps>)
     }
   });
 
+  const nameField = register('name');
   const phoneField = register('phoneNumber');
 
   const nameLength = watch('name')?.length || 0;
@@ -118,6 +125,12 @@ function ContactForm({ onSubmit, disabled = false }: Readonly<ContactFormProps>)
     reset();
   };
 
+  const handleNameBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const normalizedValue = normalizeNameSpaces(e.target.value);
+    setValue('name', normalizedValue, { shouldValidate: true });
+    nameField.onBlur(e);
+  };
+
   return (
     <>
       <Box component="form" onSubmit={handleSubmit(onValid)}>
@@ -127,7 +140,8 @@ function ContactForm({ onSubmit, disabled = false }: Readonly<ContactFormProps>)
         <Box sx={styles.textFieldsContainer}>
           <TextField
             label={t('name')}
-            {...register('name')}
+            {...nameField}
+            onBlur={handleNameBlur}
             error={!!errors.name || (isNameAtMaxLength && showNameMaxMessage)}
             helperText={
               errors.name?.message || (isNameAtMaxLength && showNameMaxMessage ? tErrors('nameMaxLength') : '')


### PR DESCRIPTION
## Description

Fixed the Contact page Name field validation behavior where multiple consecutive spaces were preserved instead of being normalized.

According to the documented user story requirements, multiple consecutive spaces in the Name field should be automatically normalized to a single space.

This update adds name value normalization on field blur and during validation to ensure the Name field consistently follows the documented behavior and stores a normalized value.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the Contacts page.
2. Enter 'Testing       Testing' (multiple spaces between words) into the Name field.
3. Move focus away from the field.
4. Verify that the value is automatically converted to 'Testing Testing'.
5. Submit the form and verify that the form is submitted successfully.
6. Enter a valid name with a single space between words and verify that it remains unchanged.

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [ ] Linting checks are clean
- [ ] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Close [#234](https://github.com/Liatoshynsky-Foundation/lf-manual-tests/issues/234)