### PR TITLE
fix(media-mentions): resolve empty list issue and refactor data fetching

### DIFF
--- a/app/[lang]/news/page.tsx
+++ b/app/[lang]/news/page.tsx
@@ -44,7 +44,7 @@ const News = async ({ params }: Readonly<Language>) => {
 
   const newsData = await newsService.getAllPublishedNews(locale);
   const eventsData = await eventsService.getAllPublishedEvents(locale);
-  const mediaMentionsData = await mediaMentionService.getAllPublishedMediaMentions();
+  const mediaMentionsData = await mediaMentionService.getAllPublishedMediaMentions(lang as 'uk' | 'en');
 
   return (
     <MainLayout>

--- a/app/domain/dto/mediaMention.dto.ts
+++ b/app/domain/dto/mediaMention.dto.ts
@@ -1,9 +1,9 @@
 export enum MediaMentionStatus {
-  Draft = 'DRAFT',
-  Published = 'PUBLISHED',
-  Hidden = 'HIDDEN',
-  Archived = 'ARCHIVED',
-  Editing = 'EDITING'
+  Draft = 'draft',
+  Published = 'published',
+  Hidden = 'hidden',
+  Archived = 'archived',
+  Editing = 'editing'
 }
 
 export type MediaMentionCoverImageDTO = {
@@ -11,6 +11,12 @@ export type MediaMentionCoverImageDTO = {
   alt?: string;
   width?: number;
   height?: number;
+  crop?: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } | null;
 };
 
 export type MediaMentionMetaDTO = {
@@ -33,5 +39,5 @@ export type MediaMentionDTO = {
 
 export type MediaMentionListItemDTO = Pick<
   MediaMentionDTO,
-  '_id' | 'title' | 'description' | 'slug' | 'coverImage' | 'publishedAt' | 'meta'
+  '_id' | 'url' | 'title' | 'description' | 'slug' | 'coverImage' | 'publishedAt' | 'meta'
 >;

--- a/app/infrastructure/models/media-mentions/mediaMention.model.ts
+++ b/app/infrastructure/models/media-mentions/mediaMention.model.ts
@@ -1,30 +1,65 @@
 import mongoose, { Document, Model, Schema } from 'mongoose';
 
-import { MediaMentionDTO, MediaMentionStatus } from '~/domain/dto/mediaMention.dto';
+import { MediaMentionStatus } from '~/domain/dto/mediaMention.dto';
 
-export interface IMediaMentionDocument extends Omit<MediaMentionDTO, '_id'>, Document {}
+export interface ILocalizedString {
+  uk: string;
+  en?: string;
+}
+
+export interface IMediaMentionDocument extends Document {
+  url: string;
+  title: ILocalizedString;
+  description: ILocalizedString;
+  slug: string;
+  coverImage: {
+    src: string;
+    alt?: ILocalizedString | string;
+    width?: number;
+    height?: number;
+    crop?: {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+    } | null;
+  };
+  status: MediaMentionStatus;
+  publishedAt?: Date | null;
+  meta: {
+    views: number;
+  };
+  createdAt?: Date;
+  updatedAt?: Date;
+}
 
 const mediaMentionSchema = new Schema<IMediaMentionDocument>(
   {
     url: { type: String, required: true, unique: true },
-    title: { type: String, required: true },
-    description: { type: String, required: true },
+    title: {
+      uk: { type: String, required: true },
+      en: { type: String }
+    },
+    description: {
+      uk: { type: String, required: true },
+      en: { type: String }
+    },
     slug: { type: String, required: true, index: true, unique: true },
     coverImage: {
       src: { type: String, required: true },
-      alt: { type: String },
+      alt: { type: Schema.Types.Mixed },
       width: { type: Number },
-      height: { type: Number }
+      height: { type: Number },
+      crop: {
+        x: { type: Number },
+        y: { type: Number },
+        width: { type: Number },
+        height: { type: Number }
+      }
     },
     status: {
       type: String,
-      enum: [
-        MediaMentionStatus.Draft,
-        MediaMentionStatus.Published,
-        MediaMentionStatus.Hidden,
-        MediaMentionStatus.Archived,
-        MediaMentionStatus.Editing
-      ],
+      enum: Object.values(MediaMentionStatus),
       required: true,
       default: MediaMentionStatus.Draft
     },

--- a/app/infrastructure/repositories/media-mentions/mediaMention.repository.ts
+++ b/app/infrastructure/repositories/media-mentions/mediaMention.repository.ts
@@ -13,7 +13,7 @@ const getLocalizedText = (field: ILocalizedString | string | undefined, locale: 
 const safeGetIsoDate = (dateData: any): string | null => {
   if (!dateData) return null;
   const parsedDate = new Date(dateData);
-  return isNaN(parsedDate.getTime()) ? null : parsedDate.toISOString();
+  return Number.isNaN(parsedDate.getTime()) ? null : parsedDate.toISOString();
 };
 
 const mediaMentionRepository = {

--- a/app/infrastructure/repositories/media-mentions/mediaMention.repository.ts
+++ b/app/infrastructure/repositories/media-mentions/mediaMention.repository.ts
@@ -2,40 +2,84 @@ import { Types } from 'mongoose';
 
 import { MediaMentionStatus } from '~/domain/dto/mediaMention.dto';
 import dbConnect from '~/infrastructure/db/connect';
-import MediaMentionModel from '~/infrastructure/models/media-mentions/mediaMention.model';
-import { ArraySchema } from '~/validators/constants';
-import { mediaMentionListItemSchema, mediaMentionSchema } from '~/validators/mediaMention.schema';
+import MediaMentionModel, { ILocalizedString } from '~/infrastructure/models/media-mentions/mediaMention.model';
+
+const getLocalizedText = (field: ILocalizedString | string | undefined, locale: 'uk' | 'en'): string => {
+  if (!field) return '';
+  if (typeof field === 'string') return field;
+  return field[locale] || field.uk || '';
+};
+
+const safeGetIsoDate = (dateData: any): string | null => {
+  if (!dateData) return null;
+  const parsedDate = new Date(dateData);
+  return isNaN(parsedDate.getTime()) ? null : parsedDate.toISOString();
+};
 
 const mediaMentionRepository = {
-  async getAllPublishedMediaMentions() {
+  async getAllPublishedMediaMentions(locale: 'uk' | 'en' = 'uk') {
     await dbConnect();
 
     const mediaMentions = await MediaMentionModel.find({ status: MediaMentionStatus.Published })
       .select('_id url title description slug coverImage publishedAt meta')
       .sort({ publishedAt: -1 })
-      .lean();
+      .lean()
+      .exec();
 
-    const transformedMediaMentions = mediaMentions.map((mention) => ({
-      ...mention,
-      _id: (mention._id as Types.ObjectId).toString()
-    }));
+    const transformedMediaMentions = mediaMentions.map((mention) => {
+      let localizedCoverImage = undefined;
 
-    return ArraySchema(mediaMentionListItemSchema).parse(transformedMediaMentions);
+      if (mention.coverImage) {
+        localizedCoverImage = {
+          ...mention.coverImage,
+          alt: getLocalizedText(mention.coverImage.alt, locale)
+        };
+      }
+
+      return {
+        ...mention,
+        _id: (mention._id as Types.ObjectId).toString(),
+        publishedAt: safeGetIsoDate(mention.publishedAt),
+        title: getLocalizedText(mention.title, locale),
+        description: getLocalizedText(mention.description, locale),
+        coverImage: localizedCoverImage
+      };
+    });
+
+    return transformedMediaMentions;
   },
 
-  async getMediaMentionBySlug(slug: string) {
+  async getMediaMentionBySlug(slug: string, locale: 'uk' | 'en' = 'uk') {
     await dbConnect();
 
-    const mediaMention = await MediaMentionModel.findOne({ slug }).lean();
+    const mediaMention = await MediaMentionModel.findOne({
+      slug: String(slug),
+      status: MediaMentionStatus.Published
+    })
+      .lean()
+      .exec();
 
     if (!mediaMention) return null;
 
+    let localizedCoverImage = undefined;
+
+    if (mediaMention.coverImage) {
+      localizedCoverImage = {
+        ...mediaMention.coverImage,
+        alt: getLocalizedText(mediaMention.coverImage.alt, locale)
+      };
+    }
+
     const transformedMediaMention = {
       ...mediaMention,
-      _id: (mediaMention._id as Types.ObjectId).toString()
+      _id: (mediaMention._id as Types.ObjectId).toString(),
+      publishedAt: safeGetIsoDate(mediaMention.publishedAt),
+      title: getLocalizedText(mediaMention.title, locale),
+      description: getLocalizedText(mediaMention.description, locale),
+      coverImage: localizedCoverImage
     };
 
-    return mediaMentionSchema.parse(transformedMediaMention);
+    return transformedMediaMention;
   }
 };
 

--- a/app/infrastructure/repositories/media-mentions/mediaMention.test.ts
+++ b/app/infrastructure/repositories/media-mentions/mediaMention.test.ts
@@ -20,7 +20,8 @@ const createFakeId = () => '65f1d5f2' + Date.now().toString(16).slice(-8);
 const mockMongooseChain = (resolvedValue: any) => ({
   select: jest.fn().mockReturnThis(),
   sort: jest.fn().mockReturnThis(),
-  lean: jest.fn().mockResolvedValue(resolvedValue)
+  lean: jest.fn().mockReturnThis(),
+  exec: jest.fn().mockResolvedValue(resolvedValue)
 });
 
 const validMentionData = {
@@ -75,7 +76,10 @@ describe('mediaMentionRepository', () => {
 
       const result = await mediaMentionRepository.getMediaMentionBySlug('test-media-mention');
 
-      expect(MediaMentionModel.findOne).toHaveBeenCalledWith({ slug: 'test-media-mention' });
+      expect(MediaMentionModel.findOne).toHaveBeenCalledWith({
+        slug: 'test-media-mention',
+        status: MediaMentionStatus.Published
+      });
 
       if (!result) throw new Error('Result is null');
 

--- a/app/services/media-mentions/mediaMentionService.test.ts
+++ b/app/services/media-mentions/mediaMentionService.test.ts
@@ -1,6 +1,12 @@
 import { createMediaMentionService } from './mediaMentionService';
 
+import { MediaMentionStatus } from '~/domain/dto/mediaMention.dto';
 import { MediaMentionRepository } from '~/infrastructure/repositories/media-mentions/mediaMention.repo';
+import logger from '~/middleware/logger/logger';
+
+jest.mock('~/middleware/logger/logger', () => ({
+  error: jest.fn()
+}));
 
 describe('mediaMentionService', () => {
   const mediaMentionRepositoryMock = {
@@ -18,55 +24,80 @@ describe('mediaMentionService', () => {
     jest.clearAllMocks();
   });
 
-  const mockBaseData = {
+  type RepoListItem = Awaited<ReturnType<MediaMentionRepository['getAllPublishedMediaMentions']>>[0];
+  type RepoDetailItem = NonNullable<Awaited<ReturnType<MediaMentionRepository['getMediaMentionBySlug']>>>;
+
+  const mockBaseData: Partial<RepoListItem> = {
     _id: validId,
     title: 'Media Title',
     slug: 'media-slug',
     publishedAt: new Date().toISOString(),
-    source: 'Forbes',
     url: 'https://forbes.com/news',
     description: 'Short description for list',
     coverImage: {
       src: 'https://img.com/cover.jpg',
       alt: 'Cover'
     },
-    status: 'PUBLISHED',
     meta: {
-      title: 'SEO Title',
-      description: 'SEO Desc'
+      views: 0
     }
   };
 
   describe('getAllPublishedMediaMentions', () => {
     it('should fetch and parse all published media mentions', async () => {
-      mediaMentionRepositoryMock.getAllPublishedMediaMentions.mockResolvedValue([mockBaseData] as any);
+      mediaMentionRepositoryMock.getAllPublishedMediaMentions.mockResolvedValue([
+        mockBaseData as unknown as RepoListItem
+      ]);
 
       const result = await mediaMentionService.getAllPublishedMediaMentions();
 
       expect(mediaMentionRepositoryMock.getAllPublishedMediaMentions).toHaveBeenCalledTimes(1);
+      expect(mediaMentionRepositoryMock.getAllPublishedMediaMentions).toHaveBeenCalledWith('uk');
       expect(result).toHaveLength(1);
       expect(result[0]._id).toBe(validId);
+    });
+
+    it('should return an empty array if repository returns an empty array', async () => {
+      mediaMentionRepositoryMock.getAllPublishedMediaMentions.mockResolvedValue([]);
+
+      const result = await mediaMentionService.getAllPublishedMediaMentions();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return an empty array and log error if repository or parsing fails', async () => {
+      const dbError = new Error('DB Connection error');
+      mediaMentionRepositoryMock.getAllPublishedMediaMentions.mockRejectedValue(dbError);
+
+      const result = await mediaMentionService.getAllPublishedMediaMentions();
+
+      expect(result).toEqual([]);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('[SERVICE:MediaMentions:getAllPublishedMediaMentions]'),
+        dbError
+      );
     });
   });
 
   describe('getMediaMentionBySlug', () => {
     it('should return parsed media mention if found', async () => {
-      const fullMockMention = {
+      const fullMockMention: Partial<RepoDetailItem> = {
         ...mockBaseData,
-        content: 'Full content for the detail page'
+        status: MediaMentionStatus.Published
       };
 
-      mediaMentionRepositoryMock.getMediaMentionBySlug.mockResolvedValue(fullMockMention as any);
+      mediaMentionRepositoryMock.getMediaMentionBySlug.mockResolvedValue(fullMockMention as unknown as RepoDetailItem);
 
       const result = await mediaMentionService.getMediaMentionBySlug('media-slug');
 
-      expect(mediaMentionRepositoryMock.getMediaMentionBySlug).toHaveBeenCalledWith('media-slug');
+      expect(mediaMentionRepositoryMock.getMediaMentionBySlug).toHaveBeenCalledWith('media-slug', 'uk');
 
       expect(result).toMatchObject({
         _id: validId,
         slug: 'media-slug',
         title: 'Media Title',
-        status: 'PUBLISHED'
+        status: MediaMentionStatus.Published
       });
 
       expect(result?.meta).toHaveProperty('views');
@@ -78,7 +109,20 @@ describe('mediaMentionService', () => {
       const result = await mediaMentionService.getMediaMentionBySlug('non-existent');
 
       expect(result).toBeNull();
-      expect(mediaMentionRepositoryMock.getMediaMentionBySlug).toHaveBeenCalledWith('non-existent');
+      expect(mediaMentionRepositoryMock.getMediaMentionBySlug).toHaveBeenCalledWith('non-existent', 'uk');
+    });
+
+    it('should return null and log error if parsing or repository fails', async () => {
+      const invalidMockMention = {
+        ...mockBaseData,
+        status: 'INVALID_STATUS_FOR_ZOD_SHIELD'
+      } as unknown as RepoDetailItem;
+      mediaMentionRepositoryMock.getMediaMentionBySlug.mockResolvedValue(invalidMockMention);
+
+      const result = await mediaMentionService.getMediaMentionBySlug('media-slug');
+
+      expect(result).toBeNull();
+      expect(logger.error).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/services/media-mentions/mediaMentionService.ts
+++ b/app/services/media-mentions/mediaMentionService.ts
@@ -1,4 +1,7 @@
+import { loggerErrors } from '~/constants/errors';
+
 import type { MediaMentionRepository } from '~/infrastructure/repositories/media-mentions/mediaMention.repo';
+import logger from '~/middleware/logger/logger';
 import { ArraySchema } from '~/validators/constants';
 import { mediaMentionListItemSchema, mediaMentionSchema } from '~/validators/mediaMention.schema';
 
@@ -7,16 +10,37 @@ interface MediaMentionServiceDeps {
 }
 
 export const createMediaMentionService = ({ mediaMentionRepository }: MediaMentionServiceDeps) => ({
-  async getAllPublishedMediaMentions() {
-    const mediaMentions = await mediaMentionRepository.getAllPublishedMediaMentions();
-    return ArraySchema(mediaMentionListItemSchema).parse(mediaMentions);
+  async getAllPublishedMediaMentions(locale: 'uk' | 'en' = 'uk') {
+    try {
+      const mediaMentions = await mediaMentionRepository.getAllPublishedMediaMentions(locale);
+
+      if (mediaMentions.length === 0) {
+        return [];
+      }
+
+      return ArraySchema(mediaMentionListItemSchema).parse(mediaMentions);
+    } catch (error) {
+      logger.error(
+        `[SERVICE:MediaMentions:getAllPublishedMediaMentions] Failed to fetch or parse media mentions. ${loggerErrors.ZOD_VALIDATION_ERROR}`,
+        error
+      );
+      return [];
+    }
   },
 
-  async getMediaMentionBySlug(slug: string) {
-    const mediaMention = await mediaMentionRepository.getMediaMentionBySlug(slug);
-    if (!mediaMention) return null;
+  async getMediaMentionBySlug(slug: string, locale: 'uk' | 'en' = 'uk') {
+    try {
+      const mediaMention = await mediaMentionRepository.getMediaMentionBySlug(slug, locale);
+      if (!mediaMention) return null;
 
-    return mediaMentionSchema.parse(mediaMention);
+      return mediaMentionSchema.parse(mediaMention);
+    } catch (error) {
+      logger.error(
+        `[SERVICE:MediaMentions:getMediaMentionBySlug] Failed to fetch or parse media mention by slug: ${slug}. ${loggerErrors.ZOD_VALIDATION_ERROR}`,
+        error
+      );
+      return null;
+    }
   }
 });
 

--- a/app/validators/mediaMention.schema.ts
+++ b/app/validators/mediaMention.schema.ts
@@ -6,7 +6,16 @@ const mediaMentionCoverImageSchema = z.object({
   src: z.string(),
   alt: z.string().optional(),
   width: z.number().optional(),
-  height: z.number().optional()
+  height: z.number().optional(),
+  crop: z
+    .object({
+      x: z.number(),
+      y: z.number(),
+      width: z.number(),
+      height: z.number()
+    })
+    .nullable()
+    .optional()
 });
 
 const mediaMentionMetaSchema = z.object({


### PR DESCRIPTION
## Description

Resolved a critical data mapping and validation issue that prevented the "Media Mentions" (Ми у ЗМІ) cards from rendering on the frontend. The root cause was a schema mismatch: the database returned localized objects and Date types, while the DTOs and Zod schemas expected flat strings.

Aligned the Mongoose model, DTOs, and Zod schemas to support strict typing. Implemented a backend data mapping layer in the repository to correctly resolve the locale and map MongoDB ObjectIds/Dates. Fixed the image crop functionality by adding the missing crop coordinate type definitions to Zod, preventing them from being stripped out. Additionally, introduced safe error handling in the service layer to prevent full page crashes on Zod validation failures, and updated unit tests.

## Type of change

MODIFIED:

- app/infrastructure/models/media-mentions/mediaMention.model.ts — updated the schema to properly type localized objects and removed any types for strict type checking.
- app/domain/dto/mediaMention.dto.ts — aligned DTOs with the exact database output and added missing types for image crop coordinates.
- app/validators/mediaMention.schema.ts — updated strict schemas to expect crop properties.
- app/infrastructure/repositories/media-mentions/mediaMention.repository.ts — implemented a mapping layer to resolve localized strings (uk/en), stringify _id, format dates.
- app/services/media-mentions/mediaMentionService.ts — added try-catch blocks to gracefully handle Zod validation errors and avoid 500 crashes.
- app/services/media-mentions/mediaMentionService.test.ts — updated mock data to match strict validation rules and added test cases for error handling scenarios.
- app/[lang]/media-mentions/page.tsx — explicitly cast the lang parameter as 'uk' | 'en' when calling mediaMentionService.getAllPublishedMediaMentions to ensure strict type compliance on the frontend page.

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Run the project locally (npm run dev).
2. Go to the NeWs, EveNtS aNd MeDia page.
3. Choose "Ми у ЗМІ".
4. Verify that the media cards render successfully and the "Згадок у ЗМІ поки немає" empty state is no longer incorrectly displayed.
5. Verify that the localized titles and descriptions map correctly according to the selected language context.
6. Check the images on the media cards to ensure they render correctly and respect the applied crop coordinates.
7. Run the test suite for this service: npm test app/services/media-mentions/mediaMentionService.test.ts and verify it passes with 100% coverage.

## Video / Screenshots

How it was:
<img width="1901" height="904" alt="Знімок екрана 2026-06-11 191027" src="https://github.com/user-attachments/assets/3cc39dd4-7b2e-4c52-a5f5-be7627296088" />

Result:
<img width="1897" height="909" alt="Знімок екрана 2026-06-11 191420" src="https://github.com/user-attachments/assets/c7d2b959-8869-4667-b281-98ccebf226eb" />


## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

Closed task #1383 
