### PR TITLE
fix: volunteer cards localization missing locale prop

### DIFF
--- a/app/shared/components/blocks/actions-help/ActionsHelp.tsx
+++ b/app/shared/components/blocks/actions-help/ActionsHelp.tsx
@@ -46,6 +46,7 @@ const ActionsHelp = ({ data }: { readonly data: Readonly<ActionsHelpProps> }) =>
           key={paper.title[locale]}
           title={paper.title}
           description={paper.description}
+          locale={locale}
         />
       )),
       <ButtonCard


### PR DESCRIPTION
## Description

The `TextCard` component accepts a `locale` prop but it was not being passed from `ActionsHelp.tsx`. As a result, the component always fell back to the default `locale = 'en'`, causing volunteer card titles and descriptions to remain in English even when the Ukrainian language was selected. Fixed by passing the `locale` value to each `TextCard`.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Tech debt
- [ ] CI/CD improvement
- [ ] Other: <!-- specify -->

## How to test

1. Open the Support page (`/support-us`)
2. Verify cards are displayed in English
3. Switch the website language to Ukrainian
4. Observe that volunteer card titles and descriptions are now displayed in Ukrainian
5. Switch back to English and verify cards return to English

## Video / Screenshots

<img width="1280" height="601" alt="image" src="https://github.com/user-attachments/assets/ac911d18-614b-4753-879b-b6d56e0c8cbf" />

<img width="1280" height="580" alt="image" src="https://github.com/user-attachments/assets/d391f490-bc1e-4e09-8bb1-068d166883b5" />

## Checklist

- [x] PR name follows the naming convention
- [x] Code compiles and runs correctly
- [x] Tests pass successfully
- [x] Linting checks are clean
- [x] No Sonar issues
- [ ] Documentation updated (if applicable)
- [ ] All comments and requested changes addressed
- [x] Branch is up to date with the target branch
- [x] Linked issue/task included
- [x] Task moved to the review column on the board

---

Close #1389 